### PR TITLE
Fix Context memory leak introduced by PR #3208

### DIFF
--- a/source/qdk_package/pyproject.toml
+++ b/source/qdk_package/pyproject.toml
@@ -46,6 +46,10 @@ all = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-m 'not slow'"
+markers = [
+    "slow: marks tests as slow (deselected by default; run explicitly with `-m slow`)",
+]
 
 [tool.maturin]
 module-name = "qdk._native"

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -11,6 +11,7 @@ independent Q# environments to coexist.
 
 import sys
 import types
+import weakref
 from dataclasses import make_dataclass
 from time import monotonic
 from typing import (
@@ -81,6 +82,21 @@ def ipython_helper():
         pass
 
 
+def _safe_clear_code_module(code_module, prefix):
+    """Backstop cleanup invoked from a `weakref.finalize` callback.
+
+    Swallows all exceptions because Python may have already torn down
+    `sys.modules` or other interpreter state by the time finalizers run
+    at shutdown.
+    """
+    try:
+        from ._interpreter import _clear_code_module
+
+        _clear_code_module(code_module, prefix)
+    except Exception:
+        pass
+
+
 def make_class_rec(qsharp_type: TypeIR) -> type:
     class_name = qsharp_type.unwrap_udt().name
     fields = {}
@@ -146,6 +162,16 @@ class Context:
         ctx.eval("operation Main() : Result { use q = Qubit(); X(q); MResetZ(q) }")
         assert ctx.run("Main()", 2) == [qdk.Result.One, qdk.Result.One]
         assert ctx.code.Main() == qdk.Result.One
+
+    For deterministic cleanup of the context's dynamically registered code
+    namespace, use the context manager form, which calls :meth:`dispose` on
+    block exit:
+
+    .. code-block:: python
+
+        with qdk.Context() as ctx:
+            ctx.eval("function Foo() : Int { 42 }")
+            assert ctx.code.Foo() == 42
     """
 
     _interpreter: Interpreter
@@ -153,6 +179,8 @@ class Context:
     code: types.ModuleType
     _code_prefix: str
     _disposed: bool
+    _is_default_context: bool
+    _finalizer: weakref.finalize
 
     def __init__(
         self,
@@ -189,12 +217,27 @@ class Context:
         """
         self._disposed = False
 
+        # Only the default context (constructed by `qdk.init()` with the
+        # global `qdk.code` module) participates in the `from qsharp.code.<ns>
+        # import …` import-statement path. For non-default contexts the
+        # namespace is reachable via `ctx.code.<ns>.<Name>` attribute access
+        # without registering anything in `sys.modules`. Skipping the
+        # registration removes a leak vector entirely.
+        self._is_default_context = _code_module is not None
+
         if _code_module is not None:
             self.code = _code_module
             self._code_prefix = _code_prefix or "qsharp.code"
         else:
             self._code_prefix = f"qsharp._context_{id(self)}"
             self.code = types.ModuleType(self._code_prefix)
+
+        # Backstop cleanup: if this Context is garbage-collected without an
+        # explicit `dispose()` call, clear its sys.modules namespace entries
+        # to avoid leaking module state.
+        self._finalizer = weakref.finalize(
+            self, _safe_clear_code_module, self.code, self._code_prefix
+        )
 
         from ._fs import exists, join, list_directory, read_file, resolve
         from ._http import fetch_github
@@ -226,6 +269,23 @@ class Context:
                     f"Error reading {qsharp_json}. qsharp.json should exist at the project root and be a valid JSON file."
                 ) from e
 
+        # Use weakref-bound shims for the Interpreter callbacks so the native
+        # Interpreter does not hold strong references back to this Context,
+        # which would create an unbreakable Python <-> Rust reference cycle.
+        weak_self = weakref.ref(self)
+
+        def _make_callable_shim(callable, namespace, callable_name):
+            ctx = weak_self()
+            if ctx is None:
+                return
+            ctx._make_callable(callable, namespace, callable_name)
+
+        def _make_class_shim(qsharp_type, namespace, class_name):
+            ctx = weak_self()
+            if ctx is None:
+                return
+            ctx._make_class(qsharp_type, namespace, class_name)
+
         self._interpreter = Interpreter(
             target_profile,
             language_features,
@@ -234,8 +294,8 @@ class Context:
             list_directory,
             resolve,
             fetch_github,
-            self._make_callable,
-            self._make_class,
+            _make_callable_shim,
+            _make_class_shim,
             _trace_circuit,
         )
 
