### PR TITLE
Fix memory leaks in Context

### DIFF
--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -27,7 +27,7 @@ from typing import (
     cast,
 )
 
-from . import telemetry_events
+from . import telemetry_events, code
 from ._native import (  # type: ignore
     Circuit,
     CircuitConfig,
@@ -151,9 +151,9 @@ class Context:
 
     _interpreter: Interpreter
     _config: Config
-    code: types.ModuleType
-    _code_prefix: str
+    code: Any
     _disposed: bool
+    _is_global_context: bool
 
     def __init__(
         self,
@@ -163,8 +163,7 @@ class Context:
         project_root: Optional[str] = None,
         language_features: Optional[List[str]] = None,
         _trace_circuit: Optional[bool] = None,
-        _code_module: Optional[types.ModuleType] = None,
-        _code_prefix: Optional[str] = None,
+        _is_global_context: bool = False,
     ):
         """
         Initializes a new isolated Q# context.
@@ -189,13 +188,12 @@ class Context:
             to use the ``set`` keyword for mutable variable assignments.
         """
         self._disposed = False
+        self._is_global_context = _is_global_context
 
-        if _code_module is not None:
-            self.code = _code_module
-            self._code_prefix = _code_prefix or "qsharp.code"
+        if _is_global_context:
+            self.code = code
         else:
-            self._code_prefix = f"qsharp._context_{id(self)}"
-            self.code = types.ModuleType(self._code_prefix)
+            self.code = types.SimpleNamespace()
 
         from ._fs import exists, join, list_directory, read_file, resolve
         from ._http import fetch_github
@@ -384,24 +382,39 @@ class Context:
                 pass
         print(output, flush=True)
 
+    def _get_code_module(
+        self, namespace: List[str]
+    ) -> types.ModuleType | types.SimpleNamespace:
+        """Returns module for given path, creating it if it doesn't exist."""
+        module = self.code
+        if self._is_global_context:
+            accumulated_namespace = code.__name__
+            for name in namespace:
+                accumulated_namespace += "." + name
+                if hasattr(module, name):
+                    module = module.__getattribute__(name)
+                    if sys.modules.get(accumulated_namespace) is None:
+                        sys.modules[accumulated_namespace] = module
+                else:
+                    new_module = types.ModuleType(accumulated_namespace)
+                    module.__setattr__(name, new_module)
+                    sys.modules[accumulated_namespace] = new_module
+                    module = new_module
+        else:
+            for name in namespace:
+                if hasattr(module, name):
+                    module = module.__getattribute__(name)
+                else:
+                    new_module = types.SimpleNamespace()
+                    module.__setattr__(name, new_module)
+                    module = new_module
+        return module
+
     def _make_callable(
         self, callable: GlobalCallable, namespace: List[str], callable_name: str
     ):
         """Registers a Q# callable in this context's code module."""
-        module = self.code
-        accumulated_namespace = self._code_prefix + "."
-        for name in namespace:
-            accumulated_namespace += name
-            if hasattr(module, name):
-                module = module.__getattribute__(name)
-                if sys.modules.get(accumulated_namespace) is None:
-                    sys.modules[accumulated_namespace] = module
-            else:
-                new_module = types.ModuleType(accumulated_namespace)
-                module.__setattr__(name, new_module)
-                sys.modules[accumulated_namespace] = new_module
-                module = new_module
-            accumulated_namespace += "."
+        module = self._get_code_module(namespace)
 
         def _callable_fn(*args):
             if self._disposed:
@@ -428,19 +441,7 @@ class Context:
 
     def _make_class(self, qsharp_type: TypeIR, namespace: List[str], class_name: str):
         """Registers a Q# type as a Python dataclass in this context's code module."""
-        module = self.code
-        accumulated_namespace = self._code_prefix + "."
-        for name in namespace:
-            accumulated_namespace += name
-            if hasattr(module, name):
-                module = module.__getattribute__(name)
-            else:
-                new_module = types.ModuleType(accumulated_namespace)
-                module.__setattr__(name, new_module)
-                sys.modules[accumulated_namespace] = new_module
-                module = new_module
-            accumulated_namespace += "."
-
+        module = self._get_code_module(namespace)
         QSharpClass = make_class_rec(qsharp_type)
         QSharpClass.__qsharp_class = True
         setattr(QSharpClass, "_qdk_context", self)

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -11,6 +11,7 @@ independent Q# environments to coexist.
 
 import sys
 import types
+import weakref
 from dataclasses import make_dataclass
 from time import monotonic
 from typing import (
@@ -226,6 +227,26 @@ class Context:
                     f"Error reading {qsharp_json}. qsharp.json should exist at the project root and be a valid JSON file."
                 ) from e
 
+        # Use weakref to avoid circular reference (Context -> Interpreter -> callback ->
+        # Context) that prevents Context from being garbage collected.
+        self_ref = weakref.ref(self)
+
+        def make_callable_weak(
+            callable: GlobalCallable, namespace: List[str], callable_name: str
+        ) -> None:
+            ctx = self_ref()
+            if ctx is None or ctx._disposed:
+                return
+            Context._make_callable(ctx, callable, namespace, callable_name)
+
+        def make_class_weak(
+            qsharp_type: TypeIR, namespace: List[str], class_name: str
+        ) -> None:
+            ctx = self_ref()
+            if ctx is None or ctx._disposed:
+                return
+            Context._make_class(ctx, qsharp_type, namespace, class_name)
+
         self._interpreter = Interpreter(
             target_profile,
             language_features,
@@ -234,8 +255,8 @@ class Context:
             list_directory,
             resolve,
             fetch_github,
-            self._make_callable,
-            self._make_class,
+            make_callable_weak,
+            make_class_weak,
             _trace_circuit,
         )
 

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -235,7 +235,7 @@ class Context:
             ctx = self_ref()
             if ctx is None or ctx._disposed:
                 return
-            Context._make_callable(ctx, callable, namespace, callable_name)
+            ctx._make_callable(callable, namespace, callable_name)
 
         def make_class_weak(
             qsharp_type: TypeIR, namespace: List[str], class_name: str
@@ -243,7 +243,7 @@ class Context:
             ctx = self_ref()
             if ctx is None or ctx._disposed:
                 return
-            Context._make_class(ctx, qsharp_type, namespace, class_name)
+            ctx._make_class(qsharp_type, namespace, class_name)
 
         self._interpreter = Interpreter(
             target_profile,

--- a/source/qdk_package/qdk/_interpreter.py
+++ b/source/qdk_package/qdk/_interpreter.py
@@ -65,18 +65,17 @@ import sys
 import types
 from time import monotonic
 
-
 # Global default context instance used by methods in this module.
 _default_context: Optional[Context] = None
 
 
-def _clear_code_module(code_module: types.ModuleType, module_prefix: str):
+def _clear_code_module():
     """
     Removes dynamically added Q# callables, structs, and namespace modules from
-    a code module and sys.modules.
+    qdk.code module and sys.modules.
     """
     keys_to_remove = []
-    for key, val in code_module.__dict__.items():
+    for key, val in code.__dict__.items():
         if (
             hasattr(val, "__global_callable")
             or hasattr(val, "__qsharp_class")
@@ -84,11 +83,12 @@ def _clear_code_module(code_module: types.ModuleType, module_prefix: str):
         ):
             keys_to_remove.append(key)
     for key in keys_to_remove:
-        code_module.__delattr__(key)
+        code.__delattr__(key)
 
     keys_to_remove = []
+    code_module_prefix = code.__name__ + "."
     for key in sys.modules:
-        if key.startswith(module_prefix + "."):
+        if key.startswith(code_module_prefix):
             keys_to_remove.append(key)
     for key in keys_to_remove:
         sys.modules.__delitem__(key)
@@ -138,8 +138,7 @@ def init(
         _default_context._disposed = True
 
     # Clean up the global code namespace before creating a new context.
-    code_prefix = "qdk.code"
-    _clear_code_module(code, code_prefix)
+    _clear_code_module()
 
     _default_context = Context(
         target_profile=target_profile,
@@ -147,8 +146,7 @@ def init(
         project_root=project_root,
         language_features=language_features,
         _trace_circuit=trace_circuit,
-        _code_module=code,
-        _code_prefix=code_prefix,
+        _is_global_context=True,
     )
     return _default_context._config
 

--- a/source/qdk_package/tests/test_context.py
+++ b/source/qdk_package/tests/test_context.py
@@ -1,6 +1,8 @@
-import qdk
-import pytest
+import gc
+import weakref
 
+import pytest
+import qdk
 from qdk import qsharp
 from qdk.qsharp import QSharpError
 
@@ -52,8 +54,8 @@ def test_seed() -> None:
 
     # Quantum seed.
     code = """{
-        use qs = Qubit[16]; 
-        for q in qs { H(q); }; 
+        use qs = Qubit[16];
+        for q in qs { H(q); };
         Microsoft.Quantum.Measurement.MResetEachZ(qs)
     }"""
     ctx1.set_quantum_seed(100)
@@ -191,3 +193,13 @@ def test_circular_reference_raises():
 
     with pytest.raises(QSharpError, match="Cannot send circular objects"):
         qdk.code.First(circular_list)
+
+
+def test_context_released_after_drop() -> None:
+    """Dropping the last strong reference to a Context releases it via gc."""
+    ctx = qdk.Context()
+    ctx.eval("function Add(a : Int, b : Int) : Int { a + b }")
+    ref = weakref.ref(ctx)
+    del ctx
+    gc.collect()
+    assert ref() is None


### PR DESCRIPTION
* Use weakref when passing `make_callable` and `make_class` to Interpreter, which breaks circular reference (Context -> Interpreter -> callback -> Context) and allows the Context object (and Interpreter) to be garbage collected.
* Do not register callables and classes for non-global Contexts in `sys.modules`. Use `types.SimpleNamespace` instead. Users access symbols for global Context via `qdk.code`, and symbols for other Contexts via `context_variable.code`. 
  * This way we don't need to clear `sys.modules` when Context is garbage collected. 
  * We still clear `qdk.code` when global context is invalidated on `init()`.