### PR TITLE
 Switch GPU test image to minimal Ubuntu 22.04 with Vulkan

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -34,7 +34,7 @@ parameters:
     default:
       - name: linux_x86_64
         poolName: "Azure-Pipelines-DevTools-GPU"
-        imageName: "1es-pt-dsvm-ubuntu-2204"
+        imageName: "ubuntu-2204-qdk-gpu"
         os: linux
         arch: x86_64
         envVars:


### PR DESCRIPTION
Replace the previous GPU test image (1es-pt-dsvm-ubuntu-2204) with a minimal Ubuntu 22.04 configuration. The DSVM image included many unnecessary packages (CUDA toolkit, cuDNN, ML frameworks, etc.) that are not required by the GPU simulator — it only needs the Vulkan loader (libvulkan1)

I tested it by running the pipeline and it returned correctly: [link](https://dev.azure.com/ms-azurequantum/AzureQuantum/_build/results?buildId=158690&view=results)


## This change:

- Reduces image size and provisioning time
- Removes unused dependencies that added maintenance burden and potential conflicts