### PR TITLE
Custom Job Params for Targets

### DIFF
--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -205,6 +205,18 @@
             "hidden"
           ],
           "description": "The root URL of the Quantum OS web portal, used when generating deep links to V2 workspaces and jobs."
+        },
+        "Q#.azure.targetJobParams": {
+          "type": "object",
+          "default": {},
+          "tags": [
+            "hidden"
+          ],
+          "markdownDescription": "Additional job parameters to include in `inputParams` when submitting to a specific target. Keys are target IDs (e.g. `ionq.simulator`), values are objects merged into the job's `inputParams`.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          }
         }
       }
     },

--- a/source/vscode/src/azure/commands.ts
+++ b/source/vscode/src/azure/commands.ts
@@ -5,7 +5,7 @@ import { log, QdkDiagnostics, TargetProfile } from "qsharp-lang";
 import * as vscode from "vscode";
 import { getCircuitOrErrorWithTimeout, getConfig } from "../circuit";
 import { qsharpExtensionId } from "../common";
-import { getUploadSupplementalData } from "../config";
+import { getTargetJobParams, getUploadSupplementalData } from "../config";
 import { FullProgramConfig, getActiveProgram } from "../programConfig";
 import { getQirForProgram, QirGenerationError } from "../qirGeneration";
 import {
@@ -664,6 +664,8 @@ export async function compileAndSubmit(
     parameters = { jobName: result.jobName, shots: result.numberOfShots };
   }
 
+  const additionalJobParams = getTargetJobParams(target.id);
+
   const { jobId, storageUris, quantumUris, token } = await submitJob(
     workspace,
     associationId,
@@ -672,6 +674,7 @@ export async function compileAndSubmit(
     target.id,
     parameters.jobName,
     parameters.shots,
+    additionalJobParams,
   );
 
   sendTelemetryEvent(

--- a/source/vscode/src/azure/workspaceActions.ts
+++ b/source/vscode/src/azure/workspaceActions.ts
@@ -645,6 +645,7 @@ export async function submitJob(
   target: string,
   jobName: string,
   numberOfShots: number,
+  additionalJobParams?: Record<string, unknown>,
 ): Promise<JobContext> {
   const quantumUris = new QuantumUris(workspace.endpointUri, workspace.id);
   const token = await getTokenForWorkspace(workspace);
@@ -677,6 +678,7 @@ export async function submitJob(
     providerId,
     target,
     numberOfShots,
+    additionalJobParams,
   );
 
   vscode.window.showInformationMessage(`Job ${jobName} submitted`);
@@ -725,6 +727,7 @@ async function putJobData(
   providerId: string,
   target: string,
   numberOfShots: number,
+  additionalJobParams?: Record<string, unknown>,
 ) {
   const putJobUri = quantumUris.jobs(jobId);
 
@@ -739,6 +742,7 @@ async function putJobData(
     inputDataFormat: "qir.v1",
     outputDataFormat: "microsoft.quantum-results.v2",
     inputParams: {
+      ...additionalJobParams,
       entryPoint: "ENTRYPOINT__main",
       arguments: [],
       shots: numberOfShots,

--- a/source/vscode/src/config.ts
+++ b/source/vscode/src/config.ts
@@ -50,3 +50,12 @@ export function getUploadSupplementalData(): boolean {
     .getConfiguration("Q#")
     .get<boolean>("azure.uploadSupplementalData", true);
 }
+
+export function getTargetJobParams(
+  targetId: string,
+): Record<string, unknown> {
+  const allTargetParams = vscode.workspace
+    .getConfiguration("Q#")
+    .get<Record<string, Record<string, unknown>>>("azure.targetJobParams", {});
+  return allTargetParams[targetId] ?? {};
+}

--- a/source/vscode/src/config.ts
+++ b/source/vscode/src/config.ts
@@ -52,8 +52,14 @@ export function getUploadSupplementalData(): boolean {
 }
 
 export function getTargetJobParams(targetId: string): Record<string, unknown> {
-  const allTargetParams = vscode.workspace
+  const raw = vscode.workspace
     .getConfiguration("Q#")
     .get<Record<string, Record<string, unknown>>>("azure.targetJobParams", {});
+  // Deep clone the entire setting to materialize VS Code's configuration proxy
+  // into a plain object. Without this, nested values may not survive object
+  // spread operations.
+  const allTargetParams: Record<string, Record<string, unknown>> = JSON.parse(
+    JSON.stringify(raw),
+  );
   return allTargetParams[targetId] ?? {};
 }

--- a/source/vscode/src/config.ts
+++ b/source/vscode/src/config.ts
@@ -51,9 +51,7 @@ export function getUploadSupplementalData(): boolean {
     .get<boolean>("azure.uploadSupplementalData", true);
 }
 
-export function getTargetJobParams(
-  targetId: string,
-): Record<string, unknown> {
+export function getTargetJobParams(targetId: string): Record<string, unknown> {
   const allTargetParams = vscode.workspace
     .getConfiguration("Q#")
     .get<Record<string, Record<string, unknown>>>("azure.targetJobParams", {});


### PR DESCRIPTION
## Add support for additional per-target job parameters

### Summary

Adds a hidden VS Code setting (`Q#.azure.targetJobParams`) that allows users to specify arbitrary additional `inputParams` to include when submitting jobs to a specific Azure Quantum target. This enables power users to pass provider-specific parameters (e.g. emulation settings) directly from the VS Code extension, matching what's already possible via the `azure-quantum` Python SDK's `target.submit(input_params={...})`.

### Motivation

Some users need to pass target-specific parameters beyond `shots` when submitting jobs. Previously, this was only possible via the Python SDK. This change brings that capability to the VS Code extension.

### Usage

Add the following to user or workspace `settings.json`:

```jsonc
"Q#.azure.targetJobParams": {
    "rigetti.sim.qvm": {
        "param1": true,
        "param2": {
            "param2-1": "clifford",
            "Foo": false,
            "param2-3": {
                "param2-3-1": "Deeply Nested",
                "param2-3-2": 1.6
            }
        }
    }
}
```

Keys are target IDs (matching the target tree item), values are objects merged into the job's `inputParams` payload.

The setting is tagged as `hidden` and will not appear in the VS Code Settings UI.

### Changes

- **`package.json`** — Added hidden `Q#.azure.targetJobParams` configuration setting
- **`config.ts`** — Added `getTargetJobParams(targetId)` helper that reads the setting and deep-clones it to a plain object (necessary because VS Code's configuration API returns proxy objects whose nested values don't survive object spread)
- **`workspaceActions.ts`** — Added `additionalJobParams` parameter to `submitJob()` and `putJobData()`, spread into `inputParams`
- **`commands.ts`** — Reads target job params from config and passes them to `submitJob()`

### Testing

Manually verified with:

- Flat parameters (e.g., `"noOpt": true`)
- Nested parameters (e.g., `"emulationSettings": { ... }`)
- No parameters configured (empty object — no effect on existing behavior)
- Compared submitted job `inputParams` against equivalent jobs submitted via the Python SDK's `target.submit(input_params={...})`

### Notes

The deep clone via `JSON.parse(JSON.stringify(...))` in `getTargetJobParams()` is intentional. VS Code's `getConfiguration().get()` returns proxy objects with lazy property resolution. Without cloning at the root level, nested values silently disappear when the object is spread into the `inputParams` payload.
