### PR TITLE
Re-Export `code` and `estimator` Submodules in `qsharp` Package

### DIFF
--- a/source/pip/qsharp/__init__.py
+++ b/source/pip/qsharp/__init__.py
@@ -48,6 +48,11 @@ from qdk.qsharp import (  # noqa: F401
     CircuitGenerationMethod,
 )
 
+# Re-export submodules that were previously loaded as side effects
+# (e.g. ``_qsharp.py`` did ``from . import code``) so that attribute
+# access like ``qsharp.code`` keeps working after a bare ``import qsharp``.
+from . import code, estimator  # noqa: F401
+
 from qdk import telemetry_events
 
 telemetry_events.on_import()


### PR DESCRIPTION
The `code` and `estimator` submodules were exposed via a side effect of _qsharp.py in the pre-migration codebase. After the migration, this side-effect disappeared, and so access to `code` and `estimator` via `qsharp.code` and `qsharp.estimator` was dropped.
This PR fixes that and explicitly re-exports these module from \_\_init\_\_.py under the `qsharp` package.