### PR TITLE
Add `frem`, `fptoui`, `uitofp` instructions to QIR simulators

### DIFF
--- a/source/qdk_package/qdk/_adaptive_bytecode.py
+++ b/source/qdk_package/qdk/_adaptive_bytecode.py
@@ -72,6 +72,7 @@ OP_FADD = 0x38
 OP_FSUB = 0x39
 OP_FMUL = 0x3A
 OP_FDIV = 0x3B
+OP_FREM = 0x3C
 
 # ── Type Conversion ──────────────────────────────────────────────────────────
 OP_ZEXT = 0x40
@@ -82,6 +83,8 @@ OP_FPTRUNC = 0x44
 OP_INTTOPTR = 0x45
 OP_FPTOSI = 0x46
 OP_SITOFP = 0x47
+OP_FPTOUI = 0x48
+OP_UITOFP = 0x49
 
 # ── SSA / Data Movement ─────────────────────────────────────────────────────
 OP_PHI = 0x50

--- a/source/qdk_package/qdk/_adaptive_pass.py
+++ b/source/qdk_package/qdk/_adaptive_pass.py
@@ -789,14 +789,20 @@ class AdaptiveProfilePass:
                 self._emit_binary(OP_FMUL | FLAG_FLOAT, instr)
             case pyqir.Opcode.FDIV:
                 self._emit_binary(OP_FDIV | FLAG_FLOAT, instr)
+            case pyqir.Opcode.FREM:
+                self._emit_binary(OP_FREM | FLAG_FLOAT, instr)
             case pyqir.Opcode.FP_EXT:
                 self._emit_unary(OP_FPEXT | FLAG_FLOAT, instr)
             case pyqir.Opcode.FP_TRUNC:
                 self._emit_unary(OP_FPTRUNC | FLAG_FLOAT, instr)
             case pyqir.Opcode.FP_TO_SI:
                 self._emit_unary(OP_FPTOSI, instr)
+            case pyqir.Opcode.FP_TO_UI:
+                self._emit_unary(OP_FPTOUI, instr)
             case pyqir.Opcode.SI_TO_FP:
                 self._emit_unary(OP_SITOFP | FLAG_FLOAT, instr)
+            case pyqir.Opcode.UI_TO_FP:
+                self._emit_unary(OP_UITOFP | FLAG_FLOAT, instr)
             case pyqir.Opcode.INT_TO_PTR:
                 self._emit_inttoptr(instr)
             case pyqir.Opcode.ALLOCA:

--- a/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
@@ -784,6 +784,11 @@ FLOAT_ARITH_PARAMS = [
     ("fsub", 3.0, 10.0, -7.0),
     ("fmul", 6.0, 7.0, 42.0),
     ("fdiv", 8.0, 2.0, 4.0),
+    ("frem", 8.0, 2.0, 0.0),
+    ("frem", 7.0, 3.0, 1.0),
+    ("frem", 10.5, 3.0, 1.5),
+    ("frem", 10.5, -3.0, 1.5),  # remainder has the same sign as dividend
+    ("frem", -10.5, 3.0, -1.5),  # remainder has the same sign as dividend
 ]
 
 
