### PR TITLE
`qsharp` should depend on the current or all future `qdk` packages

### DIFF
--- a/source/pip/pyproject.toml
+++ b/source/pip/pyproject.toml
@@ -3,7 +3,7 @@ name = "qsharp"
 version = "0.0.0"
 readme = "README.md"
 requires-python = ">= 3.10"
-dependencies = ["qdk==0.0.0"]
+dependencies = ["qdk>=0.0.0"]
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
`qsharp`'s dependency on `qdk` should be versioned to the upcoming or any future version of the `qdk` package. This saves us from not have to ship new identical `qsharp` package with every release that depend on the newest release of the `qdk`.