### PR TITLE
Improve performance of `OutputRecordingPass` when processing QIR simulation results

### DIFF
--- a/source/qdk_package/qdk/simulation/_simulation.py
+++ b/source/qdk_package/qdk/simulation/_simulation.py
@@ -317,16 +317,17 @@ class OutputRecordingPass(pyqir.QirModuleVisitor):
     _output_str = ""
     _closers = []
     _counters = []
+    _process_fn = None
 
     def process_output(self, bitstring: str):
-        return eval(
-            self._output_str,
-            {
-                "o": [
-                    Result.Zero if x == "0" else Result.One if x == "1" else Result.Loss
-                    for x in bitstring
-                ]
-            },
+        assert (
+            self._process_fn is not None
+        ), "OutputRecordingPass has not been run on a module yet"
+        return self._process_fn(
+            [
+                Result.Zero if x == "0" else Result.One if x == "1" else Result.Loss
+                for x in bitstring
+            ]
         )
 
     def _on_function(self, function):
@@ -335,6 +336,7 @@ class OutputRecordingPass(pyqir.QirModuleVisitor):
             while len(self._closers) > 0:
                 self._output_str += self._closers.pop()
                 self._counters.pop()
+            self._process_fn = eval(f"lambda o: {self._output_str}")
 
     def _on_rt_result_record_output(self, call, result, target):
         self._output_str += f"o[{pyqir.ptr_id(result)}]"


### PR DESCRIPTION
This change updates the pattern used to process results in the `OutputRecordingPass` to avoid the perf hit from running Python `eval` for each result. This led to high overhead as each input needed to be parsed and processed by a fresh Python environment. Instead the code uses `eval` once to create a lambda for processing and then is able to invoke it directly on each result, speeding up processing.