### PR TITLE
Fix button text alignment

### DIFF
--- a/source/vscode/src/learning/webview/webview-client.tsx
+++ b/source/vscode/src/learning/webview/webview-client.tsx
@@ -530,7 +530,7 @@ function ActionBar({
                   {binding.codicon && (
                     <span class={`codicon codicon-${binding.codicon}`} />
                   )}
-                  {binding.codicon ? " " + binding.label : binding.label}
+                  {binding.label}
                 </button>
               );
             })}

--- a/source/vscode/src/learning/webview/webview.css
+++ b/source/vscode/src/learning/webview/webview.css
@@ -375,6 +375,9 @@ body {
 
 /* Base button style (secondary appearance by default). */
 .action-bar button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font: inherit; /* buttons don't inherit font by default */
   font-size: var(--font-sm);
   background: var(--btn-secondary-bg);


### PR DESCRIPTION
Problem: Buttons with a codicon icon (e.g. "Hint" with the sparkle icon) had their text render lower than adjacent icon-free buttons. The codicon font's metrics differ from the button text font, and with default inline layout the icon's baseline pulls the text out of vertical alignment.

Solution: Made `.action-bar button` an `inline-flex` container with `align-items: center`, which vertically centers both the icon span and text regardless of font metrics. Replaced the manual space character between icon and label with a `gap: 4px` for consistent spacing.

Note: Copilot assures me that "4px" somehow scales automatically with zoom and DPI and that seems to be true in my testing.