### PR TITLE
Restore function get_config

### DIFF
--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -189,7 +189,7 @@ class Context:
         """
         self._disposed = False
         self._is_global_context = _is_global_context
-        self.target_profile = target_profile
+        self._target_profile = target_profile
 
         if _is_global_context:
             self.code = code
@@ -938,4 +938,4 @@ class Context:
 
     def get_target_profile(self) -> TargetProfile:
         """Returns target profile for this Context."""
-        return self.target_profile
+        return self._target_profile

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -189,6 +189,7 @@ class Context:
         """
         self._disposed = False
         self._is_global_context = _is_global_context
+        self.target_profile = target_profile
 
         if _is_global_context:
             self.code = code
@@ -934,3 +935,7 @@ class Context:
         telemetry_events.on_import_qasm_end(durationMs)
 
         return res
+
+    def get_target_profile(self) -> TargetProfile:
+        """Returns target profile for this Context."""
+        return self.target_profile

--- a/source/qdk_package/qdk/_interpreter.py
+++ b/source/qdk_package/qdk/_interpreter.py
@@ -169,6 +169,10 @@ def get_interpreter() -> Interpreter:
     return _get_default_context()._interpreter
 
 
+def get_config() -> Config:
+    return _get_default_context()._config
+
+
 def python_args_to_interpreter_args(args):
     return _get_default_context()._python_args_to_interpreter_args(args)
 
@@ -571,6 +575,7 @@ __all__ = [
     # Helpers to initialize/access the global Context object.
     "init",
     "get_interpreter",
+    "get_config",
     "python_args_to_interpreter_args",
     "qsharp_value_to_python_value",
 ]

--- a/source/qdk_package/tests/test_context.py
+++ b/source/qdk_package/tests/test_context.py
@@ -117,6 +117,7 @@ def test_config_property() -> None:
     """Context exposes a .config property with the target profile."""
     ctx = qdk.Context(target_profile=qdk.TargetProfile.Base)
     assert ctx._config.get_target_profile() == "base"
+    assert ctx.get_target_profile() == qdk.TargetProfile.Base
 
 
 def test_context_isolation() -> None:


### PR DESCRIPTION
* _interpreter.get_config() is added because it's already used in one place outside this repository (and was removed in recent PR). We don't plan to make it supported public API, this is why it's not documented and not tested.
* We also want to "officially" allow users access some parts of config. As we don't want to make class `Config` public, those  things will be accessed through getters on `Context`. Cirrently the only part of config we want to publicly expose is the target profile.