@@ -992,6 +997,88 @@ SITOFP_QIR = """
 @pytest.mark.parametrize("sim_type", SIM_TYPES)
 def test_sitofp(sim_type):
     check_arith_result(SITOFP_QIR, "1", sim_type=sim_type)
+
+
+# =========================================================================
+# OP_FPTOUI — float to unsigned int
+# =========================================================================
+
+FPTOUI_QIR = """
+  ; fptoui 3.7 → 3 (truncation toward zero), check 3 == 3 → true
+  %i = fptoui double 3.7 to i64
+  %flag = icmp eq i64 %i, 3
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_fptoui(sim_type):
+    check_arith_result(FPTOUI_QIR, "1", sim_type=sim_type)
+
+
+FPTOUI_ZERO_QIR = """
+  ; fptoui 0.0 → 0
+  %i = fptoui double 0.0 to i64
+  %flag = icmp eq i64 %i, 0
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_fptoui_zero(sim_type):
+    check_arith_result(FPTOUI_ZERO_QIR, "1", sim_type=sim_type)
+
+
+FPTOUI_LARGE_QIR = """
+  ; fptoui 255.9 → 255
+  %i = fptoui double 255.9 to i64
+  %flag = icmp eq i64 %i, 255
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_fptoui_large(sim_type):
+    check_arith_result(FPTOUI_LARGE_QIR, "1", sim_type=sim_type)
+
+
+# =========================================================================
+# OP_UITOFP — unsigned int to float
+# =========================================================================
+
+UITOFP_QIR = """
+  ; uitofp 5 → 5.0, then 5.0 > 4.0 → true
+  %f = uitofp i64 5 to double
+  %flag = fcmp ogt double %f, 4.0
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_uitofp(sim_type):
+    check_arith_result(UITOFP_QIR, "1", sim_type=sim_type)
+
+
+UITOFP_ZERO_QIR = """
+  ; uitofp 0 → 0.0
+  %f = uitofp i64 0 to double
+  %flag = fcmp oeq double %f, 0.0
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_uitofp_zero(sim_type):
+    check_arith_result(UITOFP_ZERO_QIR, "1", sim_type=sim_type)
+
+
+UITOFP_ROUNDTRIP_QIR = """
+  ; uitofp 42 → 42.0, then fptoui 42.0 → 42
+  %f = uitofp i64 42 to double
+  %i = fptoui double %f to i64
+  %flag = icmp eq i64 %i, 42
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_uitofp_fptoui_roundtrip(sim_type):
+    """Round-trip: uitofp then fptoui must recover the original value."""
+    check_arith_result(UITOFP_ROUNDTRIP_QIR, "1", sim_type=sim_type)
 
 
 # #########################################################################

--- a/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
@@ -873,6 +873,21 @@ def test_float_arith_negative_test(sim_type, bin_op, lhs, rhs, expected):
     )
 
 
+# Dividing by zero with `frem` must fail gracefully by producing NaN
+# (matching C's `fmod`) rather than crashing the interpreter. NaN never
+# compares equal to itself, so `fcmp one %a, %a` (not-equal) is true iff the
+# result is NaN.
+FREM_BY_ZERO_QIR = """
+  %a = frem double 8.0, 0.0
+  %flag = fcmp one double %a, %a
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_frem_by_zero_is_nan(sim_type):
+    check_arith_result(FREM_BY_ZERO_QIR, "1", sim_type=sim_type)
+
+
 # #########################################################################
 #  Type Conversion  (OP_ZEXT → OP_SITOFP)
 # #########################################################################
@@ -1037,6 +1052,20 @@ FPTOUI_LARGE_QIR = """
 @pytest.mark.parametrize("sim_type", SIM_TYPES)
 def test_fptoui_large(sim_type):
     check_arith_result(FPTOUI_LARGE_QIR, "1", sim_type=sim_type)
+
+
+FPTOUI_NEGATIVE_QIR = """
+  ; fptoui of a negative float is out of range for an unsigned int;
+  ; but we still round towards the nearest uint value, which is zero.
+  %neg = fsub double 0.0, 3.7
+  %i = fptoui double %neg to i64
+  %flag = icmp eq i64 %i, 0
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_fptoui_negative(sim_type):
+    check_arith_result(FPTOUI_NEGATIVE_QIR, "1", sim_type=sim_type)
 
 
 # =========================================================================

--- a/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
@@ -791,6 +791,11 @@ FLOAT_ARITH_PARAMS = [
     ("fsub", 3.0, 10.0, -7.0),
     ("fmul", 6.0, 7.0, 42.0),
     ("fdiv", 8.0, 2.0, 4.0),
+    ("frem", 8.0, 2.0, 0.0),
+    ("frem", 7.0, 3.0, 1.0),
+    ("frem", 10.5, 3.0, 1.5),
+    ("frem", 10.5, -3.0, 1.5),  # remainder has the same sign as dividend
+    ("frem", -10.5, 3.0, -1.5),  # remainder has the same sign as dividend
 ]
 
 
