### PR TITLE
rename workspace folder, fix exercise label color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ __pycache__/
 .idea/
 *.so
 samples/scratch/
-samples/qdk-learning-ws/
+samples/qdk-learning/
 samples/qdk-learning.json
 *.pyd
 /python_doc/

--- a/source/vscode/src/learning/constants.ts
+++ b/source/vscode/src/learning/constants.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /** Well-known workspace folder name for katas exercise/example files. */
-export const LEARNING_WORKSPACE_FOLDER = "qdk-learning-ws";
+export const LEARNING_WORKSPACE_FOLDER = "qdk-learning";
 
 /** Relative path form of {@link LEARNING_WORKSPACE_FOLDER}, for use in URI joins. */
 export const LEARNING_WORKSPACE_RELATIVE_PATH = `./${LEARNING_WORKSPACE_FOLDER}`;

--- a/source/vscode/src/learning/webview/webview.css
+++ b/source/vscode/src/learning/webview/webview.css
@@ -164,12 +164,6 @@ body {
   color: var(--fg);
 }
 
-/* Badge variant: incomplete exercise — accented to signal "needs action". */
-.header .badge.exercise {
-  background: var(--vscode-badge-background, var(--accent));
-  color: var(--vscode-badge-foreground, #fff);
-}
-
 /* Badge variant: completed exercise — green "done" state. */
 .header .badge.complete {
   background: var(--success);


### PR DESCRIPTION
- `qdk-learning-ws` -> `qdk-learning` - looks better as a top-level container for the content
- exercise badge had a distinct color, meant to indicate it was "actionable", but it was kind of a flop in practice, so removing that style.

(as discussed with @billti already)