### PR TITLE
Fix broken language service and double-execution in playground

### DIFF
--- a/source/npm/qsharp/src/workers/adapters/browser.ts
+++ b/source/npm/qsharp/src/workers/adapters/browser.ts
@@ -15,7 +15,7 @@ export class BrowserWorkerHost implements IWorkerHost {
     const bootstrap = `
       self.WorkerSelf = {
         postMessage(msg) { self.postMessage(msg); },
-        onMessage(handler) { self.addEventListener("message", handler); }
+        onMessage(handler) { self.onmessage = handler; }
       };
       importScripts("${scriptUrl}");
     `;


### PR DESCRIPTION
The playground the language service was non-functional, and the compiler was silently double-executing every request.

**What was happening:**

With #3153 :

- The `BrowserWorkerHost` blob bootstrap registered message handlers via `self.addEventListener("message", handler)`
- Consumers (like the playground) also assign [`self.onmessage = messageHandler` ](https://github.com/microsoft/qdk/blob/7718ef3011298a4f7d1dca6198d71f18217817fe/source/playground/src/compiler-worker.ts#L6)
- Both fire on every message, so `initService` ran twice (crashing on the second `initLogging` call) and every subsequent request produced duplicate responses that confused the proxy

**Fix:**

- Switch the blob's `onMessage` implementation to `self.onmessage = handler` — now when a consumer reassigns `self.onmessage` with the same handler, it's just a harmless overwrite instead of a second registration
- No changes needed in downstream consumers