### PR TITLE
Fix stale selection in Learning panel

### DIFF
--- a/source/vscode/src/learning/progressTreeView.ts
+++ b/source/vscode/src/learning/progressTreeView.ts
@@ -115,7 +115,11 @@ class LearningProgressTreeProvider implements vscode.TreeDataProvider<LearningPr
       : activity.type === "exercise"
         ? "Exercise"
         : "Lesson";
-    item.id = `activity:${unitId}:${activity.id}`;
+    // Vary the id by `isCurrent` so VS Code drops the stale selection when the
+    // active activity changes (e.g. after pressing Next in the lesson panel).
+    item.id = isCurrent
+      ? `activity:${unitId}:${activity.id}:current`
+      : `activity:${unitId}:${activity.id}`;
     item.command = {
       command: "qsharp-vscode.learningOpenActivity",
       title: "Go to Activity",


### PR DESCRIPTION
When a user clicks an activity node in the Learning progress tree and then presses Next (or Previous) in the lesson panel, the tree view's selection highlight remained on the originally-clicked node even though the current position had advanced. This created a confusing disconnect between the visual selection and the actual active activity.

The fix varies the activity node item.id by appending :current when the node represents the active activity — the same pattern already used for unit nodes. When the current position changes, the previously-selected node's ID no longer exists in the refreshed tree, causing VS Code to automatically drop the stale selection.