@@ -998,6 +1003,88 @@ SITOFP_QIR = """
 @pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
 def test_sitofp():
     check_arith_result(SITOFP_QIR, "1")
+
+
+# =========================================================================
+# OP_FPTOUI — float to unsigned int
+# =========================================================================
+
+FPTOUI_QIR = """
+  ; fptoui 3.7 → 3 (truncation toward zero), check 3 == 3 → true
+  %i = fptoui double 3.7 to i64
+  %flag = icmp eq i64 %i, 3
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_fptoui():
+    check_arith_result(FPTOUI_QIR, "1")
+
+
+FPTOUI_ZERO_QIR = """
+  ; fptoui 0.0 → 0
+  %i = fptoui double 0.0 to i64
+  %flag = icmp eq i64 %i, 0
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_fptoui_zero():
+    check_arith_result(FPTOUI_ZERO_QIR, "1")
+
+
+FPTOUI_LARGE_QIR = """
+  ; fptoui 255.9 → 255
+  %i = fptoui double 255.9 to i64
+  %flag = icmp eq i64 %i, 255
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_fptoui_large():
+    check_arith_result(FPTOUI_LARGE_QIR, "1")
+
+
+# =========================================================================
+# OP_UITOFP — unsigned int to float
+# =========================================================================
+
+UITOFP_QIR = """
+  ; uitofp 5 → 5.0, then 5.0 > 4.0 → true
+  %f = uitofp i64 5 to double
+  %flag = fcmp ogt double %f, 4.0
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_uitofp():
+    check_arith_result(UITOFP_QIR, "1")
+
+
+UITOFP_ZERO_QIR = """
+  ; uitofp 0 → 0.0
+  %f = uitofp i64 0 to double
+  %flag = fcmp oeq double %f, 0.0
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_uitofp_zero():
+    check_arith_result(UITOFP_ZERO_QIR, "1")
+
+
+UITOFP_ROUNDTRIP_QIR = """
+  ; uitofp 42 → 42.0, then fptoui 42.0 → 42
+  %f = uitofp i64 42 to double
+  %i = fptoui double %f to i64
+  %flag = icmp eq i64 %i, 42
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_uitofp_fptoui_roundtrip():
+    """Round-trip: uitofp then fptoui must recover the original value."""
+    check_arith_result(UITOFP_ROUNDTRIP_QIR, "1")
 
 
 # #########################################################################

--- a/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
@@ -876,6 +876,26 @@ def test_float_arith_negative_test(bin_op, lhs, rhs, expected):
     )
 
 
+# Dividing by zero with `frem` must fail gracefully (no crash, deterministic
+# result) rather than panicking the interpreter. The exact value is left
+# implementation-defined on the GPU: with strict IEEE semantics `8 frem 0` is
+# NaN, but GPUs using fast-math may yield a finite value for `x / 0`. So we only
+# assert that the program runs and every shot agrees.
+FREM_BY_ZERO_QIR = """
+  %a = frem double 8.0, 0.0
+  %flag = fcmp oeq double %a, %a
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_frem_by_zero_is_graceful():
+    body = build_arith_body(FREM_BY_ZERO_QIR)
+    qir = format_qir(body)
+    results = _run(qir, SHOTS)["shot_results"]
+    counts = Counter(map_result_list_to_str(r) for r in results)
+    assert len(counts) == 1, f"Expected a deterministic result, got {counts}"
+
+
 # #########################################################################
 #  Type Conversion  (OP_ZEXT → OP_SITOFP)
 # #########################################################################
@@ -1043,6 +1063,20 @@ FPTOUI_LARGE_QIR = """
 @pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
 def test_fptoui_large():
     check_arith_result(FPTOUI_LARGE_QIR, "1")
+
+
+FPTOUI_NEGATIVE_QIR = """
+  ; fptoui of a negative float is out of range for an unsigned int;
+  ; but we still round towards the nearest uint value, which is zero.
+  %neg = fsub double 0.0, 3.7
+  %i = fptoui double %neg to i64
+  %flag = icmp eq i64 %i, 0
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_fptoui_negative():
+    check_arith_result(FPTOUI_NEGATIVE_QIR, "1")
 
 
 # =========================================================================

--- a/source/simulators/src/bytecode/runtime.rs
+++ b/source/simulators/src/bytecode/runtime.rs
@@ -76,6 +76,7 @@ const OP_FADD: u8 = 0x38;
 const OP_FSUB: u8 = 0x39;
 const OP_FMUL: u8 = 0x3A;
 const OP_FDIV: u8 = 0x3B;
+const OP_FREM: u8 = 0x3C;
 
 // Type conversion
 const OP_ZEXT: u8 = 0x40;
@@ -86,6 +87,8 @@ const OP_FPTRUNC: u8 = 0x44;
 const OP_INTTOPTR: u8 = 0x45;
 const OP_FPTOSI: u8 = 0x46;
 const OP_SITOFP: u8 = 0x47;
+const OP_FPTOUI: u8 = 0x48;
+const OP_UITOFP: u8 = 0x49;
 
 // SSA / data movement
 const OP_PHI: u8 = 0x50;
@@ -634,6 +637,17 @@ pub fn run_shot<S: Simulator>(program: &AdaptiveProgram<u64>, sim: &mut S) {
                 rt.pc += 1;
             }
 
