### PR TITLE
Add imports to kata placeholders

### DIFF
--- a/katas/content/deutsch_algo/one_minus_x_oracle/Placeholder.qs
+++ b/katas/content/deutsch_algo/one_minus_x_oracle/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation PhaseOracle_OneMinusX (x : Qubit) : Unit is Adj + Ctl {
         // Implement your solution here...
 

--- a/katas/content/distinguishing_states/peres_wooters_game/Placeholder.qs
+++ b/katas/content/distinguishing_states/peres_wooters_game/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation IsQubitNotInABC(q : Qubit) : Int {
         // Implement your solution here...
         return -1;

--- a/katas/content/distinguishing_states/zero_plus/Placeholder.qs
+++ b/katas/content/distinguishing_states/zero_plus/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation IsQubitZeroOrPlus (q : Qubit) : Bool {
         // Implement your solution here...
         return true;

--- a/katas/content/distinguishing_states/zero_plus_inc/Placeholder.qs
+++ b/katas/content/distinguishing_states/zero_plus_inc/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Random.*;
+
     operation IsQubitZeroPlusOrInconclusive(q : Qubit) : Int {
         // Implement your solution here...
         return -2;

--- a/katas/content/grovers_search/conditional_phase_flip/Placeholder.qs
+++ b/katas/content/grovers_search/conditional_phase_flip/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation ConditionalPhaseFlip(qs : Qubit[]) : Unit is Adj + Ctl {
         // Implement your solution here...
 

--- a/katas/content/key_distribution/measure_qubits/Placeholder.qs
+++ b/katas/content/key_distribution/measure_qubits/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Convert.*;
+
     operation MeasureQubits(qs : Qubit[], bases : Bool[]) : Bool[] {
         // Implement your solution here...
         return [];

--- a/katas/content/key_distribution/random_array/Placeholder.qs
+++ b/katas/content/key_distribution/random_array/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Random.*;
+
     operation RandomArray(N : Int) : Bool[] {
         // Create a mutable array variable for storing the return value.
         mutable s = [];

--- a/katas/content/marking_oracles/balanced/Placeholder.qs
+++ b/katas/content/marking_oracles/balanced/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation Oracle_Balanced (x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         // Implement your solution here...
 

--- a/katas/content/marking_oracles/majority/Placeholder.qs
+++ b/katas/content/marking_oracles/majority/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation Oracle_Majority (x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         // Implement your solution here...
 

--- a/katas/content/multi_qubit_systems/learn_basis_state_amplitudes/Placeholder.qs
+++ b/katas/content/multi_qubit_systems/learn_basis_state_amplitudes/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Diagnostics.*;
+
     operation LearnBasisStateAmplitudes(qs : Qubit[]) : (Double, Double) {
         // Implement your solution here...
 

--- a/katas/content/oracles/bit_pattern_challenge/Placeholder.qs
+++ b/katas/content/oracles/bit_pattern_challenge/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Arrays.*;
+
     operation ArbitraryBitPattern_Oracle_Challenge(x : Qubit[], pattern : Bool[])
     : Unit is Adj + Ctl {
         // Implement your solution here...

--- a/katas/content/oracles/meeting_oracle/Placeholder.qs
+++ b/katas/content/oracles/meeting_oracle/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Arrays.*;
+
     operation Meeting_Oracle(x : Qubit[], jasmine : Qubit[], y : Qubit)
     : Unit is Adj + Ctl {
         // Implement your solution here...

--- a/katas/content/oracles/phase_oracle_seven/Placeholder.qs
+++ b/katas/content/oracles/phase_oracle_seven/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Arrays.*;
+
     operation IsSeven_PhaseOracle(x : Qubit[]) : Unit is Adj + Ctl {
         // Implement your solution here...
 

--- a/katas/content/phase_estimation/state_eigenvector/Placeholder.qs
+++ b/katas/content/phase_estimation/state_eigenvector/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Diagnostics.*;
+
     operation IsEigenvector(U : Qubit => Unit, P : Qubit => Unit is Adj) : Bool {
         // Implement your solution here...
 

--- a/katas/content/phase_estimation/state_eigenvector/Placeholder.qs
+++ b/katas/content/phase_estimation/state_eigenvector/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    import Std.Diagnostics.*;
+    import Std.Diagnostics.CheckZero;
 
     operation IsEigenvector(U : Qubit => Unit, P : Qubit => Unit is Adj) : Bool {
         // Implement your solution here...

--- a/katas/content/preparing_states/hardy_state/Placeholder.qs
+++ b/katas/content/preparing_states/hardy_state/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation Hardy_State (qs : Qubit[]) : Unit {
         // Implement your solution here...
 

--- a/katas/content/qft/periodic_state/Placeholder.qs
+++ b/katas/content/qft/periodic_state/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Convert.*;
+
     import Std.Arrays.*;
 
     operation PeriodicState(qs : Qubit[], F : Int) : Unit is Adj + Ctl {

--- a/katas/content/qubit/learn_single_qubit_state/Placeholder.qs
+++ b/katas/content/qubit/learn_single_qubit_state/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Diagnostics.*;
+
     operation LearnSingleQubitState(q : Qubit) : (Double, Double) {
         // Implement your solution here...
 

--- a/katas/content/random_numbers/random_number/Placeholder.qs
+++ b/katas/content/random_numbers/random_number/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation RandomNumberInRange(min : Int, max : Int) : Int {
         // Implement your solution here...
 

--- a/katas/content/random_numbers/weighted_random_bit/Placeholder.qs
+++ b/katas/content/random_numbers/weighted_random_bit/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Math.*;
+
     operation WeightedRandomBit(x : Double) : Int {
         // Implement your solution here...
 

--- a/katas/content/solving_graph_coloring/read_coloring/Placeholder.qs
+++ b/katas/content/solving_graph_coloring/read_coloring/Placeholder.qs
@@ -1,4 +1,7 @@
 namespace Kata {
+    import Std.Arrays.*;
+    import Std.Convert.*;
+
     operation ReadColoring(nBits : Int, qs : Qubit[]) : Int[] {
         // Implement your solution here...
 

--- a/katas/content/solving_graph_coloring/weak_coloring_one_vertex/Placeholder.qs
+++ b/katas/content/solving_graph_coloring/weak_coloring_one_vertex/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Arrays.*;
+
     operation Oracle_WeakColoring_OneVertex(
         V : Int, edges: (Int, Int)[], x : Qubit[], y : Qubit, vertex : Int
     ) : Unit is Adj + Ctl {

--- a/katas/content/solving_sat/sat_clause/Placeholder.qs
+++ b/katas/content/solving_sat/sat_clause/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Arrays.*;
+
     operation Oracle_SATClause(x : Qubit[], y : Qubit, clause : (Int, Bool)[]) : Unit is Adj + Ctl {
         // Implement your solution here...
 

--- a/katas/content/teleportation/entanglement_swapping/Placeholder.qs
+++ b/katas/content/teleportation/entanglement_swapping/Placeholder.qs
@@ -1,4 +1,6 @@
 namespace Kata {
+    import Std.Convert.*;
+
     operation EntanglementSwapping() : ((Qubit, Qubit) => Int, (Qubit, Int) => Unit) {
         return (SendMessageCharlie, ReconstructMessageBob);
     }


### PR DESCRIPTION
...copied from the corresponding Solution.qs.  In the absence of auto-import, I was wasting a bunch of time asking copilot where to find things like `Sqrt` and `PI()`.