@@ -373,28 +433,37 @@ class Context:
             accumulated_namespace += name
             if hasattr(module, name):
                 module = module.__getattribute__(name)
-                if sys.modules.get(accumulated_namespace) is None:
+                if (
+                    self._is_default_context
+                    and sys.modules.get(accumulated_namespace) is None
+                ):
                     sys.modules[accumulated_namespace] = module
             else:
                 new_module = types.ModuleType(accumulated_namespace)
                 module.__setattr__(name, new_module)
-                sys.modules[accumulated_namespace] = new_module
+                if self._is_default_context:
+                    sys.modules[accumulated_namespace] = new_module
                 module = new_module
             accumulated_namespace += "."
 
+        # Capture only a weakref to self so the generated callable does not
+        # keep its owning Context (and the native Interpreter) alive.
+        weak_self = weakref.ref(self)
+
         def _callable_fn(*args):
-            if self._disposed:
+            ctx = weak_self()
+            if ctx is None or ctx._disposed:
                 raise QSharpError(
                     "This callable belongs to a disposed Q# context. "
                     "Re-evaluate the callable in a current context."
                 )
             ipython_helper()
 
-            args = self._python_args_to_interpreter_args(args)
-            output = self._interpreter.invoke(callable, args, self._display)
-            return self._qsharp_value_to_python_value(output)
+            args = ctx._python_args_to_interpreter_args(args)
+            output = ctx._interpreter.invoke(callable, args, ctx._display)
+            return ctx._qsharp_value_to_python_value(output)
 
-        setattr(_callable_fn, "_qdk_context", self)
+        setattr(_callable_fn, "_qdk_context", weak_self)
         setattr(_callable_fn, "__global_callable", callable)
 
         if module.__dict__.get(callable_name) is None:
@@ -416,20 +485,27 @@ class Context:
             else:
                 new_module = types.ModuleType(accumulated_namespace)
                 module.__setattr__(name, new_module)
-                sys.modules[accumulated_namespace] = new_module
+                if self._is_default_context:
+                    sys.modules[accumulated_namespace] = new_module
                 module = new_module
             accumulated_namespace += "."
 
         QSharpClass = make_class_rec(qsharp_type)
         QSharpClass.__qsharp_class = True
-        setattr(QSharpClass, "_qdk_context", self)
+        setattr(QSharpClass, "_qdk_context", weakref.ref(self))
         module.__setattr__(class_name, QSharpClass)
 
     def _check_same_context_callable(self, callable_fn: Any) -> None:
         """Raise if a callable belongs to a different context."""
         # Callable must originate from Q#, so it always has a context.
         assert hasattr(callable_fn, "_qdk_context")
-        callable_context = getattr(callable_fn, "_qdk_context")
+        # _qdk_context is a weakref to the owning Context; dereference it.
+        callable_context = getattr(callable_fn, "_qdk_context")()
+        if callable_context is None:
+            raise QSharpError(
+                "This callable belongs to a disposed Q# context. "
+                "Re-evaluate the callable in a current context."
+            )
         if callable_context is not self:
             raise QSharpError("This callable belongs to a different Context. ")
 
@@ -441,8 +517,44 @@ class Context:
         if not hasattr(struct_type, "_qdk_context"):
             # Ignore objects not originating from Q#.
             return
-        if getattr(struct_type, "_qdk_context") is not self:
+        # _qdk_context is a weakref to the owning Context; dereference it.
+        struct_context = getattr(struct_type, "_qdk_context")()
+        if struct_context is None:
+            raise QSharpError(
+                "This callable belongs to a disposed Q# context. "
+                "Re-evaluate the callable in a current context."
+            )
+        if struct_context is not self:
             raise QSharpError("This struct belongs to a different Context. ")
