### PR TITLE
Update version.py to replace >= in qsharp pyproject.toml

### DIFF
--- a/version.py
+++ b/version.py
@@ -143,8 +143,8 @@ update_file(
 
 update_file(
     os.path.join(source_dir, "pip/pyproject.toml"),
-    r"qdk==0.0.0",
-    r"qdk=={}".format(pip_version),
+    r"qdk>=0.0.0",
+    r"qdk>={}".format(pip_version),
 )
 update_file(
     qdk_pyproject,


### PR DESCRIPTION
version.py needs to have the string it looks for in `qsharp`'s pyproject.toml updated to reflect the recent change to `qsharp`'s dependency on qdk.