### PR TITLE
Update python package readmes

### DIFF
--- a/source/pip/README.md
+++ b/source/pip/README.md
@@ -1,55 +1,75 @@
-# Q# Language Support for Python
+# qsharp (compatibility shim)
 
-> **Note:** The `qsharp` package is deprecated. Please use the [`qdk`](https://pypi.org/project/qdk/) package instead. This package is a thin compatibility shim that re-exports the `qdk` public API so that existing code continues to work.
-
-Q# is an open-source, high-level programming language for developing and running quantum algorithms.
-The `qsharp` package for Python provides interoperability with the Q# interpreter, making it easy
-to simulate Q# programs within Python.
+> **Deprecated.** The `qsharp` package is a thin compatibility shim that
+> re-exports the [`qdk`](https://pypi.org/project/qdk/) public API.
+> New projects should use `qdk` directly.
 
 ## Installation
+
+```bash
+pip install qsharp
+```
+
+This installs the `qdk` package as a dependency. For new projects, consider
+installing `qdk` directly instead:
 
 ```bash
 pip install qdk
 ```
 
-For backward compatibility, `pip install qsharp` also works and will install `qdk` as a dependency.
+## Migration
 
-## Usage
+Replace:
 
 ```python
-from qdk import qsharp
+import qsharp
+qsharp.init()
+qsharp.eval("...")
 ```
 
-Then, use the `%%qsharp` cell magic to run Q# directly in Jupyter notebook cells:
+With:
 
-```qsharp
-%%qsharp
-
-import Std.Diagnostics.*;
-
-@EntryPoint()
-operation BellState() : Unit {
-    use qs = Qubit[2];
-    H(qs[0]);
-    CNOT(qs[0], qs[1]);
-    DumpMachine();
-    ResetAll(qs);
-}
-
-BellState()
+```python
+import qdk
+qdk.init()
 ```
+
+Optional extras previously installed via `qsharp[…]` are now available as
+`qdk[…]`:
+
+| Old extra              | New extra        |
+| ---------------------- | ---------------- |
+| `qsharp[jupyterlab]`   | `qdk[jupyter]`   |
+| `qsharp[widgets]`      | `qdk[jupyter]`   |
+| `qsharp[qiskit]`       | `qdk[qiskit]`    |
+| `qsharp[cirq]`         | `qdk[cirq]`      |
+
+## What this package provides
+
+When imported, the `qsharp` shim:
+
+1. Emits a `DeprecationWarning` directing users to migrate to `qdk`.
+2. Re-exports the core Q# interpreter API (`init`, `eval`, `run`, `compile`,
+   `circuit`, `estimate`, `dump_machine`, `dump_circuit`, `dump_operation`,
+   `set_quantum_seed`, `set_classical_seed`, etc.) from `qdk.qsharp`.
+3. Re-exports key types: `Result`, `Pauli`, `QSharpError`, `TargetProfile`,
+   `StateDump`, `ShotResult`, `PauliNoise`, `DepolarizingNoise`,
+   `BitFlipNoise`, `PhaseFlipNoise`, `CircuitGenerationMethod`.
+
+Submodules such as `qsharp.estimator`, `qsharp.openqasm`, and
+`qsharp.code` similarly re-export from their `qdk` counterparts.
 
 ## Telemetry
 
-This library sends telemetry. Minimal anonymous data is collected to help measure feature usage and performance.
-All telemetry events can be seen in the source file [telemetry_events.py](https://github.com/microsoft/qdk/tree/main/source/qdk_package/qdk/telemetry_events.py).
-
-To disable sending telemetry from this package, set the environment variable `QDK_PYTHON_TELEMETRY=none`
+This library sends telemetry via the `qdk` package. To disable it, set
+the environment variable `QDK_PYTHON_TELEMETRY=none`.
 
 ## Support
 
-For more information about the Microsoft Quantum Development Kit, visit [https://aka.ms/qdk](https://aka.ms/qdk).
+For more information about the Microsoft Quantum Development Kit, visit
+[https://aka.ms/qdk](https://aka.ms/qdk).
 
 ## Contributing
 
-Q# welcomes your contributions! Visit the Q# GitHub repository at [https://github.com/microsoft/qdk] to find out more about the project.
+Visit the Q# GitHub repository at [https://github.com/microsoft/qdk](https://github.com/microsoft/qdk)
+to find out more about the project.

--- a/source/pip/README.md
+++ b/source/pip/README.md
@@ -1,4 +1,4 @@
-# qsharp (compatibility shim)
+# `qsharp` (compatibility shim)
 
 > **Deprecated.** The `qsharp` package is a thin compatibility shim that
 > re-exports the [`qdk`](https://pypi.org/project/qdk/) public API.

--- a/source/pip/README.md
+++ b/source/pip/README.md
@@ -71,5 +71,5 @@ For more information about the Microsoft Quantum Development Kit, visit
 
 ## Contributing
 
-Visit the Q# GitHub repository at [https://github.com/microsoft/qdk](https://github.com/microsoft/qdk)
+Visit the Quantum Development Kit GitHub repository at [https://github.com/microsoft/qdk](https://github.com/microsoft/qdk)
 to find out more about the project.

--- a/source/qdk_package/README.md
+++ b/source/qdk_package/README.md
@@ -70,7 +70,7 @@ Histogram(results)
 
 Submodules:
 
-- `qdk.qsharp` – Q# interpreter functions: `init`, `eval`, `run`, `compile`, `circuit`, `estimate`, and related types.
+- `qdk.qsharp` – Q# interpreter functions: `init`, `eval`, `run`, `compile`, `circuit`, `estimate`, `dump_machine`, `dump_circuit`, `dump_operation`, and related types.
 - `qdk.openqasm` – OpenQASM compilation and execution.
 - `qdk.estimator` – resource estimation utilities.
 - `qdk.simulation` – noise-aware simulation utilities: `NeutralAtomDevice`, `NoiseConfig`, `run_qir`, `DensityMatrixSimulator`, `StateVectorSimulator`, and related types.
@@ -86,21 +86,22 @@ Submodules:
 
 For convenience, the following helpers and types are also importable directly from the `qdk` root (e.g. `from qdk import code, Result`). Algorithm execution APIs (like `run` / `estimate`) remain under `qdk.qsharp` or `qdk.openqasm`.
 
-| Symbol               | Type     | Origin                      | Description                                                         |
-| -------------------- | -------- | --------------------------- | ------------------------------------------------------------------- |
-| `code`               | module   | `qsharp.code`               | Exposes operations defined in Q\# or OpenQASM                       |
-| `init`               | function | `qsharp.init`               | Initialize/configure the QDK interpreter (target profile, options). |
-| `set_quantum_seed`   | function | `qsharp.set_quantum_seed`   | Deterministic seed for quantum randomness (simulators).             |
-| `set_classical_seed` | function | `qsharp.set_classical_seed` | Deterministic seed for classical host RNG.                          |
-| `dump_machine`       | function | `qsharp.dump_machine`       | Emit a structured dump of full quantum state (simulator dependent). |
-| `Result`             | class    | `qsharp.Result`             | Measurement result token.                                           |
-| `TargetProfile`      | class    | `qsharp.TargetProfile`      | Target capability / profile descriptor.                             |
-| `StateDump`          | class    | `qsharp.StateDump`          | Structured state dump object.                                       |
-| `ShotResult`         | class    | `qsharp.ShotResult`         | Multi-shot execution results container.                             |
-| `PauliNoise`         | class    | `qsharp.PauliNoise`         | Pauli channel noise model spec.                                     |
-| `DepolarizingNoise`  | class    | `qsharp.DepolarizingNoise`  | Depolarizing noise model spec.                                      |
-| `BitFlipNoise`       | class    | `qsharp.BitFlipNoise`       | Bit-flip noise model spec.                                          |
-| `PhaseFlipNoise`     | class    | `qsharp.PhaseFlipNoise`     | Phase-flip noise model spec.                                        |
+| Symbol               | Type     | Origin                          | Description                                                         |
+| -------------------- | -------- | ------------------------------- | ------------------------------------------------------------------- |
+| `code`               | module   | `qdk.code`                      | Exposes operations defined in Q\# or OpenQASM                       |
+| `init`               | function | `qdk.qsharp.init`               | Initialize/configure the QDK interpreter (target profile, options). |
+| `set_quantum_seed`   | function | `qdk.qsharp.set_quantum_seed`   | Deterministic seed for quantum randomness (simulators).             |
+| `set_classical_seed` | function | `qdk.qsharp.set_classical_seed` | Deterministic seed for classical host RNG.                          |
+| `dump_machine`       | function | `qdk.qsharp.dump_machine`       | Emit a structured dump of full quantum state (simulator dependent). |
+| `Result`             | class    | `qdk.qsharp.Result`             | Measurement result token.                                           |
+| `TargetProfile`      | class    | `qdk.qsharp.TargetProfile`      | Target capability / profile descriptor.                             |
+| `StateDump`          | class    | `qdk.qsharp.StateDump`          | Structured state dump object.                                       |
+| `ShotResult`         | class    | `qdk.qsharp.ShotResult`         | Multi-shot execution results container.                             |
+| `PauliNoise`         | class    | `qdk.qsharp.PauliNoise`         | Pauli channel noise model spec.                                     |
+| `DepolarizingNoise`  | class    | `qdk.qsharp.DepolarizingNoise`  | Depolarizing noise model spec.                                      |
+| `BitFlipNoise`       | class    | `qdk.qsharp.BitFlipNoise`       | Bit-flip noise model spec.                                          |
+| `PhaseFlipNoise`     | class    | `qdk.qsharp.PhaseFlipNoise`     | Phase-flip noise model spec.                                        |
+| `Context`            | class    | `qdk.Context`                   | Isolated Q# interpreter context for independent sessions.           |
 
 ## Telemetry
 

--- a/source/qdk_package/README.md
+++ b/source/qdk_package/README.md
@@ -86,22 +86,22 @@ Submodules:
 
 For convenience, the following helpers and types are also importable directly from the `qdk` root (e.g. `from qdk import code, Result`). Algorithm execution APIs (like `run` / `estimate`) remain under `qdk.qsharp` or `qdk.openqasm`.
 
-| Symbol               | Type     | Origin                          | Description                                                         |
-| -------------------- | -------- | ------------------------------- | ------------------------------------------------------------------- |
-| `code`               | module   | `qdk.code`                      | Exposes operations defined in Q\# or OpenQASM                       |
-| `init`               | function | `qdk.qsharp.init`               | Initialize/configure the QDK interpreter (target profile, options). |
-| `set_quantum_seed`   | function | `qdk.qsharp.set_quantum_seed`   | Deterministic seed for quantum randomness (simulators).             |
-| `set_classical_seed` | function | `qdk.qsharp.set_classical_seed` | Deterministic seed for classical host RNG.                          |
-| `dump_machine`       | function | `qdk.qsharp.dump_machine`       | Emit a structured dump of full quantum state (simulator dependent). |
-| `Result`             | class    | `qdk.qsharp.Result`             | Measurement result token.                                           |
-| `TargetProfile`      | class    | `qdk.qsharp.TargetProfile`      | Target capability / profile descriptor.                             |
-| `StateDump`          | class    | `qdk.qsharp.StateDump`          | Structured state dump object.                                       |
-| `ShotResult`         | class    | `qdk.qsharp.ShotResult`         | Multi-shot execution results container.                             |
-| `PauliNoise`         | class    | `qdk.qsharp.PauliNoise`         | Pauli channel noise model spec.                                     |
-| `DepolarizingNoise`  | class    | `qdk.qsharp.DepolarizingNoise`  | Depolarizing noise model spec.                                      |
-| `BitFlipNoise`       | class    | `qdk.qsharp.BitFlipNoise`       | Bit-flip noise model spec.                                          |
-| `PhaseFlipNoise`     | class    | `qdk.qsharp.PhaseFlipNoise`     | Phase-flip noise model spec.                                        |
-| `Context`            | class    | `qdk.Context`                   | Isolated Q# interpreter context for independent sessions.           |
+| Symbol               | Type     | Origin                          | Description                                                            |
+| -------------------- | -------- | ------------------------------- | ---------------------------------------------------------------------- |
+| `code`               | module   | `qdk.code`                      | Exposes operations defined in Q\# or OpenQASM                          |
+| `init`               | function | `qdk.qsharp.init`               | Initialize/configure the QDK interpreter (target profile, options).    |
+| `set_quantum_seed`   | function | `qdk.qsharp.set_quantum_seed`   | Deterministic seed for quantum randomness (simulators).                |
+| `set_classical_seed` | function | `qdk.qsharp.set_classical_seed` | Deterministic seed for classical host RNG.                             |
+| `dump_machine`       | function | `qdk.qsharp.dump_machine`       | Emit a structured dump of full quantum state (simulator dependent).    |
+| `Result`             | class    | `qdk.qsharp.Result`             | Measurement result token.                                              |
+| `TargetProfile`      | class    | `qdk.qsharp.TargetProfile`      | Target capability / profile descriptor.                                |
+| `StateDump`          | class    | `qdk.qsharp.StateDump`          | Structured state dump object.                                          |
+| `ShotResult`         | class    | `qdk.qsharp.ShotResult`         | Multi-shot execution results container.                                |
+| `PauliNoise`         | class    | `qdk.qsharp.PauliNoise`         | Pauli channel noise model spec.                                        |
+| `DepolarizingNoise`  | class    | `qdk.qsharp.DepolarizingNoise`  | Depolarizing noise model spec.                                         |
+| `BitFlipNoise`       | class    | `qdk.qsharp.BitFlipNoise`       | Bit-flip noise model spec.                                             |
+| `PhaseFlipNoise`     | class    | `qdk.qsharp.PhaseFlipNoise`     | Phase-flip noise model spec.                                           |
+| `Context`            | class    | `qdk.Context`                   | Isolated Q# and OpenQASM interpreter context for independent sessions. |
 
 ## Telemetry
 


### PR DESCRIPTION
Updates the `qdk` package readme file with new features and top-level dump operations. Updates the `qsharp` readme to make it clear that it is a deprecated package and gives instructions on migration.