### PR TITLE
Storing string properties in ISA instructions

### DIFF
--- a/source/qdk_package/qdk/qre/_architecture.py
+++ b/source/qdk_package/qdk/qre/_architecture.py
@@ -203,7 +203,7 @@ def _make_instruction(
     space: int | _IntFunction | None,
     length: int | _IntFunction | None,
     error_rate: float | _FloatFunction,
-    properties: dict[str, bool | int | float | str],
+    properties: dict[str, int],
 ) -> Instruction:
     """Build an ``Instruction`` from keyword arguments."""
     if arity is not None:

--- a/source/qdk_package/src/qre.rs
+++ b/source/qdk_package/src/qre.rs
@@ -59,30 +59,6 @@ fn poisoned_lock_err<T>(_: std::sync::PoisonError<T>) -> PyErr {
     PyRuntimeError::new_err("provenance graph lock poisoned")
 }
 
-/// Extract a `qre::Property` from a Python value (bool, int, float, or str).
-fn extract_property(value: &Bound<'_, PyAny>) -> PyResult<qre::Property> {
-    let property = if value.is_instance_of::<PyBool>() {
-        qre::Property::new_bool(value.extract()?)
-    } else if let Ok(i) = value.extract::<i64>() {
-        qre::Property::new_int(i)
-    } else if let Ok(f) = value.extract::<f64>() {
-        qre::Property::new_float(f)
-    } else {
-        qre::Property::new_str(value.to_string())
-    };
-    Ok(property)
-}
-
-/// Convert a `qre::Property` to a Python object.
-fn property_to_py<'py>(py: Python<'py>, value: &qre::Property) -> PyResult<Bound<'py, PyAny>> {
-    match value {
-        qre::Property::Bool(b) => PyBool::new(py, *b).into_bound_py_any(py),
-        qre::Property::Int(i) => PyInt::new(py, *i).into_bound_py_any(py),
-        qre::Property::Float(f) => PyFloat::new(py, *f).into_bound_py_any(py),
-        qre::Property::Str(s) => PyString::new(py, s).into_bound_py_any(py),
-    }
-}
-
 #[allow(clippy::upper_case_acronyms)]
 #[pyclass]
 pub struct ISA(qre::ISA);
@@ -337,19 +313,12 @@ impl Instruction {
         self.0.source()
     }
 
-    pub fn set_property(&mut self, key: u64, value: &Bound<'_, PyAny>) -> PyResult<()> {
-        self.0.set_property(key, extract_property(value)?);
-        Ok(())
+    pub fn set_property(&mut self, key: u64, value: u64) {
+        self.0.set_property(key, value);
     }
 
-    pub fn get_property<'py>(
-        &self,
-        py: Python<'py>,
-        key: u64,
-    ) -> PyResult<Option<Bound<'py, PyAny>>> {
-        self.0
-            .get_property(&key)
-            .map_or_else(|| Ok(None), |value| property_to_py(py, value).map(Some))
+    pub fn get_property(&self, key: u64) -> Option<u64> {
+        self.0.get_property(&key)
     }
 
     pub fn has_property(&self, key: u64) -> bool {
@@ -357,22 +326,13 @@ impl Instruction {
     }
 
     #[pyo3(signature = (key, default))]
-    pub fn get_property_or<'py>(
-        &self,
-        py: Python<'py>,
-        key: u64,
-        default: Bound<'py, PyAny>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        if let Some(value) = self.0.get_property(&key) {
-            property_to_py(py, value)
-        } else {
-            Ok(default)
-        }
+    pub fn get_property_or(&self, key: u64, default: u64) -> u64 {
+        self.0.get_property_or(&key, default)
     }
 
