### PR TITLE
Surface multiple solutions for katas that have them

### DIFF
--- a/source/vscode/agents/qdk-learning.agent.md
+++ b/source/vscode/agents/qdk-learning.agent.md
@@ -92,7 +92,7 @@ Call `hint` and `read-code` together. The response contains `hints` (short nudge
 
 ### After a Passing Check
 
-Render the result, offer a brief reaction. Don't auto-call `next` — the user may want to review the solution first. If the exercise has alternative approaches (indicated by the panel showing a "See alternative approaches" link), you may briefly mention that other approaches exist, but don't present them unless asked.
+Render the result, offer a brief reaction. Don't auto-call `next` — the user may want to review the solution first. If the exercise has multiple solutions (indicated by the `hasMultipleSolutions` property), you may briefly mention that other approaches exist, but don't present them unless asked.
 
 ## Don'ts
 

--- a/source/vscode/agents/qdk-learning.agent.md
+++ b/source/vscode/agents/qdk-learning.agent.md
@@ -47,18 +47,20 @@ Panel actions (Next, Run, Check, Solution…) work directly — no LLM round-tri
 
 The panel routes these messages to chat. Always call `get-state` first to understand context.
 
-| Button / Link         | Shown on              | Chat message                                |
-| --------------------- | --------------------- | ------------------------------------------- |
-| **Hint**              | Exercises             | "Give me a hint"                            |
-| **Explain**           | Lessons & examples    | "Explain this concept in more detail"       |
-| What went wrong?      | Failed check output   | "Help me understand why my solution failed" |
-| Explain this solution | After solution reveal | "Explain this solution step by step"        |
+| Button / Link              | Shown on              | Chat message                                      |
+| -------------------------- | --------------------- | ------------------------------------------------- |
+| **Hint**                   | Exercises             | "Give me a hint"                                  |
+| **Explain**                | Lessons & examples    | "Explain this concept in more detail"             |
+| What went wrong?           | Failed check output   | "Help me understand why my solution failed"       |
+| Explain this solution      | After solution reveal | "Explain this solution step by step"              |
+| See alternative approaches | Passed check (multi)  | "Show me alternative approaches to this exercise" |
 
 **Handling guidance:**
 
 - **"Explain this concept in more detail"** — Provide a deeper pedagogical explanation. Offer analogies, relate to prior units. Don't repeat the panel content.
 - **"Help me understand why my solution failed"** — Analyze common mistakes for that exercise. Give targeted debugging hints, not the full solution.
 - **"Explain this solution step by step"** — Walk through the reference solution line by line, explaining the quantum concepts and Q# patterns.
+- **"Show me alternative approaches to this exercise"** — Call `solution`. Present each alternative from `alternatives` with a brief explanation of how it differs from the primary approach. Use the `solutionExplanation` from `hint` if you need more context on the reasoning behind each approach.
 
 ## Procedure
 
@@ -92,7 +94,7 @@ Call `hint` and `read-code` together. The response contains `hints` (short nudge
 
 ### After a Passing Check
 
-Render the result, offer a brief reaction. Don't auto-call `next` — the user may want to review the solution first.
+Render the result, offer a brief reaction. Don't auto-call `next` — the user may want to review the solution first. If the exercise has alternative approaches (indicated by the panel showing a "See alternative approaches" link), you may briefly mention that other approaches exist, but don't present them unless asked.
 
 ## Don'ts
 

--- a/source/vscode/agents/qdk-learning.agent.md
+++ b/source/vscode/agents/qdk-learning.agent.md
@@ -59,8 +59,8 @@ The panel routes these messages to chat. Always call `get-state` first to unders
 
 - **"Explain this concept in more detail"** — Provide a deeper pedagogical explanation. Offer analogies, relate to prior units. Don't repeat the panel content.
 - **"Help me understand why my solution failed"** — Analyze common mistakes for that exercise. Give targeted debugging hints, not the full solution.
-- **"Explain this solution step by step"** — Walk through the reference solution line by line, explaining the quantum concepts and Q# patterns.
-- **"Show me alternative approaches to this exercise"** — Call `solution`. Present each alternative from `alternatives` with a brief explanation of how it differs from the primary approach. Use the `solutionExplanation` from `hint` if you need more context on the reasoning behind each approach.
+- **"Explain this solution step by step"** — Walk through the reference solution line by line, explaining the quantum concepts and Q# patterns. If there are multiple reference solutions, walk through only the first one.
+- **"Show me alternative approaches to this exercise"** — Call `solution`. Present all returned solutions with a brief explanation of how each approach works. Use the `solutionExplanation` from `hint` if you need more context on the reasoning behind each approach.
 
 ## Procedure
 

--- a/source/vscode/agents/qdk-learning.agent.md
+++ b/source/vscode/agents/qdk-learning.agent.md
@@ -47,20 +47,18 @@ Panel actions (Next, Run, Check, Solution…) work directly — no LLM round-tri
 
 The panel routes these messages to chat. Always call `get-state` first to understand context.
 
-| Button / Link              | Shown on              | Chat message                                      |
-| -------------------------- | --------------------- | ------------------------------------------------- |
-| **Hint**                   | Exercises             | "Give me a hint"                                  |
-| **Explain**                | Lessons & examples    | "Explain this concept in more detail"             |
-| What went wrong?           | Failed check output   | "Help me understand why my solution failed"       |
-| Explain this solution      | After solution reveal | "Explain this solution step by step"              |
-| See alternative approaches | Passed check (multi)  | "Show me alternative approaches to this exercise" |
+| Button / Link              | Shown on                                       | Chat message                                      |
+| -------------------------- | ---------------------------------------------- | ------------------------------------------------- |
+| **Hint**                   | Exercises                                      | "Give me a hint"                                  |
+| **Explain**                | Lessons & examples                             | "Explain this concept in more detail"             |
+| What went wrong?           | Failed check output                            | "Help me understand why my solution failed"       |
+| See alternative approaches | Passed check with multiple solutions available | "Show me alternative approaches to this exercise" |
 
 **Handling guidance:**
 
 - **"Explain this concept in more detail"** — Provide a deeper pedagogical explanation. Offer analogies, relate to prior units. Don't repeat the panel content.
 - **"Help me understand why my solution failed"** — Analyze common mistakes for that exercise. Give targeted debugging hints, not the full solution.
-- **"Explain this solution step by step"** — Walk through the reference solution line by line, explaining the quantum concepts and Q# patterns. If there are multiple reference solutions, walk through only the first one.
-- **"Show me alternative approaches to this exercise"** — Call `solution`. Present all returned solutions with a brief explanation of how each approach works. Use the `solutionExplanation` from `hint` if you need more context on the reasoning behind each approach.
+- **"Show me alternative approaches to this exercise"** — Call `read-code` to determine what solution the user submitted. Call `solution` to determine what solutions were available. If one is substantially similar to the user's solution, call that out, highlighting any non-trivial differences. Present all returned solutions with a brief explanation of how each approach works. Use the `solutionExplanation` from `hint` if you need more context on the reasoning behind each approach.
 
 ## Procedure
 

--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -1457,7 +1457,7 @@
         ],
         "toolReferenceName": "qdkLearningSolution",
         "displayName": "QDK Learning: Solution",
-        "modelDescription": "Return the full reference solution code for the current exercise. Only valid on exercises.",
+        "modelDescription": "Return the reference solution code for the current exercise. Returns the primary solution in `result` and any alternative approaches in `alternatives` (may be empty). Only valid on exercises.",
         "canBeReferencedInPrompt": true,
         "icon": "./resources/file-icon-light.svg",
         "inputSchema": {

--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -1457,7 +1457,7 @@
         ],
         "toolReferenceName": "qdkLearningSolution",
         "displayName": "QDK Learning: Solution",
-        "modelDescription": "Return the reference solution code for the current exercise. Returns the primary solution in `result` and any alternative approaches in `alternatives` (may be empty). Only valid on exercises.",
+        "modelDescription": "Return all reference solutions for the current exercise as an array. Only valid on exercises.",
         "canBeReferencedInPrompt": true,
         "icon": "./resources/file-icon-light.svg",
         "inputSchema": {

--- a/source/vscode/src/gh-copilot/learningTools.ts
+++ b/source/vscode/src/gh-copilot/learningTools.ts
@@ -252,21 +252,14 @@ export class LearningTools {
   }
 
   /**
-   * Show the full reference solution code(s).
+   * Show the reference solution code(s).
    */
-  async solution(): Promise<
-    { result: string; alternatives: string[] } & StateSnapshot
-  > {
+  async solution(): Promise<{ solutions: string[] } & StateSnapshot> {
     await this.ensureInitialized();
     return this.invoke(async () => {
-      const result = this.service.getFullSolution("chat");
-      const all = this.service.getAllSolutions();
+      const solutions = this.service.getAllSolutions("chat");
       await this.showActivity();
-      return {
-        result,
-        alternatives: all.slice(1),
-        state: this.serializeState(),
-      };
+      return { solutions, state: this.serializeState() };
     });
   }
 

--- a/source/vscode/src/gh-copilot/learningTools.ts
+++ b/source/vscode/src/gh-copilot/learningTools.ts
@@ -252,14 +252,21 @@ export class LearningTools {
   }
 
   /**
-   * Show the full reference solution code.
+   * Show the full reference solution code(s).
    */
-  async solution(): Promise<{ result: string } & StateSnapshot> {
+  async solution(): Promise<
+    { result: string; alternatives: string[] } & StateSnapshot
+  > {
     await this.ensureInitialized();
     return this.invoke(async () => {
       const result = this.service.getFullSolution("chat");
+      const all = this.service.getAllSolutions();
       await this.showActivity();
-      return { result, state: this.serializeState() };
+      return {
+        result,
+        alternatives: all.slice(1),
+        state: this.serializeState(),
+      };
     });
   }
 

--- a/source/vscode/src/learning/catalog.ts
+++ b/source/vscode/src/learning/catalog.ts
@@ -20,9 +20,9 @@ export async function loadKatasCourse(): Promise<CatalogCourse> {
     title: kata.title,
     activities: kata.sections.map<CatalogActivity>((s) => {
       if (s.type === "exercise") {
-        const solutionItem = s.explainedSolution.items.find(
-          (i) => i.type === "solution",
-        );
+        const solutionCodes = s.explainedSolution.items
+          .filter((i) => i.type === "solution")
+          .map((i) => i.code);
         const solutionExplanation = s.explainedSolution.items
           .filter((i) => i.type === "text-content")
           .map((i) => i.content)
@@ -35,7 +35,7 @@ export async function loadKatasCourse(): Promise<CatalogCourse> {
           placeholderCode: s.placeholderCode,
           sourceIds: s.sourceIds,
           hints: s.hints ?? [],
-          solutionCode: solutionItem?.code ?? "",
+          solutionCodes,
           solutionExplanation,
         } satisfies CatalogExercise;
       }

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -370,16 +370,11 @@ export class LearningService {
     };
   }
 
-  getFullSolution(source?: TelemetrySource): string {
+  getAllSolutions(source?: TelemetrySource): string[] {
     const exercise = this.resolveExercise();
     if (source) {
       this.sendActivityActionTelemetry("solution", source);
     }
-    return exercise.solutionCodes[0] ?? "";
-  }
-
-  getAllSolutions(): string[] {
-    const exercise = this.resolveExercise();
     return exercise.solutionCodes;
   }
 

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -375,7 +375,12 @@ export class LearningService {
     if (source) {
       this.sendActivityActionTelemetry("solution", source);
     }
-    return exercise.solutionCode;
+    return exercise.solutionCodes[0] ?? "";
+  }
+
+  getAllSolutions(): string[] {
+    const exercise = this.resolveExercise();
+    return exercise.solutionCodes;
   }
 
   getExerciseFileUri(): vscode.Uri {
@@ -852,6 +857,7 @@ export class LearningService {
         description: activity.description,
         filePath: fileUri.toString(),
         isComplete: this.isComplete(location),
+        hasAlternatives: activity.solutionCodes.length > 1,
       } satisfies ExerciseContent;
     }
 

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -852,7 +852,7 @@ export class LearningService {
         description: activity.description,
         filePath: fileUri.toString(),
         isComplete: this.isComplete(location),
-        hasAlternatives: activity.solutionCodes.length > 1,
+        hasMultipleSolutions: activity.solutionCodes.length > 1,
       } satisfies ExerciseContent;
     }
 

--- a/source/vscode/src/learning/types.d.ts
+++ b/source/vscode/src/learning/types.d.ts
@@ -60,6 +60,8 @@ export interface ExerciseContent {
   /** URI string for the user's .qs solution file */
   filePath: string;
   isComplete: boolean;
+  /** True when multiple reference solutions exist for this exercise. */
+  hasAlternatives: boolean;
 }
 
 // ─── Actions ───
@@ -232,8 +234,8 @@ export interface CatalogExercise {
   sourceIds: string[];
   /** Author-written pedagogical hints. */
   hints: string[];
-  /** Reference solution code. */
-  solutionCode: string;
+  /** Reference solution code (one per @[solution] block in the content). */
+  solutionCodes: string[];
   /** Prose explanation of the solution (markdown). */
   solutionExplanation: string;
 }

--- a/source/vscode/src/learning/types.d.ts
+++ b/source/vscode/src/learning/types.d.ts
@@ -61,7 +61,7 @@ export interface ExerciseContent {
   filePath: string;
   isComplete: boolean;
   /** True when multiple reference solutions exist for this exercise. */
-  hasAlternatives: boolean;
+  hasMultipleSolutions: boolean;
 }
 
 // ─── Actions ───

--- a/source/vscode/src/learning/webview/webview-client.tsx
+++ b/source/vscode/src/learning/webview/webview-client.tsx
@@ -235,9 +235,9 @@ function App() {
         <OutputPanel
           output={output}
           onDismiss={onDismiss}
-          hasAlternatives={
+          hasMultipleSolutions={
             learning.position.content.type === "exercise" &&
-            learning.position.content.hasAlternatives
+            learning.position.content.hasMultipleSolutions
           }
         />
       ) : null}
@@ -386,11 +386,11 @@ function FilePathNote({
 function OutputPanel({
   output: out,
   onDismiss,
-  hasAlternatives,
+  hasMultipleSolutions,
 }: {
   output: OutputState;
   onDismiss: () => void;
-  hasAlternatives: boolean;
+  hasMultipleSolutions: boolean;
 }) {
   const className = "output" + (out.variant ? " " + out.variant : "");
   const label = out.variant ? "Result" : "Output";
@@ -406,17 +406,17 @@ function OutputPanel({
         ×
       </button>
       <div class="out-label">{label}</div>
-      <OutputBody output={out} hasAlternatives={hasAlternatives} />
+      <OutputBody output={out} hasMultipleSolutions={hasMultipleSolutions} />
     </div>
   );
 }
 
 function OutputBody({
   output: out,
-  hasAlternatives,
+  hasMultipleSolutions,
 }: {
   output: OutputState;
-  hasAlternatives: boolean;
+  hasMultipleSolutions: boolean;
 }) {
   switch (out.type) {
     case "loading":
@@ -432,17 +432,20 @@ function OutputBody({
     }
     case "check":
       return (
-        <SolutionResult result={out.result} hasAlternatives={hasAlternatives} />
+        <SolutionResult
+          result={out.result}
+          hasMultipleSolutions={hasMultipleSolutions}
+        />
       );
   }
 }
 
 function SolutionResult({
   result,
-  hasAlternatives,
+  hasMultipleSolutions,
 }: {
   result: SolutionCheckResult;
-  hasAlternatives: boolean;
+  hasMultipleSolutions: boolean;
 }) {
   return (
     <>
@@ -461,7 +464,7 @@ function SolutionResult({
           <span class="codicon codicon-sparkle" /> What went wrong?
         </span>
       )}
-      {result.passed && hasAlternatives && (
+      {result.passed && hasMultipleSolutions && (
         <span
           class="chat-link"
           onClick={() =>

--- a/source/vscode/src/learning/webview/webview-client.tsx
+++ b/source/vscode/src/learning/webview/webview-client.tsx
@@ -231,7 +231,16 @@ function App() {
         content={learning.position.content}
         activityKey={locationKey(learning.position.location)}
       />
-      {output ? <OutputPanel output={output} onDismiss={onDismiss} /> : null}
+      {output ? (
+        <OutputPanel
+          output={output}
+          onDismiss={onDismiss}
+          hasAlternatives={
+            learning.position.content.type === "exercise" &&
+            learning.position.content.hasAlternatives
+          }
+        />
+      ) : null}
       <ActionBar groups={learning.actions} busy={busy} onAction={onAction} />
       <ProgressBar progress={learning.progress} />
     </>
@@ -377,9 +386,11 @@ function FilePathNote({
 function OutputPanel({
   output: out,
   onDismiss,
+  hasAlternatives,
 }: {
   output: OutputState;
   onDismiss: () => void;
+  hasAlternatives: boolean;
 }) {
   const className = "output" + (out.variant ? " " + out.variant : "");
   const label = out.variant ? "Result" : "Output";
@@ -395,12 +406,18 @@ function OutputPanel({
         ×
       </button>
       <div class="out-label">{label}</div>
-      <OutputBody output={out} />
+      <OutputBody output={out} hasAlternatives={hasAlternatives} />
     </div>
   );
 }
 
-function OutputBody({ output: out }: { output: OutputState }) {
+function OutputBody({
+  output: out,
+  hasAlternatives,
+}: {
+  output: OutputState;
+  hasAlternatives: boolean;
+}) {
   switch (out.type) {
     case "loading":
       return <div class="loading">Working…</div>;
@@ -414,11 +431,19 @@ function OutputBody({ output: out }: { output: OutputState }) {
       return <div class={cls}>{out.text}</div>;
     }
     case "check":
-      return <SolutionResult result={out.result} />;
+      return (
+        <SolutionResult result={out.result} hasAlternatives={hasAlternatives} />
+      );
   }
 }
 
-function SolutionResult({ result }: { result: SolutionCheckResult }) {
+function SolutionResult({
+  result,
+  hasAlternatives,
+}: {
+  result: SolutionCheckResult;
+  hasAlternatives: boolean;
+}) {
   return (
     <>
       {result.passed ? (
@@ -434,6 +459,16 @@ function SolutionResult({ result }: { result: SolutionCheckResult }) {
           onClick={() => openChat("Help me understand why my solution failed")}
         >
           <span class="codicon codicon-sparkle" /> What went wrong?
+        </span>
+      )}
+      {result.passed && hasAlternatives && (
+        <span
+          class="chat-link"
+          onClick={() =>
+            openChat("Show me alternative approaches to this exercise")
+          }
+        >
+          <span class="codicon codicon-sparkle" /> See alternative approaches
         </span>
       )}
     </>


### PR DESCRIPTION
I remember finding the alternative solutions useful in the web version of the katas and I thought they might be useful in VS Code too.  I decided not to try to figure out if the user's solution matched one of the available solutions since I wasn't sure Haiku could handle that reliably and it's easy enough to read past the one that matches yours.
<img width="1190" height="786" alt="AlternativeApproaches" src="https://github.com/user-attachments/assets/7dc3e5fe-85b5-4dce-b89a-7464047f3e8c" />