+            // Rust documentation says f64::rem is implemented as
+            // `x - (x / y).trunc() * y`
+            // which has the same semantics as C's `fmod`,
+            // satisfying LLVM's semantics for `FREM`.
+            OP_FREM => {
+                let a = rt.resolve_f64(instr.src0, flags, 0);
+                let b = rt.resolve_f64(instr.src1, flags, 1);
+                rt.write_f64(instr.dst, a % b);
+                rt.pc += 1;
+            }
+
             // ----- Type conversion -----
             OP_ZEXT | OP_TRUNC | OP_INTTOPTR => {
                 let val = rt.resolve_u64(instr.src0, flags, 0);
@@ -680,6 +694,18 @@ pub fn run_shot<S: Simulator>(program: &AdaptiveProgram<u64>, sim: &mut S) {
 
             OP_SITOFP => {
                 let val = rt.resolve_i64(instr.src0, flags, 0);
+                rt.write_f64(instr.dst, val as f64);
+                rt.pc += 1;
+            }
+
+            OP_FPTOUI => {
+                let val = rt.resolve_f64(instr.src0, flags, 0);
+                rt.write_reg(instr.dst, val as u64);
+                rt.pc += 1;
+            }
+
+            OP_UITOFP => {
+                let val = rt.resolve_u64(instr.src0, flags, 0);
                 rt.write_f64(instr.dst, val as f64);
                 rt.pc += 1;
             }

--- a/source/simulators/src/gpu_full_state_simulator/simulator_adaptive.wgsl
+++ b/source/simulators/src/gpu_full_state_simulator/simulator_adaptive.wgsl
@@ -358,6 +358,7 @@ const OP_FADD:          u32 = 0x38;
 const OP_FSUB:          u32 = 0x39;
 const OP_FMUL:          u32 = 0x3A;
 const OP_FDIV:          u32 = 0x3B;
+const OP_FREM:          u32 = 0x3C;
 
 // -- Type Conversion ----------------------------------------------------------
 const OP_ZEXT:          u32 = 0x40;
@@ -368,6 +369,8 @@ const OP_FPTRUNC:       u32 = 0x44;
 const OP_INTTOPTR:      u32 = 0x45;
 const OP_FPTOSI:        u32 = 0x46;
 const OP_SITOFP:        u32 = 0x47;
+const OP_FPTOUI:        u32 = 0x48;
+const OP_UITOFP:        u32 = 0x49;
 
 // -- SSA / Data Movement -----------------------------------------------------
 const OP_PHI:           u32 = 0x50;
@@ -1210,6 +1213,16 @@ fn interpret_classical(@builtin(global_invocation_id) gid: vec3<u32>) {
                 pc++;
             }
 
+            // FREM: Float remainder. LLVM docs say this instruction has
+            // the same semantics as C's fmod, which is implemented as:
+            // dst = src0 - trunc(src0/src1) * src1
+            case OP_FREM {
+                let a = resolve_f32(shot_idx, instr.src0, flags, 0u);
+                let b = resolve_f32(shot_idx, instr.src1, flags, 1u);
+                write_reg_f32(shot_idx, instr.dst, a - trunc(a / b) * b);
+                pc++;
+            }
+
             // -------------------------------------------------------------
             // TYPE CONVERSIONS
             // -------------------------------------------------------------
@@ -1273,6 +1286,18 @@ fn interpret_classical(@builtin(global_invocation_id) gid: vec3<u32>) {
             // SITOFP: Signed integer to float conversion. dst = f32(src0).
             case OP_SITOFP {
                 write_reg_f32(shot_idx, instr.dst, f32(resolve_i32(shot_idx, instr.src0, flags, 0u)));
+                pc++;
+            }
+
+            // FPTOUI: Float to unsigned integer conversion. dst = u32(src0).
+            case OP_FPTOUI {
+                write_reg(shot_idx, instr.dst, u32(resolve_f32(shot_idx, instr.src0, flags, 0u)));
+                pc++;
+            }
+
+            // UITOFP: Unsigned integer to float conversion. dst = f32(src0).
+            case OP_UITOFP {
+                write_reg_f32(shot_idx, instr.dst, f32(resolve_u32(shot_idx, instr.src0, flags, 0u)));
                 pc++;
             }
 


### PR DESCRIPTION
This PR adds support for the `frem`, `fptoui`, and `uitofp` instructions to the QIR simulators to handle the codegen changes in #3187 .