-    pub fn __getitem__<'py>(&self, py: Python<'py>, key: u64) -> PyResult<Bound<'py, PyAny>> {
+    pub fn __getitem__(&self, key: u64) -> PyResult<u64> {
         match self.0.get_property(&key) {
-            Some(value) => property_to_py(py, value),
+            Some(value) => Ok(value),
             None => Err(PyKeyError::new_err(format!(
                 "Property with key {key} not found"
             ))),
@@ -548,7 +508,8 @@ fn build_instruction(
                 qre::property_name_to_key(&key_str.to_ascii_uppercase()).ok_or_else(|| {
                     PyValueError::new_err(format!("Unknown property name: {key_str}"))
                 })?;
-            instr.set_property(prop_key, extract_property(&value)?);
+            let prop_value: u64 = value.extract()?;
+            instr.set_property(prop_key, prop_value);
         }
     }
 
@@ -1043,7 +1004,17 @@ impl EstimationResult {
     }
 
     pub fn set_property(&mut self, key: u64, value: &Bound<'_, PyAny>) -> PyResult<()> {
-        self.0.set_property(key, extract_property(value)?);
+        let property = if value.is_instance_of::<pyo3::types::PyBool>() {
+            qre::Property::new_bool(value.extract()?)
+        } else if let Ok(i) = value.extract::<i64>() {
+            qre::Property::new_int(i)
+        } else if let Ok(f) = value.extract::<f64>() {
+            qre::Property::new_float(f)
+        } else {
+            qre::Property::new_str(value.to_string())
+        };
+
+        self.0.set_property(key, property);
 
         Ok(())
     }
@@ -1129,17 +1100,41 @@ impl Trace {
     }
 
     pub fn set_property(&mut self, key: u64, value: &Bound<'_, PyAny>) -> PyResult<()> {
-        self.0.set_property(key, extract_property(value)?);
+        let property = if value.is_instance_of::<pyo3::types::PyBool>() {
+            qre::Property::new_bool(value.extract()?)
+        } else if let Ok(i) = value.extract::<i64>() {
+            qre::Property::new_int(i)
+        } else if let Ok(f) = value.extract::<f64>() {
+            qre::Property::new_float(f)
+        } else {
+            qre::Property::new_str(value.to_string())
+        };
+
+        self.0.set_property(key, property);
 
         Ok(())
     }
 
     #[allow(clippy::needless_pass_by_value)]
     pub fn get_property(self_: PyRef<'_, Self>, key: u64) -> Option<Bound<'_, PyAny>> {
-        self_
-            .0
-            .get_property(key)
-            .and_then(|value| property_to_py(self_.py(), value).ok())
+        if let Some(value) = self_.0.get_property(key) {
+            match value {
+                qre::Property::Bool(b) => PyBool::new(self_.py(), *b)
+                    .into_bound_py_any(self_.py())
+                    .ok(),
+                qre::Property::Int(i) => PyInt::new(self_.py(), *i)
+                    .into_bound_py_any(self_.py())
+                    .ok(),
+                qre::Property::Float(f) => PyFloat::new(self_.py(), *f)
+                    .into_bound_py_any(self_.py())
+                    .ok(),
+                qre::Property::Str(s) => PyString::new(self_.py(), s)
+                    .into_bound_py_any(self_.py())
+                    .ok(),
+            }
+        } else {
+            None
+        }
     }
 
     pub fn has_property(&self, key: u64) -> bool {

--- a/source/qdk_package/tests/qre/test_isa.py
+++ b/source/qdk_package/tests/qre/test_isa.py
@@ -196,7 +196,7 @@ def test_qualitative_properties_on_instruction():
         None,
         1e-8,
         {
-            "assumptions": "ideal qubits, no leakage",
+            "assumptions": 42,
             "feasibility": 4,
             "target_year": 2030,
         },
@@ -206,7 +206,7 @@ def test_qualitative_properties_on_instruction():
     assert instr.has_property(FEASIBILITY) is True
     assert instr.has_property(TARGET_YEAR) is True
 
-    assert instr.get_property(ASSUMPTIONS) == "ideal qubits, no leakage"
+    assert instr.get_property(ASSUMPTIONS) == 42
     assert instr.get_property(FEASIBILITY) == 4
     assert instr.get_property(TARGET_YEAR) == 2030
 

--- a/source/qre/src/isa.rs
+++ b/source/qre/src/isa.rs
@@ -12,7 +12,6 @@ use num_traits::FromPrimitive;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
-use crate::Property;
 use crate::trace::instruction_ids::instruction_name;
 
 pub mod property_keys;
@@ -268,7 +267,7 @@ pub struct Instruction {
     encoding: Encoding,
     metrics: Metrics,
     source: usize,
-    properties: Option<FxHashMap<u64, Property>>,
+    properties: Option<FxHashMap<u64, u64>>,
 }
 
 impl Instruction {
@@ -419,7 +418,7 @@ impl Instruction {
         self.source
     }
 
-    pub fn set_property(&mut self, key: u64, value: Property) {
+    pub fn set_property(&mut self, key: u64, value: u64) {
         if let Some(ref mut properties) = self.properties {
             properties.insert(key, value);
         } else {
@@ -430,8 +429,8 @@ impl Instruction {
     }
 
     #[must_use]
-    pub fn get_property(&self, key: &u64) -> Option<&Property> {
-        self.properties.as_ref()?.get(key)
+    pub fn get_property(&self, key: &u64) -> Option<u64> {
+        self.properties.as_ref()?.get(key).copied()
     }
 
     #[must_use]
@@ -442,7 +441,7 @@ impl Instruction {
     }
 
     #[must_use]
-    pub fn get_property_or<'a>(&'a self, key: &u64, default: &'a Property) -> &'a Property {
+    pub fn get_property_or(&self, key: &u64, default: u64) -> u64 {
         self.get_property(key).unwrap_or(default)
     }
 }

--- a/source/qre/src/isa/provenance.rs
+++ b/source/qre/src/isa/provenance.rs
@@ -126,18 +126,20 @@ impl ProvenanceGraph {
         let mut pareto_index = FxHashMap::default();
         for (id, node_indices) in groups {
             // Sub-partition by encoding and property keys to avoid comparing
-            // incompatible instructions (Risk R2 mitigation). Property values
-            // are compared via their `Display` representation, which is stable
-            // across all Property variants.
+            // incompatible instructions (Risk R2 mitigation)
             #[allow(clippy::type_complexity)]
-            let mut sub_groups: FxHashMap<(Encoding, Vec<(u64, String)>), Vec<usize>> =
+            let mut sub_groups: FxHashMap<(Encoding, Vec<(u64, u64)>), Vec<usize>> =
                 FxHashMap::default();
             for &idx in &node_indices {
                 let instr = &self.nodes[idx].instruction;
-                let mut prop_vec: Vec<(u64, String)> = instr
+                let mut prop_vec: Vec<(u64, u64)> = instr
                     .properties
                     .as_ref()
-                    .map(|p| p.iter().map(|(&k, v)| (k, v.to_string())).collect())
+                    .map(|p| {
+                        let mut v: Vec<_> = p.iter().map(|(&k, &v)| (k, v)).collect();
+                        v.sort_unstable();
+                        v
+                    })
                     .unwrap_or_default();
                 prop_vec.sort_unstable();
                 sub_groups


### PR DESCRIPTION
This PR reverts the changes to instruction properties in #3241 and proposes an alternative way to store strings (e.g., in the provenance graph or in the origin transform of the instruction) to keep the memory footprint of instructions small.