+
+    def dispose(self) -> None:
+        """Releases this context's dynamically registered code namespace.
+
+        Marks the context as disposed (so any callables previously created
+        via ``self.code.<Name>`` raise a clear error) and removes the
+        attributes and ``sys.modules`` entries that were added on its
+        behalf. Safe to call more than once; subsequent calls are no-ops.
+        """
+        if self._disposed:
+            return
+        self._disposed = True
+
+        # Lazy import to avoid a circular import at module load time.
+        from ._interpreter import _clear_code_module
+
+        _clear_code_module(self.code, self._code_prefix)
+
+        # The finalize-based backstop is no longer needed once explicit
+        # cleanup has run; detach it so it does not fire a second time.
+        self._finalizer.detach()
+
+    def __enter__(self) -> "Context":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> Optional[bool]:
+        self.dispose()
+        # Returning None (falsy) re-raises any in-flight exception.
+        return None
 
     def eval(
         self,

--- a/source/qdk_package/qdk/_interpreter.py
+++ b/source/qdk_package/qdk/_interpreter.py
@@ -65,7 +65,6 @@ import sys
 import types
 from time import monotonic
 
-
 # Global default context instance used by methods in this module.
 _default_context: Optional[Context] = None
 
@@ -135,9 +134,12 @@ def init(
 
     # Dispose the old context so its callables fail gracefully.
     if _default_context is not None:
-        _default_context._disposed = True
+        _default_context.dispose()
 
     # Clean up the global code namespace before creating a new context.
+    # `dispose()` above already cleared this for the previous default context;
+    # the explicit call is kept as a defensive no-op so the flow remains clear
+    # even on first init when there is no previous default to dispose.
     code_prefix = "qdk.code"
     _clear_code_module(code, code_prefix)
 

--- a/source/qdk_package/src/interpreter.rs
+++ b/source/qdk_package/src/interpreter.rs
@@ -38,7 +38,7 @@ use miette::{Diagnostic, Report};
 use num_bigint::BigUint;
 use num_complex::Complex64;
 use pyo3::{
-    IntoPyObjectExt, create_exception,
+    IntoPyObjectExt, PyTraverseError, PyVisit, create_exception,
     exceptions::{PyException, PyValueError},
     prelude::*,
     types::{PyDict, PyList, PyString, PyTuple, PyType},
@@ -403,6 +403,30 @@ thread_local! { static PACKAGE_CACHE: Rc<RefCell<PackageCache>> = Rc::default();
 #[pymethods]
 /// A Q# interpreter.
 impl Interpreter {
+    /// Visits the Python callback fields so Python's cyclic garbage
+    /// collector can detect reference cycles that pass through this
+    /// pyclass. Defining `__traverse__` (together with `__clear__`)
+    /// auto-enables PyO3's GC integration in PyO3 0.21+.
+    #[allow(clippy::needless_pass_by_value)]
+    fn __traverse__(&self, visit: PyVisit<'_>) -> std::result::Result<(), PyTraverseError> {
+        if let Some(cb) = &self.make_callable {
+            visit.call(cb)?;
+        }
+        if let Some(cb) = &self.make_class {
+            visit.call(cb)?;
+        }
+        Ok(())
+    }
+
+    /// Drops the Python callback references during cyclic GC clearing.
+    /// Existing call sites already handle the `None` case, so subsequent
+    /// invocations will surface a clear "callback missing" error path
+    /// rather than dereference a stale reference.
+    fn __clear__(&mut self) {
+        self.make_callable = None;
+        self.make_class = None;
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::needless_pass_by_value)]
     #[pyo3(signature = (target_profile, language_features=None, project_root=None, read_file=None, list_directory=None, resolve_path=None, fetch_github=None, make_callable=None, make_class=None, trace_circuit=None))]

--- a/source/qdk_package/tests/test_context.py
+++ b/source/qdk_package/tests/test_context.py
@@ -1,3 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import gc
+import sys
+import weakref
+
 import qdk
 import pytest
 
@@ -92,12 +99,18 @@ def test_import_openqasm() -> None:
 
 
 def test_context_callable_has_context_ref() -> None:
-    """Callables created via eval carry a _qdk_context attribute."""
+    """Callables created via eval carry a _qdk_context attribute.
+
+    The attribute is a weakref that resolves to the owning Context. Storing a
+    weakref (rather than a direct reference) avoids creating a Python <-> Rust
+    reference cycle between the generated Python callable and the native
+    Interpreter that owns its underlying Q# callable.
+    """
     ctx = qdk.Context()
     ctx.eval("function Add(a : Int, b : Int) : Int { a + b }")
     add_fn = ctx.code.Add
     assert hasattr(add_fn, "_qdk_context")
-    assert add_fn._qdk_context is ctx
+    assert add_fn._qdk_context() is ctx
 
 
 def test_stale_callable_after_reinit() -> None:
@@ -109,6 +122,60 @@ def test_stale_callable_after_reinit() -> None:
     qdk.init()
     with pytest.raises(QSharpError, match="disposed"):
         old_fn()
+
+
+def test_default_context_replaced_on_reinit() -> None:
+    """Re-calling qdk.init() releases the prior default context and registers
+    the new one's callables, with no leak of the old context object.
+
+    Covers the full handover: prior context dispose, sys.modules cleanup of
+    the prior namespace, weak-reference release of the prior context object,
+    and registration of the new context's callables under qdk.code.
+    """
+    from qdk import _interpreter as _qdk_interp
+
+    # Establish a fresh default with a uniquely-named callable.
+    qdk.init()
+    qsharp.eval("namespace OldNs.Inner { function OldFn() : Int { 1 } }")
+    assert qdk.code.OldNs.Inner.OldFn() == 1
+    # Default context's _code_prefix is "qdk.code".
+    assert "qdk.code.OldNs" in sys.modules
+    assert "qdk.code.OldNs.Inner" in sys.modules
+
+    old_ctx_ref = weakref.ref(_qdk_interp._default_context)
+    old_fn = qdk.code.OldNs.Inner.OldFn
+
+    # Re-initialize — installs a fresh default context.
+    qdk.init()
+
+    # The new default is a distinct object.
+    assert _qdk_interp._default_context is not None
+    assert old_ctx_ref() is not _qdk_interp._default_context
+
+    # Old namespace attributes are removed from the shared qdk.code module.
+    assert not hasattr(qdk.code, "OldNs")
+    # And from sys.modules.
+    assert "qdk.code.OldNs" not in sys.modules
+    assert "qdk.code.OldNs.Inner" not in sys.modules
+
+    # The old callable still raises the disposed-context error.
+    with pytest.raises(QSharpError, match="disposed"):
+        old_fn()
+
+    # New callables register cleanly under the same qdk.code module.
+    qsharp.eval("namespace NewNs { function NewFn() : Int { 2 } }")
+    assert qdk.code.NewNs.NewFn() == 2
+    assert "qdk.code.NewNs" in sys.modules
+
+    # The old default context is now collectable — no leak.
+    del old_fn
+    gc.collect()
+    assert (
+        old_ctx_ref() is None
+    ), "previous default Context was not released after qdk.init() replaced it"
+
+    # Cleanup so subsequent tests start from a clean default namespace.
+    qdk.init()
 
 
 def test_config_property() -> None:
@@ -191,3 +258,164 @@ def test_circular_reference_raises():
 
     with pytest.raises(QSharpError, match="Cannot send circular objects"):
         qdk.code.First(circular_list)
+
+
+def test_context_released_after_drop() -> None:
+    """Dropping the last strong reference to a Context releases it via gc."""
+    ctx = qdk.Context()
+    ctx.eval("function Add(a : Int, b : Int) : Int { a + b }")
+    ref = weakref.ref(ctx)
+    del ctx
+    gc.collect()
+    assert ref() is None
+
+
+def test_sys_modules_cleared_after_dispose() -> None:
+    """Dropping a Context removes its synthetic modules from sys.modules."""
+    ctx = qdk.Context()
+    ctx.eval("namespace Foo.Bar { function Hello() : Int { 7 } }")
+    prefix = ctx._code_prefix
+    del ctx
+    gc.collect()
+    leaked = [key for key in sys.modules if key.startswith(f"{prefix}.")]
+    assert leaked == []
+
+
+def test_context_manager_returns_self() -> None:
+    """Using a Context as a context manager yields the Context itself."""
+    ctx = qdk.Context()
+    with ctx as got:
+        assert got is ctx
+    assert ctx._disposed is True
+
+
+def test_context_manager_disposes_on_exit() -> None:
+    """Exiting the with-block disposes the context and allows gc."""
+    with qdk.Context() as ctx:
+        ctx.eval("function Foo() : Int { 42 }")
+        ref = weakref.ref(ctx)
+        assert ctx.code.Foo() == 42
+    # Outside the with-block, dispose() ran.
+    assert ctx._disposed is True
+    del ctx
+    gc.collect()
+    assert ref() is None
+
+
+def test_context_manager_disposes_on_exception() -> None:
+    """An exception inside the with-block still triggers dispose()."""
+    with pytest.raises(RuntimeError, match="boom"):
+        with qdk.Context() as ctx:
+            ctx.eval("function Bar() : Int { 1 }")
+            raise RuntimeError("boom")
+    # ctx is still in scope; dispose() ran during __exit__.
+    assert ctx._disposed is True
+
+
+def _build_interpreter_cycle() -> "weakref.ref":
+    """Construct an Interpreter whose make_callable closes over a holder.
+
+    The closure forms a cycle:
+    holder -> Interpreter (Rust) -> make_callable (Py<PyAny>) -> closure ->
+    holder. Returning only a `weakref.ref` lets the strong references go out
+    of scope so the cycle becomes unreachable.
+    """
+    from qdk._native import Interpreter, TargetProfile
+
+    class Holder:
+        pass
+
+    holder = Holder()
+
+    def make_callable(*_args):
+        # Capture `holder` so the cycle exists at construction time.
+        _ = holder
+
+    holder.interp = Interpreter(  # type: ignore[attr-defined]
+        TargetProfile.Unrestricted,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        make_callable,
+        None,
+        None,
+    )
+    return weakref.ref(holder)
+
+
+def test_interpreter_gc_breaks_cycle() -> None:
+    """Python's cyclic GC can collect Interpreter cycles via __traverse__/__clear__."""
+    ref = _build_interpreter_cycle()
+    gc.collect()
+    assert (
+        ref() is None
+    ), "Interpreter cycle should be collectable via __traverse__/__clear__"
+
+
+def _rss_kib() -> int:
+    import resource
+
+    raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # macOS ru_maxrss is in bytes; Linux is in kilobytes (see getrusage(2)).
+    return raw // 1024 if sys.platform == "darwin" else raw
+
+
+@pytest.mark.slow
+def test_context_soak_no_growth() -> None:
+    """1000 dropped Contexts must release with bounded RSS growth."""
+    # Warm up: prime caches once so first-context allocation cost is excluded.
+    warm = qdk.Context()
+    warm.eval("function Warm() : Int { 1 }")
+    del warm
+    gc.collect()
+
+    baseline_kib = _rss_kib()
+    refs = []
+    for _ in range(1000):
+        ctx = qdk.Context()
+        ctx.eval("function Foo() : Int { 42 }")
+        refs.append(weakref.ref(ctx))
+        del ctx
+        gc.collect()
+
+    alive = sum(1 for r in refs if r() is not None)
+    assert alive == 0, f"{alive}/1000 contexts still alive"
+
+    growth_mib = (_rss_kib() - baseline_kib) / 1024
+    assert growth_mib < 50, f"RSS grew by {growth_mib:.1f} MiB over 1000 contexts"
+
+
+def test_non_default_context_no_sys_modules() -> None:
+    """Non-default Contexts never write to sys.modules.
+
+    Using `from qsharp.code.<ns> import ...` is only
+    supported for the default context. Non-default contexts expose Q# code via
+    `ctx.code.<ns>.<Name>` attribute access without registering anything in
+    `sys.modules`.
+    """
+    ctx = qdk.Context()
+    ctx.eval("namespace Foo.Bar { function Hello() : Int { 7 } }")
+    prefix = ctx._code_prefix
+
+    leaked = [
+        key for key in sys.modules if key == prefix or key.startswith(f"{prefix}.")
+    ]
+    assert leaked == [], f"non-default context leaked sys.modules entries: {leaked}"
+
+    # Attribute access still works.
+    assert ctx.code.Foo.Bar.Hello() == 7
+
+
+def test_default_context_supports_import_path() -> None:
+    """Default context's namespaces are registered in sys.modules so
+    `from qdk.code.<ns> import <name>` works."""
+    qdk.init()
+    qdk.qsharp.eval("namespace Demo.Sub { function Answer() : Int { 42 } }")
+
+    # Import path must work for the default context.
+    from qdk.code.Demo.Sub import Answer  # type: ignore[import-not-found]
+
+    assert Answer() == 42


### PR DESCRIPTION
PR #3208 created two unbreakable reference cycles per qdk.Context:
- bound-method callbacks passed to the native Interpreter, plus per-callable `_callable_fn` closures that captured `self`, formed Python <-> Rust cycles outside the cyclic GC's reach (PyO3 pyclasses default to no GC integration).
- Per-context synthetic namespace modules registered in sys.modules with no cleanup path until the Context was explicitly disposed.