### PR TITLE
RIFLA: Support emitting constant `Result` arrays

### DIFF
--- a/source/compiler/qsc_eval/src/val.rs
+++ b/source/compiler/qsc_eval/src/val.rs
@@ -237,6 +237,7 @@ pub enum VarTy {
     Integer,
     Double,
     Qubit,
+    Result,
 }
 
 impl Display for VarTy {
@@ -246,6 +247,7 @@ impl Display for VarTy {
             Self::Integer => write!(f, "Integer"),
             Self::Double => write!(f, "Double"),
             Self::Qubit => write!(f, "Qubit"),
+            Self::Result => write!(f, "Result"),
         }
     }
 }

--- a/source/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/source/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -144,10 +144,8 @@ impl Scope {
                     Arg::Discard(value) => value,
                     Arg::Var(_, var) => &var.value,
                 };
-                ComputeKind::Dynamic {
-                    runtime_features: RuntimeFeatureFlags::empty(),
-                    value_kind: map_eval_value_to_value_kind(value),
-                }
+
+                map_eval_value_to_compute_kind(value)
             })
             .collect();
 
@@ -296,28 +294,60 @@ impl EvalControlFlow {
     }
 }
 
-fn map_eval_value_to_value_kind(value: &Value) -> ValueKind {
+fn map_eval_value_to_compute_kind(value: &Value) -> ComputeKind {
     match value {
         Value::Array(elements) => {
+            let mut dynamic_count = 0;
             for element in elements.iter() {
-                let element_runtime_kind = map_eval_value_to_value_kind(element);
-                if element_runtime_kind == ValueKind::Variable {
-                    return ValueKind::Variable;
+                let element_compute_kind = map_eval_value_to_compute_kind(element);
+                if let ComputeKind::Dynamic { value_kind, .. } = element_compute_kind {
+                    if value_kind == ValueKind::Variable {
+                        // A dynamic variable in an array makes the whole array dynamic and variable.
+                        return element_compute_kind;
+                    }
+                    dynamic_count += 1;
                 }
             }
-
-            ValueKind::Constant
+            if dynamic_count > 0 {
+                // If there are any dynamic constant elements, the array is dynamic and constant.
+                ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::empty(),
+                    value_kind: ValueKind::Constant,
+                }
+            } else {
+                ComputeKind::Static
+            }
         }
         Value::Tuple(elements, _) => {
+            let mut dynamic_count = 0;
             for element in elements.iter() {
-                let element_runtime_kind = map_eval_value_to_value_kind(element);
-                if element_runtime_kind == ValueKind::Variable {
-                    return ValueKind::Variable;
+                let element_compute_kind = map_eval_value_to_compute_kind(element);
+                if let ComputeKind::Dynamic { value_kind, .. } = element_compute_kind {
+                    if value_kind == ValueKind::Variable {
+                        // A dynamic variable in a tuple makes the whole tuple dynamic and variable.
+                        return element_compute_kind;
+                    }
+                    dynamic_count += 1;
                 }
             }
-            ValueKind::Constant
+            if dynamic_count > 0 {
+                // If there are any dynamic constant elements, the tuple is dynamic and constant.
+                ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::empty(),
+                    value_kind: ValueKind::Constant,
+                }
+            } else {
+                ComputeKind::Static
+            }
         }
-        Value::Result(Result::Id(_) | Result::Loss) | Value::Var(_) => ValueKind::Variable,
+        Value::Result(Result::Loss) | Value::Var(_) => ComputeKind::Dynamic {
+            runtime_features: RuntimeFeatureFlags::empty(),
+            value_kind: ValueKind::Variable,
+        },
+        Value::Qubit(_) | Value::Result(Result::Id(_)) => ComputeKind::Dynamic {
+            runtime_features: RuntimeFeatureFlags::empty(),
+            value_kind: ValueKind::Constant,
+        },
         Value::BigInt(_)
         | Value::Bool(_)
         | Value::Closure(_)
@@ -325,9 +355,8 @@ fn map_eval_value_to_value_kind(value: &Value) -> ValueKind {
         | Value::Global(_, _)
         | Value::Int(_)
         | Value::Pauli(_)
-        | Value::Qubit(_)
         | Value::Range(_)
         | Value::Result(Result::Val(_))
-        | Value::String(_) => ValueKind::Constant,
+        | Value::String(_) => ComputeKind::Static,
     }
 }

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -2528,6 +2528,11 @@ impl<'a> PartialEvaluator<'a> {
                 .push(jump_to_continuation_ins);
             let _ = self.eval_context.pop_block_node();
             return Ok(EvalControlFlow::Continue(Value::unit()));
+        } else if let Value::Bool(true) = condition_value {
+            return Err(Error::Unexpected(
+                "loop with constant true condition".to_string(),
+                self.get_expr_package_span(condition_expr_id),
+            ));
         }
 
         // Otherwise, branch to either the body block or the continuation block.

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -604,9 +604,15 @@ impl<'a> PartialEvaluator<'a> {
                 rhs_expr_id,
                 bin_op_expr_span,
             ),
-            Value::Result(lhs_result) => self.eval_bin_op_with_lhs_result_operand(
+            Value::Result(_) => self.eval_bin_op_with_lhs_result_operand(
                 bin_op,
-                lhs_result,
+                &lhs_value,
+                rhs_expr_id,
+                bin_op_expr_span,
+            ),
+            Value::Var(v) if v.ty == VarTy::Result => self.eval_bin_op_with_lhs_result_operand(
+                bin_op,
+                &lhs_value,
                 rhs_expr_id,
                 bin_op_expr_span,
             ),
@@ -645,6 +651,33 @@ impl<'a> PartialEvaluator<'a> {
                     ));
                 };
                 Ok(EvalControlFlow::Continue(rhs_value))
+            }
+            Value::Pauli(p) => {
+                let rhs_control_flow = self.try_eval_expr(rhs_expr_id)?;
+                let EvalControlFlow::Continue(rhs_value) = rhs_control_flow else {
+                    return Err(Error::Unexpected(
+                        "embedded return in RHS expression".to_string(),
+                        self.get_expr_package_span(rhs_expr_id),
+                    ));
+                };
+                match bin_op {
+                    BinOp::Eq => {
+                        let Value::Pauli(rhs_pauli) = rhs_value else {
+                            panic!("expected pauli value from RHS expression");
+                        };
+                        Ok(EvalControlFlow::Continue(Value::Bool(p == rhs_pauli)))
+                    }
+                    BinOp::Neq => {
+                        let Value::Pauli(rhs_pauli) = rhs_value else {
+                            panic!("expected pauli value from RHS expression");
+                        };
+                        Ok(EvalControlFlow::Continue(Value::Bool(p != rhs_pauli)))
+                    }
+                    _ => Err(Error::Unimplemented(
+                        "pauli binary operation".to_string(),
+                        bin_op_expr_span,
+                    )),
+                }
             }
             _ => Err(Error::Unexpected(
                 format!("unsupported LHS value: {lhs_value}"),
@@ -696,7 +729,7 @@ impl<'a> PartialEvaluator<'a> {
     fn eval_bin_op_with_lhs_result_operand(
         &mut self,
         bin_op: BinOp,
-        lhs_result: val::Result,
+        lhs_value: &Value,
         rhs_expr_id: ExprId,
         bin_op_expr_span: PackageSpan, // For diagnostic purposes only.
     ) -> Result<EvalControlFlow, Error> {
@@ -707,9 +740,6 @@ impl<'a> PartialEvaluator<'a> {
                 self.get_expr_package_span(rhs_expr_id),
             ));
         };
-        let Value::Result(rhs_result) = rhs_value else {
-            panic!("expected result value from RHS expression");
-        };
 
         // Even though to get to this path, an expression would have to be categorized as hybrid by RCA, it is
         // possible that the expression is in fact purely classical.
@@ -717,8 +747,10 @@ impl<'a> PartialEvaluator<'a> {
         // dynamic values. In such instances, RCA identifies all the contents of the data structure as dynamic even if
         // some values are static.
         // Here we handle this case and if both operands are purely classical we evaluate them.
-        if let (val::Result::Val(lhs_result_value), val::Result::Val(rhs_result_value)) =
-            (lhs_result, rhs_result)
+        if let (
+            Value::Result(val::Result::Val(lhs_result_value)),
+            Value::Result(val::Result::Val(rhs_result_value)),
+        ) = (lhs_value, &rhs_value)
         {
             let bool_value = match bin_op {
                 BinOp::Eq => lhs_result_value == rhs_result_value,
@@ -734,8 +766,8 @@ impl<'a> PartialEvaluator<'a> {
         }
 
         // Get the operands to use when generating the binary operation instruction.
-        let lhs_operand = self.eval_result_as_bool_operand(lhs_result);
-        let rhs_operand = self.eval_result_as_bool_operand(rhs_result);
+        let lhs_operand = self.eval_result_as_bool_operand(lhs_value);
+        let rhs_operand = self.eval_result_as_bool_operand(&rhs_value);
 
         // Create a variable to store the result of the expression.
         let variable_id = self.resource_manager.next_var();
@@ -1155,7 +1187,7 @@ impl<'a> PartialEvaluator<'a> {
                     bin_op_expr_span,
                 )
             }
-            VarTy::Qubit => Err(Error::Unexpected(
+            VarTy::Qubit | VarTy::Result => Err(Error::Unexpected(
                 format!(
                     "unsupported LHS variable type {} in binary operation",
                     lhs_eval_var.ty
@@ -1822,14 +1854,7 @@ impl<'a> PartialEvaluator<'a> {
                     callee_expr_span,
                 ))
             }
-            "IntAsDouble" => {
-                let variable_id = self.resource_manager.next_var();
-                self.convert_value(&args_value, rir::Variable::new_double(variable_id))
-            }
-            "Truncate" => {
-                let variable_id = self.resource_manager.next_var();
-                self.convert_value(&args_value, rir::Variable::new_integer(variable_id))
-            }
+            "IntAsDouble" | "Truncate" => self.convert_value(&args_value, args_span),
             _ => self.eval_expr_call_to_intrinsic_qis(
                 store_item_id,
                 callable_decl,
@@ -1887,8 +1912,11 @@ impl<'a> PartialEvaluator<'a> {
         let ret_val = match output_var {
             None => Value::unit(),
             Some(output_var) => {
-                if output_var.ty == rir::Ty::Prim(rir::Prim::Qubit) {
-                    // We don't actually accept custom intrinsics that return qubits, so emit an error here.
+                if matches!(
+                    output_var.ty,
+                    rir::Ty::Prim(rir::Prim::Qubit | rir::Prim::Result)
+                ) {
+                    // We don't actually accept custom intrinsics that return qubits or results, so emit an error here.
                     return Err(Error::UnsupportedCustomIntrinsicType(
                         callable_decl.output.to_string(),
                         callee_expr_span,
@@ -2246,14 +2274,6 @@ impl<'a> PartialEvaluator<'a> {
             ));
         };
 
-        // Get the variable type corresponding to the value the unary operator acts upon.
-        let Some(eval_variable_type) = try_get_eval_var_type(&value) else {
-            return Err(Error::Unexpected(
-                format!("invalid type for unary operation value: {value}"),
-                value_expr_package_span,
-            ));
-        };
-
         // The leading positive operator is a no-op.
         if matches!(un_op, UnOp::Pos) {
             let control_flow = EvalControlFlow::Continue(value);
@@ -2269,6 +2289,14 @@ impl<'a> PartialEvaluator<'a> {
         // For all the other supported unary operations we have to generate an instruction, so create a variable to
         // store the result.
         let variable_id = self.resource_manager.next_var();
+
+        // Get the variable type corresponding to the value the unary operator acts upon.
+        let Some(eval_variable_type) = try_get_eval_var_type(&value) else {
+            return Err(Error::Unexpected(
+                format!("invalid type for unary operation value: {value}"),
+                value_expr_package_span,
+            ));
+        };
         let rir_variable_type = map_eval_var_type_to_rir_type(eval_variable_type);
         let rir_variable = rir::Variable {
             variable_id,
@@ -2370,7 +2398,7 @@ impl<'a> PartialEvaluator<'a> {
                                 .capabilities
                                 .contains(TargetCapabilityFlags::BackwardsBranching))
                     {
-                        map_rir_literal_to_eval_value(*literal)
+                        map_rir_literal_to_eval_value(*literal, var.ty)
                     } else {
                         bound_value.clone()
                     }
@@ -2538,36 +2566,43 @@ impl<'a> PartialEvaluator<'a> {
         Ok(EvalControlFlow::Continue(Value::unit()))
     }
 
-    fn eval_result_as_bool_operand(&mut self, result: val::Result) -> Operand {
-        match result {
-            val::Result::Id(id) => {
-                // If this is a result ID, generate the instruction to read it.
-                let result_operand = Operand::Literal(Literal::Result(
-                    id.try_into().expect("could not convert result ID to u32"),
-                ));
-                let read_result_callable_id =
-                    self.get_or_insert_callable(builder::read_result_decl());
-                let variable_id = self.resource_manager.next_var();
-                let variable_ty = rir::Ty::Prim(rir::Prim::Boolean);
-                let variable = rir::Variable {
-                    variable_id,
-                    ty: variable_ty,
-                };
-                // Current debug location should be set to the call expression currently being evaluated.
-                let metadata = self.metadata_from_current_dbg_location();
-                let current_block = self.get_current_rir_block_mut();
-                let instruction = Instruction::Call(
-                    read_result_callable_id,
-                    vec![result_operand],
-                    Some(variable),
-                    metadata,
-                );
-                current_block.0.push(instruction);
-                Operand::Variable(variable)
+    fn eval_result_as_bool_operand(&mut self, result: &Value) -> Operand {
+        let result_operand = match result {
+            Value::Result(val::Result::Id(id)) => Operand::Literal(Literal::Result(
+                (*id)
+                    .try_into()
+                    .expect("could not convert result ID to u32"),
+            )),
+            Value::Var(v) if v.ty == VarTy::Result => {
+                Operand::Variable(map_eval_var_to_rir_var(*v))
             }
-            val::Result::Val(bool) => Operand::Literal(Literal::Bool(bool)),
-            val::Result::Loss => panic!("loss result should not occur in partial evaluation"),
-        }
+            Value::Result(val::Result::Val(bool)) => return Operand::Literal(Literal::Bool(*bool)),
+            Value::Result(val::Result::Loss) => {
+                panic!("loss result should not occur in partial evaluation")
+            }
+            _ => unreachable!(
+                "result eval value should be result id or result variable, found: {result:?}"
+            ),
+        };
+        // Generate the instruction to read the result.
+        let read_result_callable_id = self.get_or_insert_callable(builder::read_result_decl());
+        let variable_id = self.resource_manager.next_var();
+        let variable_ty = rir::Ty::Prim(rir::Prim::Boolean);
+        let variable = rir::Variable {
+            variable_id,
+            ty: variable_ty,
+        };
+        // Current debug location should be set to the call expression currently being evaluated.
+        let metadata = self.metadata_from_current_dbg_location();
+        let current_block = self.get_current_rir_block_mut();
+        let instruction = Instruction::Call(
+            read_result_callable_id,
+            vec![result_operand],
+            Some(variable),
+            metadata,
+        );
+        current_block.0.push(instruction);
+        Operand::Variable(variable)
     }
 
     fn generate_instructions_for_binary_operation_with_double_operands(
@@ -2975,6 +3010,12 @@ impl<'a> PartialEvaluator<'a> {
         // Check if we can create a mutable variable for this value.
         let var_ty = try_get_eval_var_type(value)?;
 
+        // If the value is a result literal, we skip creating a mutable variable as these are not
+        // representable in QIR.
+        if var_ty == VarTy::Result && matches!(value, Value::Result(val::Result::Val(_))) {
+            return None;
+        }
+
         // Create an evaluator variable and insert it.
         let var_id = self.resource_manager.next_var();
         let eval_var = Var {
@@ -3314,15 +3355,38 @@ impl<'a> PartialEvaluator<'a> {
     fn convert_value(
         &mut self,
         args_value: &Value,
-        variable: rir::Variable,
+        args_span: PackageSpan,
     ) -> Result<Value, Error> {
-        let instruction =
-            Instruction::Convert(self.map_eval_value_to_rir_operand(args_value), variable);
-        let current_block = self.get_current_rir_block_mut();
-        current_block.0.push(instruction);
-        Ok(Value::Var(
-            map_rir_var_to_eval_var(variable).expect("variable should convert"),
-        ))
+        match args_value {
+            Value::Var(var) => {
+                let variable_id = self.resource_manager.next_var();
+                let variable = match var.ty {
+                    VarTy::Double => rir::Variable::new_integer(variable_id),
+                    VarTy::Integer => rir::Variable::new_double(variable_id),
+                    _ => {
+                        return Err(Error::Unimplemented(
+                            format!("unsupported variable type in conversion {:?}", var.ty),
+                            args_span,
+                        ));
+                    }
+                };
+                let instruction =
+                    Instruction::Convert(self.map_eval_value_to_rir_operand(args_value), variable);
+                let current_block = self.get_current_rir_block_mut();
+                current_block.0.push(instruction);
+                Ok(Value::Var(
+                    map_rir_var_to_eval_var(variable).expect("variable should convert"),
+                ))
+            }
+            #[allow(clippy::cast_precision_loss)]
+            Value::Int(i) => Ok(Value::Double(*i as f64)),
+            #[allow(clippy::cast_possible_truncation)]
+            Value::Double(d) => Ok(Value::Int(*d as i64)),
+            _ => Err(Error::Unimplemented(
+                format!("unsupported value type in conversion {args_value:?}"),
+                args_span,
+            )),
+        }
     }
 
     fn update_bindings(&mut self, lhs_expr_id: ExprId, rhs_value: Value) -> Result<(), Error> {
@@ -3388,8 +3452,14 @@ impl<'a> PartialEvaluator<'a> {
             // Insert a store instruction when the value of a variable is updated.
             let rhs_operand = self.map_eval_value_to_rir_operand(&value);
             let rir_var = map_eval_var_to_rir_var(*var);
-            let store_ins = Instruction::Store(rhs_operand, rir_var);
-            self.get_current_rir_block_mut().0.push(store_ins);
+
+            // We only want to emit a store instruction if that does not involve storing a boolean literal into a result variable.
+            // Result literals are rendered as boolean but are not expected to be emitted into the RIR, as QIR does not support the notion
+            // of a result literal.
+            if !(var.ty == VarTy::Result && matches!(value, Value::Result(val::Result::Val(_)))) {
+                let store_ins = Instruction::Store(rhs_operand, rir_var);
+                self.get_current_rir_block_mut().0.push(store_ins);
+            }
 
             // If this is a mutable variable, make sure to update whether it is static or dynamic.
             let current_scope = self.eval_context.get_current_scope_mut();
@@ -3547,6 +3617,7 @@ impl<'a> PartialEvaluator<'a> {
             Ty::Prim(Prim::Bool) => (self.get_bool_record_callable(), "b"),
             Ty::Prim(Prim::Int) => (self.get_int_record_callable(), "i"),
             Ty::Prim(Prim::Double) => (self.get_double_record_callable(), "d"),
+            Ty::Prim(Prim::Result) => (self.get_result_record_callable(), "r"),
             _ => panic!("unsupported variable type in output recording"),
         };
         let tag = format!("{idx}_{tag_root}{tag_ty}");
@@ -4130,13 +4201,6 @@ fn eval_bin_op_with_double_literals(
     rhs_literal: Literal,
     bin_op_expr_span: PackageSpan, // For diagnostic purposes only
 ) -> Result<Value, Error> {
-    fn eval_double_div(lhs: f64, rhs: f64, span: PackageSpan) -> Result<Value, Error> {
-        match (lhs, rhs) {
-            (_, 0.0) => Err(EvalError::DivZero(span).into()),
-            (lhs, rhs) => Ok(Value::Double(lhs / rhs)),
-        }
-    }
-
     // Validate that both literals are doubles.
     let (Literal::Double(lhs), Literal::Double(rhs)) = (lhs_literal, rhs_literal) else {
         panic!("at least one literal is not an double: {lhs_literal}, {rhs_literal}");
@@ -4160,7 +4224,14 @@ fn eval_bin_op_with_double_literals(
         BinOp::Add => Ok(Value::Double(lhs + rhs)),
         BinOp::Sub => Ok(Value::Double(lhs - rhs)),
         BinOp::Mul => Ok(Value::Double(lhs * rhs)),
-        BinOp::Div => eval_double_div(lhs, rhs, bin_op_expr_span),
+        BinOp::Div => match (lhs, rhs) {
+            (_, 0.0) => Err(EvalError::DivZero(bin_op_expr_span).into()),
+            (lhs, rhs) => Ok(Value::Double(lhs / rhs)),
+        },
+        BinOp::Mod => match (lhs, rhs) {
+            (_, 0.0) => Err(EvalError::DivZero(bin_op_expr_span).into()),
+            (lhs, rhs) => Ok(Value::Double(lhs % rhs)),
+        },
         _ => panic!("invalid double operator: {bin_op:?}"),
     }
 }
@@ -4254,6 +4325,7 @@ fn map_eval_var_type_to_rir_type(var_ty: VarTy) -> rir::Ty {
         VarTy::Integer => rir::Ty::Prim(rir::Prim::Integer),
         VarTy::Double => rir::Ty::Prim(rir::Prim::Double),
         VarTy::Qubit => rir::Ty::Prim(rir::Prim::Qubit),
+        VarTy::Result => rir::Ty::Prim(rir::Prim::Result),
     }
 }
 
@@ -4268,11 +4340,16 @@ fn map_fir_type_to_rir_type(ty: &Ty) -> Result<rir::Ty, String> {
     }
 }
 
-fn map_rir_literal_to_eval_value(literal: rir::Literal) -> Value {
+fn map_rir_literal_to_eval_value(literal: rir::Literal, var_ty: VarTy) -> Value {
     match literal {
-        rir::Literal::Bool(b) => Value::Bool(b),
+        rir::Literal::Bool(b) => match var_ty {
+            VarTy::Boolean => Value::Bool(b),
+            VarTy::Result => Value::Result(val::Result::Val(b)),
+            _ => panic!("Incompatible literal and variable types: {literal}, {var_ty}"),
+        },
         rir::Literal::Double(d) => Value::Double(d),
         rir::Literal::Integer(i) => Value::Int(i),
+        rir::Literal::Result(r) => Value::Result(val::Result::Id(r as usize)),
         _ => panic!("{literal:?} RIR literal cannot be mapped to evaluator value"),
     }
 }
@@ -4290,6 +4367,7 @@ fn map_rir_type_to_eval_var_type(ty: rir::Ty) -> Result<VarTy, ()> {
         rir::Ty::Prim(rir::Prim::Integer) => Ok(VarTy::Integer),
         rir::Ty::Prim(rir::Prim::Double) => Ok(VarTy::Double),
         rir::Ty::Prim(rir::Prim::Qubit) => Ok(VarTy::Qubit),
+        rir::Ty::Prim(rir::Prim::Result) => Ok(VarTy::Result),
         _ => Err(()),
     }
 }
@@ -4300,6 +4378,7 @@ fn try_get_eval_var_type(value: &Value) -> Option<VarTy> {
         Value::Int(_) => Some(VarTy::Integer),
         Value::Double(_) => Some(VarTy::Double),
         Value::Qubit(_) => Some(VarTy::Qubit),
+        Value::Result(_) => Some(VarTy::Result),
         Value::Var(var) => Some(var.ty),
         _ => None,
     }

--- a/source/compiler/qsc_partial_eval/src/tests.rs
+++ b/source/compiler/qsc_partial_eval/src/tests.rs
@@ -83,7 +83,7 @@ pub fn get_partial_evaluation_error_with_capabilities(
         },
     );
     match maybe_program {
-        Ok(_) => panic!("partial evaluation succeeded"),
+        Ok(program) => panic!("partial evaluation succeeded: {program}"),
         Err(error) => error,
     }
 }

--- a/source/compiler/qsc_partial_eval/src/tests.rs
+++ b/source/compiler/qsc_partial_eval/src/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::too_many_lines)]
+
 mod arrays;
 mod assigns;
 mod bindings;

--- a/source/compiler/qsc_partial_eval/src/tests/bindings.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/bindings.rs
@@ -64,7 +64,7 @@ fn immutable_result_binding_does_not_generate_store_instruction() {
 }
 
 #[test]
-fn mutable_result_binding_does_not_generate_store_instruction() {
+fn mutable_result_binding_generates_store_instruction() {
     let program = get_rir_program(indoc! {r#"
         namespace Test {
             @EntryPoint()
@@ -109,6 +109,7 @@ fn mutable_result_binding_does_not_generate_store_instruction() {
             Block:
                 Call id(1), args( Pointer, )
                 Call id(2), args( Qubit(0), Result(0), )
+                Variable(0, Result) = Store Result(0)
                 Call id(3), args( Result(0), Tag(0, 3), )
                 Return"#]],
     );

--- a/source/compiler/qsc_partial_eval/src/tests/branching.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/branching.rs
@@ -1307,28 +1307,6 @@ fn if_else_expression_with_dynamic_condition_and_subsequent_call_to_operation() 
 }
 
 #[test]
-fn if_else_expression_with_result_literal_fails() {
-    let error = get_partial_evaluation_error(indoc! {
-        r#"
-        namespace Test {
-            @EntryPoint()
-            operation Main() : Result {
-                use q = Qubit();
-                MResetZ(q) == One ? One | MResetZ(q)
-            }
-        }
-        "#,
-    });
-
-    assert_error(
-        &error,
-        &expect![[
-            r#"Unexpected("dynamic value of type Result in conditional expression", PackageSpan { package: PackageId(2), span: Span { lo: 101, hi: 137 } })"#
-        ]],
-    );
-}
-
-#[test]
 fn if_expression_with_classical_operand_from_hybrid_results_array_comparing_to_literal_zero() {
     let program = get_rir_program(indoc! {r#"
         @EntryPoint()

--- a/source/compiler/qsc_partial_eval/src/tests/loops.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/loops.rs
@@ -1611,6 +1611,118 @@ fn result_array_index_range_in_for_loop_unrolled() {
 }
 
 #[test]
+fn result_array_index_range_in_for_loop() {
+    let program = get_rir_program_with_capabilities(
+        indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use qs = Qubit[2];
+                let results = MResetEachZ(qs);
+                mutable count = 0;
+                for i in Std.Arrays.IndexRange(results) {
+                    if results[i] == One {
+                        set count += 1;
+                    }
+                }
+                count
+            }
+        }
+    "#},
+        Profile::AdaptiveRIFLA.into(),
+    );
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: Integer
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__rt__initialize
+                    call_type: Regular
+                    input_type:
+                        [0]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: __quantum__qis__mresetz__body
+                    call_type: Measurement
+                    input_type:
+                        [0]: Qubit
+                        [1]: Result
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 3: Callable:
+                    name: __quantum__rt__read_result
+                    call_type: Readout
+                    input_type:
+                        [0]: Result
+                    output_type: Boolean
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__int_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Pointer, )
+                    Variable(0, Integer) = Store Integer(0)
+                    Variable(0, Integer) = Store Integer(1)
+                    Variable(0, Integer) = Store Integer(2)
+                    Variable(1, Integer) = Store Integer(0)
+                    Call id(2), args( Qubit(0), Result(0), )
+                    Variable(1, Integer) = Store Integer(1)
+                    Call id(2), args( Qubit(1), Result(1), )
+                    Variable(1, Integer) = Store Integer(2)
+                    Variable(2, Integer) = Store Integer(0)
+                    Variable(3, Integer) = Store Integer(0)
+                    Jump(1)
+                Block 1: Block:
+                    Variable(4, Boolean) = Icmp Sle, Variable(3, Integer), Integer(1)
+                    Variable(5, Boolean) = Store Bool(true)
+                    Branch Variable(4, Boolean), 3, 4
+                Block 2: Block:
+                    Variable(11, Integer) = Store Variable(2, Integer)
+                    Call id(4), args( Variable(11, Integer), Tag(0, 3), )
+                    Return
+                Block 3: Block:
+                    Branch Variable(5, Boolean), 5, 2
+                Block 4: Block:
+                    Variable(5, Boolean) = Store Bool(false)
+                    Jump(3)
+                Block 5: Block:
+                    Variable(6, Result) = Index Array(0), Variable(3, Integer)
+                    Variable(7, Boolean) = Call id(3), args( Variable(6, Result), )
+                    Variable(8, Boolean) = Store Variable(7, Boolean)
+                    Branch Variable(8, Boolean), 7, 6
+                Block 6: Block:
+                    Variable(10, Integer) = Add Variable(3, Integer), Integer(1)
+                    Variable(3, Integer) = Store Variable(10, Integer)
+                    Jump(1)
+                Block 7: Block:
+                    Variable(9, Integer) = Add Variable(2, Integer), Integer(1)
+                    Variable(2, Integer) = Store Variable(9, Integer)
+                    Jump(6)
+            config: Config:
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | StaticSizedArrays)
+            num_qubits: 2
+            num_results: 2
+            tags:
+                [0]: 0_i
+            array_literals:
+                [0]: [Result(0), Result(1)]
+    "#]].assert_eq(&program.to_string());
+}
+
+#[test]
 fn dynamic_while_loop() {
     let program = get_rir_program_with_capabilities(
         indoc! {

--- a/source/compiler/qsc_partial_eval/src/tests/misc.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/misc.rs
@@ -608,10 +608,15 @@ fn evaluation_error_within_stdlib_yield_correct_package_span() {
         namespace Test {
             import Std.Arrays.*;
             @EntryPoint()
-            operation Main() : Result[] {
-                use qs = Qubit[1];
-                let rs = ForEach(MResetZ, qs);
-                return rs;
+            operation Main() : Int[] {
+                use q = Qubit();
+                let a = if MResetZ(q) == One {
+                    1
+                } else {
+                    0
+                };
+                let b = [(a, a)];
+                ForEach(t => Fst(t), b)
             }
         }
         "#,

--- a/source/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck.rs
@@ -14,6 +14,9 @@ mod tests_adaptive_plus_integers;
 mod tests_adaptive_plus_integers_and_floats;
 
 #[cfg(test)]
+mod tests_adaptive_plus_integers_and_floats_and_loops;
+
+#[cfg(test)]
 pub mod tests_common;
 
 use qsc_data_structures::{span::Span, target::TargetCapabilityFlags};

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::capabilitiesck::tests_common::DYNAMIC_RESULT_LITERAL;
+
 use super::tests_common::{
     CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION, CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
     CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
@@ -787,6 +789,29 @@ fn binary_op_with_dynamic_array_succeeds() {
         DYNAMIC_ARRAY_BINARY_OP,
         &expect![[r#"
             []
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_dynamic_result_literal_errors() {
+    check_profile(
+        DYNAMIC_RESULT_LITERAL,
+        &expect![[r#"
+            [
+                UseOfDynamicResult(
+                    Span {
+                        lo: 98,
+                        hi: 190,
+                    },
+                ),
+                UseOfStaticResultInVariable(
+                    Span {
+                        lo: 98,
+                        hi: 190,
+                    },
+                ),
+            ]
         "#]],
     );
 }

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::capabilitiesck::tests_common::USE_DYNAMIC_RANGE;
+use crate::capabilitiesck::tests_common::{DYNAMIC_RESULT_LITERAL, USE_DYNAMIC_RANGE};
 
 use super::tests_common::{
     CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION, CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
@@ -19,22 +19,14 @@ use super::tests_common::{
     USE_ENTRY_POINT_STATIC_RANGE, USE_ENTRY_POINT_STATIC_STRING, check, check_for_exe,
 };
 use expect_test::{Expect, expect};
-use qsc_data_structures::target::TargetCapabilityFlags;
+use qsc_data_structures::target::Profile;
 
 fn check_profile(source: &str, expect: &Expect) {
-    check(
-        source,
-        expect,
-        TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations,
-    );
+    check(source, expect, Profile::AdaptiveRI.into());
 }
 
 fn check_profile_for_exe(source: &str, expect: &Expect) {
-    check_for_exe(
-        source,
-        expect,
-        TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations,
-    );
+    check_for_exe(source, expect, Profile::AdaptiveRI.into());
 }
 
 #[test]
@@ -624,6 +616,29 @@ fn use_of_static_sized_array_in_tuple_allowed() {
         USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE,
         &expect![[r#"
             []
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_dynamic_result_literal_errors() {
+    check_profile(
+        DYNAMIC_RESULT_LITERAL,
+        &expect![[r#"
+            [
+                UseOfDynamicResult(
+                    Span {
+                        lo: 98,
+                        hi: 190,
+                    },
+                ),
+                UseOfStaticResultInVariable(
+                    Span {
+                        lo: 98,
+                        hi: 190,
+                    },
+                ),
+            ]
         "#]],
     );
 }

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats_and_loops.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats_and_loops.rs
@@ -22,11 +22,11 @@ use expect_test::{Expect, expect};
 use qsc_data_structures::target::Profile;
 
 fn check_profile(source: &str, expect: &Expect) {
-    check(source, expect, Profile::AdaptiveRIF.into());
+    check(source, expect, Profile::AdaptiveRIFLA.into());
 }
 
 fn check_profile_for_exe(source: &str, expect: &Expect) {
-    check_for_exe(source, expect, Profile::AdaptiveRIF.into());
+    check_for_exe(source, expect, Profile::AdaptiveRIFLA.into());
 }
 
 #[test]
@@ -108,14 +108,7 @@ fn use_of_dynamic_qubit_yields_errors() {
     check_profile(
         USE_DYNAMIC_QUBIT,
         &expect![[r#"
-            [
-                UseOfDynamicQubit(
-                    Span {
-                        lo: 146,
-                        hi: 162,
-                    },
-                ),
-            ]
+            []
         "#]],
     );
 }
@@ -381,14 +374,7 @@ fn use_of_dynamic_index_yields_errors() {
     check_profile(
         USE_DYNAMIC_INDEX,
         &expect![[r#"
-            [
-                UseOfDynamicIndex(
-                    Span {
-                        lo: 299,
-                        hi: 303,
-                    },
-                ),
-            ]
+            []
         "#]],
     );
 }
@@ -444,12 +430,6 @@ fn loop_with_dynamic_condition_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicRange(
-                    Span {
-                        lo: 141,
-                        hi: 159,
-                    },
-                ),
-                LoopWithDynamicCondition(
                     Span {
                         lo: 141,
                         hi: 159,
@@ -600,12 +580,6 @@ fn use_of_dynamic_result_literal_errors() {
         DYNAMIC_RESULT_LITERAL,
         &expect![[r#"
             [
-                UseOfDynamicResult(
-                    Span {
-                        lo: 98,
-                        hi: 190,
-                    },
-                ),
                 UseOfStaticResultInVariable(
                     Span {
                         lo: 98,

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::capabilitiesck::tests_common::DYNAMIC_RESULT_LITERAL;
+
 use super::tests_common::{
     CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION, CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
     CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
@@ -970,6 +972,29 @@ fn binary_op_with_dynamic_array_error() {
                     Span {
                         lo: 66,
                         hi: 97,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_dynamic_result_literal_errors() {
+    check_profile(
+        DYNAMIC_RESULT_LITERAL,
+        &expect![[r#"
+            [
+                UseOfDynamicBool(
+                    Span {
+                        lo: 101,
+                        hi: 112,
+                    },
+                ),
+                MeasurementWithinDynamicScope(
+                    Span {
+                        lo: 172,
+                        hi: 176,
                     },
                 ),
             ]

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -528,3 +528,15 @@ pub const DYNAMIC_ARRAY_BINARY_OP: &str = r#"
         MResetEachZ(qs) == [Zero, Zero];
     }
 "#;
+
+pub const DYNAMIC_RESULT_LITERAL: &str = r#"
+    namespace Test {
+        operation Foo() : Result {
+            use q = Qubit();
+            if M(q) == One {
+                One
+            } else {
+                M(q)
+            }
+        }
+    }"#;

--- a/source/compiler/qsc_rca/src/applications.rs
+++ b/source/compiler/qsc_rca/src/applications.rs
@@ -33,7 +33,7 @@ impl GeneratorSetsBuilder {
         //   application. For array parameters it is a three-element vector and for the parameters of any other type it
         //   is a single-element vector.
         let mut application_instances =
-            Vec::<Vec<ApplicationInstance>>::with_capacity(input_params.len() + 1);
+            Vec::<Vec<ApplicationInstance>>::with_capacity((input_params.len() * 2) + 1);
 
         // Insert the inherent application instance.
         application_instances.push(vec![ApplicationInstance::new(
@@ -47,9 +47,10 @@ impl GeneratorSetsBuilder {
         for input_param in input_params {
             let input_param_variants = match input_param.ty {
                 Ty::Array(_) => {
-                    // For parameters of type array, two dynamic variants exist:
+                    // For parameters of type array, three dynamic variants exist:
                     // - An array with dynamic content and static size.
                     // - An array with dynamic content and dynamic size.
+                    // - An array with constant content.
                     let dynamic_content_static_size = ApplicationInstance::new(
                         input_params,
                         controls,
@@ -74,11 +75,7 @@ impl GeneratorSetsBuilder {
                             },
                         )),
                     );
-                    vec![dynamic_content_static_size, dynamic_content_dynamic_size]
-                }
-                _ => {
-                    // For non-array params, only one dynamic variant exists.
-                    vec![ApplicationInstance::new(
+                    let constant_content = ApplicationInstance::new(
                         input_params,
                         controls,
                         return_type,
@@ -86,10 +83,43 @@ impl GeneratorSetsBuilder {
                             input_param.index,
                             ComputeKind::Dynamic {
                                 runtime_features: RuntimeFeatureFlags::empty(),
-                                value_kind: ValueKind::Variable,
+                                value_kind: ValueKind::Constant,
                             },
                         )),
-                    )]
+                    );
+                    vec![
+                        dynamic_content_static_size,
+                        dynamic_content_dynamic_size,
+                        constant_content,
+                    ]
+                }
+                _ => {
+                    vec![
+                        ApplicationInstance::new(
+                            input_params,
+                            controls,
+                            return_type,
+                            Some((
+                                input_param.index,
+                                ComputeKind::Dynamic {
+                                    runtime_features: RuntimeFeatureFlags::empty(),
+                                    value_kind: ValueKind::Constant,
+                                },
+                            )),
+                        ),
+                        ApplicationInstance::new(
+                            input_params,
+                            controls,
+                            return_type,
+                            Some((
+                                input_param.index,
+                                ComputeKind::Dynamic {
+                                    runtime_features: RuntimeFeatureFlags::empty(),
+                                    value_kind: ValueKind::Variable,
+                                },
+                            )),
+                        ),
+                    ]
                 }
             };
             application_instances.push(input_param_variants);
@@ -218,6 +248,15 @@ impl GeneratorSetsBuilder {
                             .dynamic_size
                             .aggregate_value_kind(*value_kind);
                     });
+                array_compute_properties
+                    .constant_content
+                    .value_kind
+                    .iter()
+                    .for_each(|value_kind| {
+                        array_param_application
+                            .constant_content
+                            .aggregate_value_kind(*value_kind);
+                    });
             }
             crate::ParamApplication::Element(element_param_application) => {
                 let ParamApplicationComputeProperties::Element(element_compute_properties) =
@@ -226,10 +265,22 @@ impl GeneratorSetsBuilder {
                     panic!("expected an element param application");
                 };
                 element_compute_properties
+                    .constant
                     .value_kind
                     .iter()
                     .for_each(|value_kind| {
-                        element_param_application.aggregate_value_kind(*value_kind);
+                        element_param_application
+                            .constant
+                            .aggregate_value_kind(*value_kind);
+                    });
+                element_compute_properties
+                    .variable
+                    .value_kind
+                    .iter()
+                    .for_each(|value_kind| {
+                        element_param_application
+                            .variable
+                            .aggregate_value_kind(*value_kind);
                     });
             }
         }
@@ -245,8 +296,8 @@ impl GeneratorSetsBuilder {
     }
 
     fn close_param(&mut self, param_index: InputParamIndex) -> ParamApplicationComputeProperties {
-        const DYNAMIC_ELEMENTS_PARAM_VARIANTS: usize = 1;
-        const DYNAMIC_ARRAY_PARAM_VARIANTS: usize = 2;
+        const DYNAMIC_ELEMENTS_PARAM_VARIANTS: usize = 2;
+        const DYNAMIC_ARRAY_PARAM_VARIANTS: usize = 3;
 
         // We need to offset the index since the first top-level vector in application instances is reserved for the
         // inherent variant.
@@ -257,14 +308,26 @@ impl GeneratorSetsBuilder {
 
         // The kind of parameter application we create depends on the number of variants that the parameter has.
         if variants.len() == DYNAMIC_ELEMENTS_PARAM_VARIANTS {
-            let application_instance = variants
+            // IMPORTANT: the position of each application instance in the variants vector has a specific meaning, so
+            // we need the order of pops to remain consistent.
+            let variable_application_instance = variants
                 .pop()
                 .expect("element parameter application instance could not be popped");
-            let compute_properties = application_instance.close();
-            ParamApplicationComputeProperties::Element(compute_properties)
+            let constant_application_instance = variants
+                .pop()
+                .expect("element parameter application instance could not be popped");
+            ParamApplicationComputeProperties::Element(Box::new(
+                ElemParamApplicationComputeProperties {
+                    constant: constant_application_instance.close(),
+                    variable: variable_application_instance.close(),
+                },
+            ))
         } else if variants.len() == DYNAMIC_ARRAY_PARAM_VARIANTS {
             // IMPORTANT: the position of each application instance in the variants vector has a specific meaning, so
             // we need the order of pops to remain consistent.
+            let constant_content_application_instance = variants
+                .pop()
+                .expect("array parameter application instance could not be popped");
             let dynamic_size_application_instance = variants
                 .pop()
                 .expect("array parameter application instance could not be popped");
@@ -275,6 +338,7 @@ impl GeneratorSetsBuilder {
                 ArrayParamApplicationComputeProperties {
                     static_size: static_size_application_instance.close(),
                     dynamic_size: dynamic_size_application_instance.close(),
+                    constant_content: constant_content_application_instance.close(),
                 },
             ))
         } else {
@@ -647,7 +711,7 @@ impl ApplicationInstanceComputeProperties {
 }
 
 enum ParamApplicationComputeProperties {
-    Element(ApplicationInstanceComputeProperties),
+    Element(Box<ElemParamApplicationComputeProperties>),
     Array(Box<ArrayParamApplicationComputeProperties>),
 }
 
@@ -655,23 +719,33 @@ impl ParamApplicationComputeProperties {
     fn remove_item(&mut self, item: ApplicationInstanceItem) -> crate::ParamApplication {
         match self {
             Self::Element(compute_properties) => {
-                let compute_kind = compute_properties.remove(item);
-                crate::ParamApplication::Element(compute_kind)
+                // let compute_kind = compute_properties.remove(item);
+                let constant = compute_properties.constant.remove(item);
+                let variable = compute_properties.variable.remove(item);
+                crate::ParamApplication::Element(crate::ElemParamApplication { constant, variable })
             }
             Self::Array(array_param) => {
-                let dynamic_content_static_size = array_param.static_size.remove(item);
-                let dynamic_content_dynamic_size = array_param.dynamic_size.remove(item);
+                let static_size = array_param.static_size.remove(item);
+                let dynamic_size = array_param.dynamic_size.remove(item);
+                let constant_content = array_param.constant_content.remove(item);
                 crate::ParamApplication::Array(crate::ArrayParamApplication {
-                    static_size: dynamic_content_static_size,
-                    dynamic_size: dynamic_content_dynamic_size,
+                    static_size,
+                    dynamic_size,
+                    constant_content,
                 })
             }
         }
     }
 }
 
+struct ElemParamApplicationComputeProperties {
+    constant: ApplicationInstanceComputeProperties,
+    variable: ApplicationInstanceComputeProperties,
+}
+
 #[allow(clippy::struct_field_names)]
 struct ArrayParamApplicationComputeProperties {
     static_size: ApplicationInstanceComputeProperties,
     dynamic_size: ApplicationInstanceComputeProperties,
+    constant_content: ApplicationInstanceComputeProperties,
 }

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -1208,10 +1208,7 @@ impl<'a> Analyzer<'a> {
 
         // If the condition is dynamic, we may require an additional runtime feature.
         if let ComputeKind::Dynamic { value_kind, .. } = condition_expr_compute_kind
-            && (value_kind == ValueKind::Variable
-                || self
-                    .target_capabilities
-                    .contains(TargetCapabilityFlags::BackwardsBranching))
+            && (value_kind == ValueKind::Variable || self.should_emit_classical_loops())
         {
             let ComputeKind::Dynamic {
                 runtime_features, ..

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, ComputePropertiesLookup,
-    ParamApplication, RuntimeFeatureFlags, ValueKind,
+    ElemParamApplication, ParamApplication, RuntimeFeatureFlags, ValueKind,
     applications::{ApplicationInstance, GeneratorSetsBuilder, LocalComputeKind},
     common::{
         AssignmentStmtCounter, Callee, FunctorAppExt, GlobalSpecId, Local, LocalKind,
@@ -19,9 +19,9 @@ use qsc_fir::{
     extensions::InputParam,
     fir::{
         Attr, BinOp, Block, BlockId, CallableDecl, CallableImpl, CallableKind, Expr, ExprId,
-        ExprKind, FieldAssign, Global, Ident, Item, ItemKind, LocalVarId, Mutability, Package,
-        PackageId, PackageLookup, PackageStore, PackageStoreLookup, Pat, PatId, PatKind, Res,
-        SpecDecl, SpecImpl, Stmt, StmtId, StmtKind, StoreExprId, StoreItemId, StorePatId,
+        ExprKind, Field, FieldAssign, Global, Ident, Item, ItemKind, LocalVarId, Mutability,
+        Package, PackageId, PackageLookup, PackageStore, PackageStoreLookup, Pat, PatId, PatKind,
+        Res, SpecDecl, SpecImpl, Stmt, StmtId, StmtKind, StoreExprId, StoreItemId, StorePatId,
         StringComponent,
     },
     ty::{Arrow, FunctorSetValue, Prim, Ty},
@@ -260,12 +260,16 @@ impl<'a> Analyzer<'a> {
             value_kind,
         } = &mut compute_kind
         {
+            let lhs_expr_ty = &self.get_expr(lhs_expr_id).ty;
+            if is_any_result(lhs_expr_ty) {
+                *value_kind = ValueKind::Variable;
+            }
+
             *runtime_features |=
                 derive_runtime_features_for_value_kind_associated_to_type(*value_kind, expr_type);
 
-            let lhs_expr_ty = &self.get_expr(lhs_expr_id).ty;
             if *value_kind == ValueKind::Variable
-                && matches!(lhs_expr_ty, Ty::Prim(Prim::String))
+                && *lhs_expr_ty == Ty::Prim(Prim::String)
                 && expr_type == &Ty::Prim(Prim::Bool)
             {
                 // Strings can only be concatenated or compared for equality, and only equality comparison
@@ -614,7 +618,12 @@ impl<'a> Analyzer<'a> {
         compute_kind
     }
 
-    fn analyze_expr_field(&mut self, record_expr_id: ExprId, expr_type: &Ty) -> ComputeKind {
+    fn analyze_expr_field(
+        &mut self,
+        record_expr_id: ExprId,
+        expr_type: &Ty,
+        field: &Field,
+    ) -> ComputeKind {
         // Visit the record expression to determine its compute kind.
         self.visit_expr(record_expr_id);
 
@@ -622,15 +631,24 @@ impl<'a> Analyzer<'a> {
         // the value kind adapted to the expression's type.
         let application_instance = self.get_current_application_instance();
         let record_expr_compute_kind = *application_instance.get_expr_compute_kind(record_expr_id);
-        let runtime_kind = if record_expr_compute_kind.is_variable_value_kind() {
-            ValueKind::new_variable_from_type(expr_type)
+        let value_kind = if let ComputeKind::Dynamic { value_kind, .. } = record_expr_compute_kind {
+            if value_kind == ValueKind::Constant {
+                if matches!(field, Field::Prim(_)) {
+                    // This is a special case: a primitive field is a range accessor, which for constant ranges
+                    // should be treated as a static.
+                    return ComputeKind::Static;
+                }
+                ValueKind::Constant
+            } else {
+                ValueKind::new_variable_from_type(expr_type)
+            }
         } else {
             ValueKind::Constant
         };
 
         let mut compute_kind = ComputeKind::Static;
         compute_kind =
-            compute_kind.aggregate_runtime_features(record_expr_compute_kind, runtime_kind);
+            compute_kind.aggregate_runtime_features(record_expr_compute_kind, value_kind);
         compute_kind
     }
 
@@ -679,14 +697,18 @@ impl<'a> Analyzer<'a> {
         compute_kind = compute_kind
             .aggregate_runtime_features(condition_expr_compute_kind, ValueKind::Constant);
         let body_expr_compute_kind = *application_instance.get_expr_compute_kind(body_expr_id);
+        let body_expr_is_static = matches!(body_expr_compute_kind, ComputeKind::Static);
         compute_kind =
             compute_kind.aggregate_runtime_features(body_expr_compute_kind, ValueKind::Constant);
-        if let Some(otherwise_expr_id) = otherwise_expr_id {
+        let otherwise_expr_is_static = if let Some(otherwise_expr_id) = otherwise_expr_id {
             let otherwise_expr_compute_kind =
                 *application_instance.get_expr_compute_kind(otherwise_expr_id);
             compute_kind = compute_kind
                 .aggregate_runtime_features(otherwise_expr_compute_kind, ValueKind::Constant);
-        }
+            matches!(otherwise_expr_compute_kind, ComputeKind::Static)
+        } else {
+            false
+        };
 
         // If any of the sub-expressions is variable, then the compute kind of an if-expression is variable and additional
         // runtime features are aggregated.
@@ -712,6 +734,10 @@ impl<'a> Analyzer<'a> {
             if condition_expr_compute_kind.is_variable_value_kind() {
                 if is_any_result(expr_type) {
                     dynamic_runtime_features |= RuntimeFeatureFlags::UseOfDynamicResult;
+                    if body_expr_is_static || otherwise_expr_is_static {
+                        dynamic_runtime_features |=
+                            RuntimeFeatureFlags::UseOfStaticResultInVariable;
+                    }
                 }
                 match expr_type {
                     Ty::Tuple(tup) if !tup.is_empty() => {
@@ -850,12 +876,18 @@ impl<'a> Analyzer<'a> {
         compute_kind = compute_kind.aggregate(step_expr_compute_kind);
         compute_kind = compute_kind.aggregate(end_expr_compute_kind);
 
-        // Additionally, if the compute kind of the range is variable, mark it with the appropriate runtime feature.
-        if compute_kind.is_variable_value_kind() {
-            compute_kind = compute_kind.aggregate(ComputeKind::Dynamic {
-                runtime_features: RuntimeFeatureFlags::UseOfDynamicRange,
-                value_kind: ValueKind::Constant,
-            });
+        if let ComputeKind::Dynamic {
+            runtime_features,
+            value_kind,
+        } = &mut compute_kind
+        {
+            // Additionally, if the compute kind of the range is variable, mark it with the appropriate runtime feature.
+            if value_kind == &ValueKind::Variable {
+                *runtime_features |= RuntimeFeatureFlags::UseOfDynamicRange;
+            } else if runtime_features.is_empty() {
+                // If the runtime features are empty and the value is constant, we can treat the whole range as static.
+                compute_kind = ComputeKind::Static;
+            }
         }
         compute_kind
     }
@@ -1174,13 +1206,18 @@ impl<'a> Analyzer<'a> {
             }
         };
 
-        // If the condition is dynamic, we require an additional runtime feature.
-        if !matches!(condition_expr_compute_kind, ComputeKind::Static) {
+        // If the condition is dynamic, we may require an additional runtime feature.
+        if let ComputeKind::Dynamic { value_kind, .. } = condition_expr_compute_kind
+            && (value_kind == ValueKind::Variable
+                || self
+                    .target_capabilities
+                    .contains(TargetCapabilityFlags::BackwardsBranching))
+        {
             let ComputeKind::Dynamic {
                 runtime_features, ..
             } = &mut compute_kind
             else {
-                panic!("if the loop condition is quantum, the loop expression must be quantum too");
+                panic!("if the loop condition is dynamic, the loop expression must be dynamic too");
             };
             *runtime_features |= RuntimeFeatureFlags::LoopWithDynamicCondition;
         }
@@ -1930,8 +1967,8 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
             }
             ExprKind::Closure(..) => ComputeKind::Static,
             ExprKind::Fail(msg_expr_id) => self.analyze_expr_fail(*msg_expr_id),
-            ExprKind::Field(record_expr_id, _) => {
-                self.analyze_expr_field(*record_expr_id, &expr.ty)
+            ExprKind::Field(record_expr_id, field) => {
+                self.analyze_expr_field(*record_expr_id, &expr.ty, field)
             }
             ExprKind::Hole | ExprKind::Lit(_) => {
                 // Hole and literal expressions are always static.
@@ -2278,7 +2315,10 @@ fn derive_intrinsic_function_application_generator_set(
             Ty::Array(_) => {
                 array_param_application_from_runtime_features(runtime_features, value_kind)
             }
-            _ => ParamApplication::Element(param_compute_kind),
+            _ => ParamApplication::Element(ElemParamApplication {
+                constant: ComputeKind::Static,
+                variable: param_compute_kind,
+            }),
         };
         dynamic_param_applications.push(param_application);
     }
@@ -2303,6 +2343,10 @@ fn array_param_application_from_runtime_features(
             runtime_features: runtime_features | RuntimeFeatureFlags::UseOfDynamicallySizedArray,
             value_kind,
         },
+        constant_content: ComputeKind::Dynamic {
+            runtime_features: RuntimeFeatureFlags::empty(),
+            value_kind: ValueKind::Constant,
+        },
     })
 }
 
@@ -2311,10 +2355,12 @@ fn derive_instrinsic_operation_application_generator_set(
 ) -> ApplicationGeneratorSet {
     assert!(matches!(callable_context.kind, CallableKind::Operation));
 
-    // The value kind of intrinsic operations is inherently dynamic if their output is not `Unit` or `Qubit`.
-    let runtime_kind = if callable_context.output_type == Ty::UNIT
-        || callable_context.output_type == Ty::Prim(Prim::Qubit)
-    {
+    // The value kind of intrinsic operations is inherently dynamic if their output is not `Unit`, `Qubit` or `Result`.
+    let inherent_value_kind = if callable_context.output_type == Ty::UNIT
+        || matches!(
+            callable_context.output_type,
+            Ty::Prim(Prim::Qubit | Prim::Result)
+        ) {
         ValueKind::Constant
     } else {
         ValueKind::new_variable_from_type(&callable_context.output_type)
@@ -2331,7 +2377,7 @@ fn derive_instrinsic_operation_application_generator_set(
     // The compute kind of intrinsic operations is always dynamic.
     let inherent_compute_kind = ComputeKind::Dynamic {
         runtime_features: inherent_runtime_features,
-        value_kind: runtime_kind,
+        value_kind: inherent_value_kind,
     };
 
     // Determine the compute kind of all dynamic parameter applications.
@@ -2339,14 +2385,18 @@ fn derive_instrinsic_operation_application_generator_set(
         Vec::<ParamApplication>::with_capacity(callable_context.input_params.len());
     for param in &callable_context.input_params {
         // For intrinsic operations, we assume any parameter can contribute to the output, so if any parameter is
-        // dynamic the output of the operation is dynamic.
+        // dynamic the output of the operation is dynamic, unless it is of type `Result`.
         // When a parameter is bound to a dynamic value, its type contributes to the runtime features used by the
         // operation application.
         let runtime_features = derive_runtime_features_for_value_kind_associated_to_type(
             ValueKind::new_variable_from_type(&param.ty),
             &param.ty,
         );
-        let value_kind = ValueKind::new_variable_from_type(&callable_context.output_type);
+        let value_kind = if matches!(callable_context.output_type, Ty::Prim(Prim::Result)) {
+            ValueKind::Constant
+        } else {
+            ValueKind::new_variable_from_type(&callable_context.output_type)
+        };
         let param_compute_kind = ComputeKind::Dynamic {
             runtime_features,
             value_kind,
@@ -2357,7 +2407,13 @@ fn derive_instrinsic_operation_application_generator_set(
             Ty::Array(_) => {
                 array_param_application_from_runtime_features(runtime_features, value_kind)
             }
-            _ => ParamApplication::Element(param_compute_kind),
+            _ => ParamApplication::Element(ElemParamApplication {
+                constant: ComputeKind::Dynamic {
+                    runtime_features: inherent_runtime_features,
+                    value_kind: inherent_value_kind,
+                },
+                variable: param_compute_kind,
+            }),
         };
         dynamic_param_applications.push(param_application);
     }

--- a/source/compiler/qsc_rca/src/cyclic_callables.rs
+++ b/source/compiler/qsc_rca/src/cyclic_callables.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 use crate::{
-    ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, ParamApplication,
-    RuntimeFeatureFlags, ValueKind, common::LocalSpecId, cycle_detection::CycleDetector,
-    scaffolding::InternalPackageStoreComputeProperties,
+    ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, ElemParamApplication,
+    ParamApplication, RuntimeFeatureFlags, ValueKind, common::LocalSpecId,
+    cycle_detection::CycleDetector, scaffolding::InternalPackageStoreComputeProperties,
 };
 use qsc_fir::{
     extensions::InputParam,
@@ -151,14 +151,22 @@ impl<'a> Analyzer<'a> {
                 runtime_features: RuntimeFeatureFlags::CallToCyclicFunctionWithDynamicArg,
                 value_kind,
             };
+            let constant_compute_kind = ComputeKind::Dynamic {
+                runtime_features: RuntimeFeatureFlags::CallToCyclicFunctionWithDynamicArg,
+                value_kind: ValueKind::Constant,
+            };
 
             // Create a parameter application depending on the parameter type.
             let param_application = match &param.ty {
                 Ty::Array(_) => ParamApplication::Array(ArrayParamApplication {
                     static_size: param_compute_kind,
                     dynamic_size: param_compute_kind,
+                    constant_content: constant_compute_kind,
                 }),
-                _ => ParamApplication::Element(param_compute_kind),
+                _ => ParamApplication::Element(ElemParamApplication {
+                    constant: constant_compute_kind,
+                    variable: param_compute_kind,
+                }),
             };
             dynamic_param_applications.push(param_application);
         }
@@ -281,6 +289,10 @@ fn create_operation_specialization_application_generator_set(
         runtime_features: RuntimeFeatureFlags::CyclicOperationSpec,
         value_kind,
     };
+    let constant_compute_kind = ComputeKind::Dynamic {
+        runtime_features: RuntimeFeatureFlags::CyclicOperationSpec,
+        value_kind: ValueKind::Constant,
+    };
 
     // The compute kind of a cyclic operation for all dynamic parameter applications is the same as its inherent
     // compute kind.
@@ -291,8 +303,12 @@ fn create_operation_specialization_application_generator_set(
             Ty::Array(_) => ParamApplication::Array(ArrayParamApplication {
                 static_size: inherent_compute_kind,
                 dynamic_size: inherent_compute_kind,
+                constant_content: constant_compute_kind,
             }),
-            _ => ParamApplication::Element(inherent_compute_kind),
+            _ => ParamApplication::Element(ElemParamApplication {
+                constant: constant_compute_kind,
+                variable: inherent_compute_kind,
+            }),
         };
         dynamic_param_applications.push(param_application);
     }

--- a/source/compiler/qsc_rca/src/errors.rs
+++ b/source/compiler/qsc_rca/src/errors.rs
@@ -252,6 +252,14 @@ pub enum Error {
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-generic"))]
     #[diagnostic(code("Qsc.CapabilitiesCk.UseOfDynamicGeneric"))]
     UseOfDynamicGeneric(#[label] Span),
+
+    #[error("cannot use a Result literal as output from a dynamic scope")]
+    #[diagnostic(help(
+        "using the static Result values `One` and `Zero` as the output of a dynamic branch is not supported by the configured target profile"
+    ))]
+    #[diagnostic(url("https://aka.ms/qdk.qir#use-of-static-result-in-variable"))]
+    #[diagnostic(code("Qsc.CapabilitiesCk.UseOfStaticResultInVariable"))]
+    UseOfStaticResultInVariable(#[label] Span),
 }
 
 #[must_use]
@@ -355,6 +363,9 @@ pub fn generate_errors_from_runtime_features(
     }
     if runtime_features.contains(RuntimeFeatureFlags::UseOfDynamicGeneric) {
         errors.push(Error::UseOfDynamicGeneric(span));
+    }
+    if runtime_features.contains(RuntimeFeatureFlags::UseOfStaticResultInVariable) {
+        errors.push(Error::UseOfStaticResultInVariable(span));
     }
     errors
 }

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -360,8 +360,15 @@ impl ApplicationGeneratorSet {
         {
             match param_application {
                 ParamApplication::Element(param_compute_kind) => {
-                    if arg_compute_kind.is_variable_value_kind() {
-                        compute_kind = compute_kind.aggregate(*param_compute_kind);
+                    if let ComputeKind::Dynamic { value_kind, .. } = arg_compute_kind {
+                        match value_kind {
+                            ValueKind::Variable => {
+                                compute_kind = compute_kind.aggregate(param_compute_kind.variable);
+                            }
+                            ValueKind::Constant => {
+                                compute_kind = compute_kind.aggregate(param_compute_kind.constant);
+                            }
+                        }
                     }
                 }
                 ParamApplication::Array(array_param_application) => {
@@ -383,7 +390,8 @@ impl ApplicationGeneratorSet {
                                     compute_kind.aggregate(array_param_application.static_size);
                             }
                             ValueKind::Constant => {
-                                // No aggregation needed for static arrays.
+                                compute_kind = compute_kind
+                                    .aggregate(array_param_application.constant_content);
                             }
                         }
                     }
@@ -396,7 +404,7 @@ impl ApplicationGeneratorSet {
 
 #[derive(Clone, Debug)]
 pub enum ParamApplication {
-    Element(ComputeKind),
+    Element(ElemParamApplication),
     Array(ArrayParamApplication),
 }
 
@@ -413,9 +421,27 @@ impl Display for ParamApplication {
 }
 
 #[derive(Clone, Debug)]
+pub struct ElemParamApplication {
+    pub constant: ComputeKind,
+    pub variable: ComputeKind,
+}
+
+impl Display for ElemParamApplication {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut indent = set_indentation(indented(f), 0);
+        write!(indent, "ElemParamApplication:")?;
+        indent = set_indentation(indent, 1);
+        write!(indent, "\nconstant: {}", self.constant)?;
+        write!(indent, "\nvariable: {}", self.variable)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct ArrayParamApplication {
     pub static_size: ComputeKind,
     pub dynamic_size: ComputeKind,
+    pub constant_content: ComputeKind,
 }
 
 impl Display for ArrayParamApplication {
@@ -425,6 +451,7 @@ impl Display for ArrayParamApplication {
         indent = set_indentation(indent, 1);
         write!(indent, "\nstatic_size: {}", self.static_size)?;
         write!(indent, "\ndynamic_size: {}", self.dynamic_size)?;
+        write!(indent, "\nconstant_content: {}", self.constant_content)?;
         Ok(())
     }
 }
@@ -601,7 +628,7 @@ bitflags! {
     /// Runtime features represent anything a program can do that is more complex than executing quantum operations on
     /// statically allocated qubits and using constant arguments.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct RuntimeFeatureFlags: u32 {
+    pub struct RuntimeFeatureFlags: u64 {
         /// Use of a dynamic `Bool`.
         const UseOfDynamicBool = 1 << 0;
         /// Use of a dynamic `Int`.
@@ -666,6 +693,8 @@ bitflags! {
         const CallToCustomReset = 1 << 30;
         /// Use of a dynamic generic parameter.
         const UseOfDynamicGeneric = 1 << 31;
+        /// Use of a static `Result` value as a dynamic variable.
+        const UseOfStaticResultInVariable = 1 << 32;
     }
 }
 
@@ -774,7 +803,7 @@ impl RuntimeFeatureFlags {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicResult) {
-            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::StaticSizedArrays;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicTuple) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
@@ -786,6 +815,9 @@ impl RuntimeFeatureFlags {
             capabilities |= TargetCapabilityFlags::Adaptive;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicGeneric) {
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
+        }
+        if self.contains(RuntimeFeatureFlags::UseOfStaticResultInVariable) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         capabilities

--- a/source/compiler/qsc_rca/src/overrider.rs
+++ b/source/compiler/qsc_rca/src/overrider.rs
@@ -52,6 +52,7 @@ impl<'a> Overrider<'a> {
                                 runtime_features: RuntimeFeatureFlags::UseOfDynamicallySizedArray,
                                 value_kind: ValueKind::Variable,
                             },
+                            constant_content: ComputeKind::Static,
                         },
                     )],
                 },

--- a/source/compiler/qsc_rca/src/tests.rs
+++ b/source/compiler/qsc_rca/src/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::too_many_lines)]
+
 mod arrays;
 mod assigns;
 mod bindings;

--- a/source/compiler/qsc_rca/src/tests/arrays.rs
+++ b/source/compiler/qsc_rca/src/tests/arrays.rs
@@ -34,7 +34,7 @@ fn check_rca_for_array_with_dynamic_results() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -89,7 +89,7 @@ fn check_rca_for_array_repeat_with_dynamic_result_value_and_classical_size() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -179,7 +179,7 @@ fn check_rca_for_mutable_array_statically_appended() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -522,7 +522,7 @@ fn check_rca_for_array_with_static_size_bound_through_dynamic_tuple() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/assigns.rs
+++ b/source/compiler/qsc_rca/src/tests/assigns.rs
@@ -42,7 +42,7 @@ fn check_rca_for_dynamic_result_assign_to_local() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -284,8 +284,8 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                    value_kind: Variable
+                    runtime_features: RuntimeFeatureFlags(0x0)
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
     compilation_context.update(
@@ -298,8 +298,8 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                    value_kind: Variable
+                    runtime_features: RuntimeFeatureFlags(0x0)
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -444,7 +444,7 @@ fn check_rca_for_immutable_dynamic_result_bound_to_dynamic_result() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicResult)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicResult | UseOfStaticResultInVariable)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -472,7 +472,7 @@ fn check_rca_for_immutable_dynamic_result_bound_to_result_from_classical_conditi
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -500,7 +500,7 @@ fn check_rca_for_immutable_dynamic_result_bound_to_call_with_dynamic_args() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicResult)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicResult | UseOfStaticResultInVariable)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/bindings.rs
+++ b/source/compiler/qsc_rca/src/tests/bindings.rs
@@ -40,7 +40,7 @@ fn check_rca_for_immutable_dynamic_result_binding() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -19,12 +19,20 @@ fn check_rca_for_function_in_core_package() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicallySizedArray | LoopWithDynamicCondition)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicallySizedArray | LoopWithDynamicCondition)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -248,33 +256,49 @@ fn check_rca_for_unrestricted_h() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -292,33 +316,49 @@ fn check_rca_for_base_h() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -336,45 +376,77 @@ fn check_rca_for_unrestricted_r1() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -392,45 +464,77 @@ fn check_rca_for_base_r1() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -448,45 +552,77 @@ fn check_rca_for_unrestricted_rx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -504,45 +640,77 @@ fn check_rca_for_base_rx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -560,57 +728,105 @@ fn check_rca_for_unrestricted_rxx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -628,57 +844,105 @@ fn check_rca_for_base_rxx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -696,45 +960,77 @@ fn check_rca_for_unrestricted_ry() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -752,45 +1048,77 @@ fn check_rca_for_base_ry() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -808,57 +1136,105 @@ fn check_rca_for_unrestricted_ryy() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -876,57 +1252,105 @@ fn check_rca_for_base_ryy() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -944,45 +1368,77 @@ fn check_rca_for_unrestricted_rz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1000,45 +1456,77 @@ fn check_rca_for_base_rz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1056,57 +1544,105 @@ fn check_rca_for_unrestricted_rzz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1124,57 +1660,105 @@ fn check_rca_for_base_rzz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1192,33 +1776,49 @@ fn check_rca_for_unrestricted_s() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1236,33 +1836,49 @@ fn check_rca_for_base_s() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1280,33 +1896,49 @@ fn check_rca_for_unrestricted_t() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1324,33 +1956,49 @@ fn check_rca_for_base_t() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1368,33 +2016,49 @@ fn check_rca_for_unrestricted_x() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1412,33 +2076,49 @@ fn check_rca_for_base_x() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1456,33 +2136,49 @@ fn check_rca_for_unrestricted_y() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1500,33 +2196,49 @@ fn check_rca_for_base_y() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1544,33 +2256,49 @@ fn check_rca_for_unrestricted_z() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1588,32 +2316,48 @@ fn check_rca_for_base_z() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/cycles.rs
+++ b/source/compiler/qsc_rca/src/tests/cycles.rs
@@ -23,9 +23,13 @@ fn check_rca_for_one_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -54,9 +58,13 @@ fn check_rca_for_two_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -71,9 +79,13 @@ fn check_rca_for_two_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -104,9 +116,13 @@ fn check_rca_for_three_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -120,9 +136,13 @@ fn check_rca_for_three_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -136,9 +156,13 @@ fn check_rca_for_three_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -164,9 +188,13 @@ fn check_rca_for_indirect_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -194,9 +222,13 @@ fn check_rca_for_indirect_chain_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -222,9 +254,13 @@ fn check_rca_for_indirect_tuple_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -250,9 +286,13 @@ fn check_rca_for_function_cycle_within_binding() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -279,9 +319,13 @@ fn check_rca_for_function_cycle_within_assignment() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -306,9 +350,13 @@ fn check_rca_for_function_cycle_within_return() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -334,9 +382,13 @@ fn check_rca_for_function_cycle_within_tuple() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -387,9 +439,13 @@ fn check_rca_for_function_cycle_within_call_input() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                         [1]: [Parameter Type Array] ArrayParamApplication:
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
@@ -397,6 +453,9 @@ fn check_rca_for_function_cycle_within_call_input() {
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
                                 value_kind: Variable
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -425,9 +484,13 @@ fn check_rca_for_function_cycle_within_if_block() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -456,9 +519,13 @@ fn check_rca_for_function_cycle_within_if_condition() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -486,9 +553,13 @@ fn check_rca_for_function_cycle_within_for_block() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -516,9 +587,13 @@ fn check_rca_for_function_cycle_within_while_block() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -545,9 +620,13 @@ fn check_rca_for_function_cycle_within_while_condition() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -572,15 +651,27 @@ fn check_rca_for_multi_param_recursive_bool_function() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -605,9 +696,13 @@ fn check_rca_for_multi_param_recursive_unit_function() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
                         [1]: [Parameter Type Array] ArrayParamApplication:
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
@@ -615,9 +710,16 @@ fn check_rca_for_multi_param_recursive_unit_function() {
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
                                 value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Constant
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -644,9 +746,13 @@ fn check_rca_for_result_recursive_operation() {
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -673,18 +779,34 @@ fn check_rca_for_multi_param_result_recursive_operation() {
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
-                        [3]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                        [3]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -711,9 +833,13 @@ fn check_rca_for_operation_body_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -745,17 +871,25 @@ fn check_rca_for_operation_body_adj_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 ctl: <none>
                 ctl-adj: <none>"#]],
     );
@@ -786,18 +920,26 @@ fn check_rca_for_operation_body_ctl_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 ctl-adj: <none>"#]],
     );
 }
@@ -827,18 +969,26 @@ fn check_rca_for_operation_multi_controlled_functor_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 ctl-adj: <none>"#]],
     );
 }
@@ -863,9 +1013,13 @@ fn check_rca_for_operation_body_recursion_non_unit_return() {
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -895,9 +1049,13 @@ fn check_rca_for_operation_body_recursion_preserves_inherent_capabilities() {
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -933,9 +1091,13 @@ fn check_rca_for_two_operation_cycle() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -952,9 +1114,13 @@ fn check_rca_for_two_operation_cycle() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],

--- a/source/compiler/qsc_rca/src/tests/ifs.rs
+++ b/source/compiler/qsc_rca/src/tests/ifs.rs
@@ -109,3 +109,53 @@ fn check_rca_for_if_else_expr_with_dynamic_condition_and_classic_branch_blocks()
                 dynamic_param_applications: <empty>"#]],
     );
 }
+
+#[test]
+fn check_rca_for_if_else_expr_with_static_result_literal_in_then_block() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        use q = Qubit();
+        let r = if M(q) == One {
+            One
+        } else {
+            M(q)
+        };
+        r"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Dynamic:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | UseOfDynamicResult | UseOfStaticResultInVariable)
+                    value_kind: Variable
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_if_else_expr_with_static_result_literal_in_else_block() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        use q = Qubit();
+        let r = if M(q) == One {
+            M(q)
+        } else {
+            Zero
+        };
+        r"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Dynamic:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | UseOfDynamicResult | UseOfStaticResultInVariable)
+                    value_kind: Variable
+                dynamic_param_applications: <empty>"#]],
+    );
+}

--- a/source/compiler/qsc_rca/src/tests/intrinsics.rs
+++ b/source/compiler/qsc_rca/src/tests/intrinsics.rs
@@ -38,9 +38,13 @@ fn check_rca_for_quantum_rt_qubit_release() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -59,11 +63,15 @@ fn check_rca_for_quantum_qis_m_body() {
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Variable
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -87,6 +95,7 @@ fn check_rca_for_length() {
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
                                 value_kind: Variable
+                            constant_content: Static
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -105,11 +114,15 @@ fn check_rca_for_quantum_qis_mresetz_body() {
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Variable
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -128,9 +141,11 @@ fn check_rca_for_int_as_double() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -149,9 +164,11 @@ fn check_rca_for_int_as_big_int() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -190,9 +207,13 @@ fn check_rca_for_check_zero() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -211,9 +232,11 @@ fn check_rca_for_message() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -232,9 +255,11 @@ fn check_rca_for_arc_cos() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -253,9 +278,11 @@ fn check_rca_for_arc_sin() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -274,9 +301,11 @@ fn check_rca_for_arc_tan() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -295,12 +324,16 @@ fn check_rca_for_arc_tan_2() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -319,9 +352,11 @@ fn check_rca_for_cos() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -340,9 +375,11 @@ fn check_rca_for_cosh() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -361,9 +398,11 @@ fn check_rca_for_sin() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -382,9 +421,11 @@ fn check_rca_for_sinh() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -403,9 +444,11 @@ fn check_rca_for_tan() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -424,9 +467,11 @@ fn check_rca_for_tanh() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -445,9 +490,11 @@ fn check_rca_for_sqrt() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -466,9 +513,11 @@ fn check_rca_for_log() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -487,9 +536,11 @@ fn check_rca_for_truncate() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -510,15 +561,27 @@ fn check_rca_for_quantum_qis_ccx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -539,12 +602,20 @@ fn check_rca_for_quantum_qis_cx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -565,12 +636,20 @@ fn check_rca_for_quantum_qis_cy_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -591,12 +670,20 @@ fn check_rca_for_quantum_qis_cz_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -617,12 +704,20 @@ fn check_rca_for_quantum_qis_rx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -643,15 +738,27 @@ fn check_rca_for_quantum_qis_rxx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -672,12 +779,20 @@ fn check_rca_for_quantum_qis_ry_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -698,15 +813,27 @@ fn check_rca_for_quantum_qis_ryy_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -727,12 +854,20 @@ fn check_rca_for_quantum_qis_rz_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -753,15 +888,27 @@ fn check_rca_for_quantum_qis_rzz_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -782,9 +929,13 @@ fn check_rca_for_quantum_qis_h_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -805,9 +956,13 @@ fn check_rca_for_quantum_qis_s_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -828,9 +983,13 @@ fn check_rca_for_quantum_qis_s_adj() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -851,9 +1010,13 @@ fn check_rca_for_quantum_qis_sx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -874,9 +1037,13 @@ fn check_rca_for_quantum_qis_t_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -897,9 +1064,13 @@ fn check_rca_for_quantum_qis_t_adj() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -920,9 +1091,13 @@ fn check_rca_for_quantum_qis_x_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -943,9 +1118,13 @@ fn check_rca_for_quantum_qis_y_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -966,9 +1145,13 @@ fn check_rca_for_quantum_qis_z_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -989,12 +1172,20 @@ fn check_rca_for_quantum_qis_swap_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1015,9 +1206,13 @@ fn check_rca_for_quantum_qis_reset_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1036,12 +1231,16 @@ fn check_rca_for_begin_estimate_caching() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Static
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1087,15 +1286,25 @@ fn check_rca_for_account_for_estimates_internal() {
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
                                 value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Constant
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Constant
                         [2]: [Parameter Type Array] ArrayParamApplication:
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | UseOfDynamicallySizedArray)
+                                value_kind: Constant
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                 adj: <none>
                 ctl: <none>
@@ -1117,9 +1326,13 @@ fn check_rca_for_begin_repeat_estimates_internal() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElemParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],

--- a/source/compiler/qsc_rca/src/tests/lambdas.rs
+++ b/source/compiler/qsc_rca/src/tests/lambdas.rs
@@ -191,7 +191,7 @@ fn check_rca_for_operation_lambda_two_parameters() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/measurements.rs
+++ b/source/compiler/qsc_rca/src/tests/measurements.rs
@@ -19,7 +19,7 @@ fn check_rca_for_static_single_qubit_measurement() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -64,7 +64,7 @@ fn check_rca_for_static_single_measurement_and_reset() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -110,7 +110,7 @@ fn check_rca_for_static_multi_qubit_measurement() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/strings.rs
+++ b/source/compiler/qsc_rca/src/tests/strings.rs
@@ -67,7 +67,7 @@ fn check_rca_for_dynamic_interpolated_string() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -169,8 +169,8 @@ fn check_rca_for_dynamic_string_comparison() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicString)
-                    value_kind: Variable
+                    runtime_features: RuntimeFeatureFlags(0x0)
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/types.rs
+++ b/source/compiler/qsc_rca/src/tests/types.rs
@@ -33,7 +33,7 @@ fn check_rca_for_dynamic_result() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/vars.rs
+++ b/source/compiler/qsc_rca/src/tests/vars.rs
@@ -90,7 +90,7 @@ fn check_rca_for_dynamic_result_var() {
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Variable
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/qdk_package/tests-integration/resources/adaptive_rifla/output/ArithmeticOps.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive_rifla/output/ArithmeticOps.ll
@@ -4,6 +4,7 @@
 @3 = internal constant [6 x i8] c"3_t2i\00"
 @4 = internal constant [6 x i8] c"4_t3i\00"
 @array0 = internal constant [5 x ptr] [ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 4 to ptr)]
+@array1 = internal constant [5 x ptr] [ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 4 to ptr)]
 
 define i64 @ENTRYPOINT__main() #0 {
 block_0:
@@ -12,7 +13,8 @@ block_0:
   %var_2 = alloca i64
   %var_3 = alloca i64
   %var_5 = alloca i64
-  %var_42 = alloca i64
+  %var_11 = alloca i64
+  %var_22 = alloca i64
   call void @__quantum__rt__initialize(ptr null)
   store i64 0, ptr %var_0
   store i64 0, ptr %var_1
@@ -21,15 +23,15 @@ block_0:
   store i64 0, ptr %var_5
   br label %block_1
 block_1:
-  %var_52 = load i64, ptr %var_5
-  %var_6 = icmp slt i64 %var_52, 5
+  %var_32 = load i64, ptr %var_5
+  %var_6 = icmp slt i64 %var_32, 5
   br i1 %var_6, label %block_2, label %block_3
 block_2:
-  %var_102 = load i64, ptr %var_5
-  %var_7 = getelementptr ptr, ptr @array0, i64 %var_102
-  %var_103 = load ptr, ptr %var_7
-  call void @__quantum__qis__x__body(ptr %var_103)
-  %var_9 = add i64 %var_102, 1
+  %var_56 = load i64, ptr %var_5
+  %var_7 = getelementptr ptr, ptr @array0, i64 %var_56
+  %var_57 = load ptr, ptr %var_7
+  call void @__quantum__qis__x__body(ptr %var_57)
+  %var_9 = add i64 %var_56, 1
   store i64 %var_9, ptr %var_5
   br label %block_1
 block_3:
@@ -38,115 +40,62 @@ block_3:
   call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
   call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 3 to ptr))
   call void @__quantum__qis__m__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 4 to ptr))
-  %var_12 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-  br i1 %var_12, label %block_4, label %block_5
+  store i64 0, ptr %var_11
+  br label %block_4
 block_4:
-  %var_94 = load i64, ptr %var_0
-  %var_14 = add i64 %var_94, 1
-  store i64 %var_14, ptr %var_0
-  %var_96 = load i64, ptr %var_1
-  %var_15 = add i64 %var_96, 5
-  store i64 %var_15, ptr %var_1
-  %var_98 = load i64, ptr %var_2
-  %var_16 = sub i64 %var_98, 2
-  store i64 %var_16, ptr %var_2
-  %var_100 = load i64, ptr %var_3
-  %var_17 = mul i64 %var_100, 3
-  store i64 %var_17, ptr %var_3
-  br label %block_5
+  %var_34 = load i64, ptr %var_11
+  %var_12 = icmp slt i64 %var_34, 5
+  br i1 %var_12, label %block_5, label %block_6
 block_5:
-  %var_18 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-  br i1 %var_18, label %block_6, label %block_7
+  %var_44 = load i64, ptr %var_11
+  %var_13 = getelementptr ptr, ptr @array1, i64 %var_44
+  %var_45 = load ptr, ptr %var_13
+  %var_15 = call i1 @__quantum__rt__read_result(ptr %var_45)
+  br i1 %var_15, label %block_7, label %block_9
 block_6:
-  %var_86 = load i64, ptr %var_0
-  %var_20 = add i64 %var_86, 1
-  store i64 %var_20, ptr %var_0
-  %var_88 = load i64, ptr %var_1
-  %var_21 = add i64 %var_88, 5
-  store i64 %var_21, ptr %var_1
-  %var_90 = load i64, ptr %var_2
-  %var_22 = sub i64 %var_90, 2
-  store i64 %var_22, ptr %var_2
-  %var_92 = load i64, ptr %var_3
-  %var_23 = mul i64 %var_92, 3
-  store i64 %var_23, ptr %var_3
-  br label %block_7
+  store i64 0, ptr %var_22
+  br label %block_8
 block_7:
-  %var_24 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-  br i1 %var_24, label %block_8, label %block_9
-block_8:
-  %var_78 = load i64, ptr %var_0
-  %var_26 = add i64 %var_78, 1
-  store i64 %var_26, ptr %var_0
-  %var_80 = load i64, ptr %var_1
-  %var_27 = add i64 %var_80, 5
-  store i64 %var_27, ptr %var_1
-  %var_82 = load i64, ptr %var_2
-  %var_28 = sub i64 %var_82, 2
-  store i64 %var_28, ptr %var_2
-  %var_84 = load i64, ptr %var_3
-  %var_29 = mul i64 %var_84, 3
-  store i64 %var_29, ptr %var_3
+  %var_48 = load i64, ptr %var_0
+  %var_17 = add i64 %var_48, 1
+  store i64 %var_17, ptr %var_0
+  %var_50 = load i64, ptr %var_1
+  %var_18 = add i64 %var_50, 5
+  store i64 %var_18, ptr %var_1
+  %var_52 = load i64, ptr %var_2
+  %var_19 = sub i64 %var_52, 2
+  store i64 %var_19, ptr %var_2
+  %var_54 = load i64, ptr %var_3
+  %var_20 = mul i64 %var_54, 3
+  store i64 %var_20, ptr %var_3
   br label %block_9
+block_8:
+  %var_36 = load i64, ptr %var_22
+  %var_23 = icmp slt i64 %var_36, 5
+  br i1 %var_23, label %block_10, label %block_11
 block_9:
-  %var_30 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 3 to ptr))
-  br i1 %var_30, label %block_10, label %block_11
+  %var_46 = load i64, ptr %var_11
+  %var_21 = add i64 %var_46, 1
+  store i64 %var_21, ptr %var_11
+  br label %block_4
 block_10:
-  %var_70 = load i64, ptr %var_0
-  %var_32 = add i64 %var_70, 1
-  store i64 %var_32, ptr %var_0
-  %var_72 = load i64, ptr %var_1
-  %var_33 = add i64 %var_72, 5
-  store i64 %var_33, ptr %var_1
-  %var_74 = load i64, ptr %var_2
-  %var_34 = sub i64 %var_74, 2
-  store i64 %var_34, ptr %var_2
-  %var_76 = load i64, ptr %var_3
-  %var_35 = mul i64 %var_76, 3
-  store i64 %var_35, ptr %var_3
-  br label %block_11
+  %var_41 = load i64, ptr %var_22
+  %var_24 = getelementptr ptr, ptr @array0, i64 %var_41
+  %var_42 = load ptr, ptr %var_24
+  call void @__quantum__qis__reset__body(ptr %var_42)
+  %var_26 = add i64 %var_41, 1
+  store i64 %var_26, ptr %var_22
+  br label %block_8
 block_11:
-  %var_36 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 4 to ptr))
-  br i1 %var_36, label %block_12, label %block_13
-block_12:
-  %var_62 = load i64, ptr %var_0
-  %var_38 = add i64 %var_62, 1
-  store i64 %var_38, ptr %var_0
-  %var_64 = load i64, ptr %var_1
-  %var_39 = add i64 %var_64, 5
-  store i64 %var_39, ptr %var_1
-  %var_66 = load i64, ptr %var_2
-  %var_40 = sub i64 %var_66, 2
-  store i64 %var_40, ptr %var_2
-  %var_68 = load i64, ptr %var_3
-  %var_41 = mul i64 %var_68, 3
-  store i64 %var_41, ptr %var_3
-  br label %block_13
-block_13:
-  store i64 0, ptr %var_42
-  br label %block_14
-block_14:
-  %var_54 = load i64, ptr %var_42
-  %var_43 = icmp slt i64 %var_54, 5
-  br i1 %var_43, label %block_15, label %block_16
-block_15:
-  %var_59 = load i64, ptr %var_42
-  %var_44 = getelementptr ptr, ptr @array0, i64 %var_59
-  %var_60 = load ptr, ptr %var_44
-  call void @__quantum__qis__reset__body(ptr %var_60)
-  %var_46 = add i64 %var_59, 1
-  store i64 %var_46, ptr %var_42
-  br label %block_14
-block_16:
   call void @__quantum__rt__tuple_record_output(i64 4, ptr @0)
-  %var_55 = load i64, ptr %var_0
-  call void @__quantum__rt__int_record_output(i64 %var_55, ptr @1)
-  %var_56 = load i64, ptr %var_1
-  call void @__quantum__rt__int_record_output(i64 %var_56, ptr @2)
-  %var_57 = load i64, ptr %var_2
-  call void @__quantum__rt__int_record_output(i64 %var_57, ptr @3)
-  %var_58 = load i64, ptr %var_3
-  call void @__quantum__rt__int_record_output(i64 %var_58, ptr @4)
+  %var_37 = load i64, ptr %var_0
+  call void @__quantum__rt__int_record_output(i64 %var_37, ptr @1)
+  %var_38 = load i64, ptr %var_1
+  call void @__quantum__rt__int_record_output(i64 %var_38, ptr @2)
+  %var_39 = load i64, ptr %var_2
+  call void @__quantum__rt__int_record_output(i64 %var_39, ptr @3)
+  %var_40 = load i64, ptr %var_3
+  call void @__quantum__rt__int_record_output(i64 %var_40, ptr @4)
   ret i64 0
 }
 

--- a/source/qdk_package/tests-integration/resources/adaptive_rifla/output/SwitchHandling.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive_rifla/output/SwitchHandling.ll
@@ -1,95 +1,103 @@
 @0 = internal constant [4 x i8] c"0_r\00"
 @array0 = internal constant [2 x ptr] [ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr)]
+@array1 = internal constant [2 x ptr] [ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr)]
 
 define i64 @ENTRYPOINT__main() #0 {
 block_0:
   %var_1 = alloca i64
   %var_6 = alloca i64
-  %var_16 = alloca i64
+  %var_8 = alloca i64
+  %var_17 = alloca i64
   call void @__quantum__rt__initialize(ptr null)
   store i64 0, ptr %var_1
   br label %block_1
 block_1:
-  %var_25 = load i64, ptr %var_1
-  %var_2 = icmp slt i64 %var_25, 2
+  %var_26 = load i64, ptr %var_1
+  %var_2 = icmp slt i64 %var_26, 2
   br i1 %var_2, label %block_2, label %block_3
 block_2:
-  %var_42 = load i64, ptr %var_1
-  %var_3 = getelementptr ptr, ptr @array0, i64 %var_42
-  %var_43 = load ptr, ptr %var_3
-  call void @__quantum__qis__x__body(ptr %var_43)
-  %var_5 = add i64 %var_42, 1
+  %var_46 = load i64, ptr %var_1
+  %var_3 = getelementptr ptr, ptr @array0, i64 %var_46
+  %var_47 = load ptr, ptr %var_3
+  call void @__quantum__qis__x__body(ptr %var_47)
+  %var_5 = add i64 %var_46, 1
   store i64 %var_5, ptr %var_1
   br label %block_1
 block_3:
   store i64 0, ptr %var_6
   call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
   call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-  store i64 0, ptr %var_6
-  %var_9 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-  br i1 %var_9, label %block_4, label %block_5
+  store i64 0, ptr %var_8
+  br label %block_4
 block_4:
-  %var_40 = load i64, ptr %var_6
-  %var_11 = add i64 %var_40, 1
-  store i64 %var_11, ptr %var_6
-  br label %block_5
+  %var_29 = load i64, ptr %var_8
+  %var_9 = icmp slt i64 %var_29, 2
+  br i1 %var_9, label %block_5, label %block_6
 block_5:
-  %var_28 = load i64, ptr %var_6
-  %var_12 = shl i64 %var_28, 1
+  %var_38 = load i64, ptr %var_8
+  %var_10 = getelementptr ptr, ptr @array1, i64 %var_38
+  %var_39 = load ptr, ptr %var_10
+  %var_40 = load i64, ptr %var_6
+  %var_12 = shl i64 %var_40, 1
   store i64 %var_12, ptr %var_6
-  %var_13 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-  br i1 %var_13, label %block_6, label %block_7
+  %var_13 = call i1 @__quantum__rt__read_result(ptr %var_39)
+  br i1 %var_13, label %block_7, label %block_9
 block_6:
-  %var_38 = load i64, ptr %var_6
-  %var_15 = add i64 %var_38, 1
-  store i64 %var_15, ptr %var_6
-  br label %block_7
+  store i64 0, ptr %var_17
+  br label %block_8
 block_7:
-  store i64 0, ptr %var_16
-  br label %block_8
+  %var_44 = load i64, ptr %var_6
+  %var_15 = add i64 %var_44, 1
+  store i64 %var_15, ptr %var_6
+  br label %block_9
 block_8:
-  %var_31 = load i64, ptr %var_16
-  %var_17 = icmp slt i64 %var_31, 2
-  br i1 %var_17, label %block_9, label %block_10
+  %var_31 = load i64, ptr %var_17
+  %var_18 = icmp slt i64 %var_31, 2
+  br i1 %var_18, label %block_10, label %block_11
 block_9:
-  %var_35 = load i64, ptr %var_16
-  %var_18 = getelementptr ptr, ptr @array0, i64 %var_35
-  %var_36 = load ptr, ptr %var_18
-  call void @__quantum__qis__reset__body(ptr %var_36)
-  %var_20 = add i64 %var_35, 1
-  store i64 %var_20, ptr %var_16
-  br label %block_8
+  %var_42 = load i64, ptr %var_8
+  %var_16 = add i64 %var_42, 1
+  store i64 %var_16, ptr %var_8
+  br label %block_4
 block_10:
-  %var_32 = load i64, ptr %var_6
-  %var_21 = icmp eq i64 %var_32, 0
-  br i1 %var_21, label %block_11, label %block_12
+  %var_35 = load i64, ptr %var_17
+  %var_19 = getelementptr ptr, ptr @array0, i64 %var_35
+  %var_36 = load ptr, ptr %var_19
+  call void @__quantum__qis__reset__body(ptr %var_36)
+  %var_21 = add i64 %var_35, 1
+  store i64 %var_21, ptr %var_17
+  br label %block_8
 block_11:
-  br label %block_13
+  %var_32 = load i64, ptr %var_6
+  %var_22 = icmp eq i64 %var_32, 0
+  br i1 %var_22, label %block_12, label %block_13
 block_12:
-  %var_33 = load i64, ptr %var_6
-  %var_22 = icmp eq i64 %var_33, 1
-  br i1 %var_22, label %block_14, label %block_15
+  br label %block_14
 block_13:
+  %var_33 = load i64, ptr %var_6
+  %var_23 = icmp eq i64 %var_33, 1
+  br i1 %var_23, label %block_15, label %block_16
+block_14:
   call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
   call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr @0)
   ret i64 0
-block_14:
-  call void @__quantum__qis__ry__body(double 3.141592653589793, ptr inttoptr (i64 2 to ptr))
-  br label %block_16
 block_15:
-  %var_34 = load i64, ptr %var_6
-  %var_23 = icmp eq i64 %var_34, 2
-  br i1 %var_23, label %block_17, label %block_18
+  call void @__quantum__qis__ry__body(double 3.141592653589793, ptr inttoptr (i64 2 to ptr))
+  br label %block_17
 block_16:
-  br label %block_13
+  %var_34 = load i64, ptr %var_6
+  %var_24 = icmp eq i64 %var_34, 2
+  br i1 %var_24, label %block_18, label %block_19
 block_17:
-  call void @__quantum__qis__rz__body(double 3.141592653589793, ptr inttoptr (i64 2 to ptr))
-  br label %block_19
+  br label %block_14
 block_18:
-  call void @__quantum__qis__rx__body(double 3.141592653589793, ptr inttoptr (i64 2 to ptr))
-  br label %block_19
+  call void @__quantum__qis__rz__body(double 3.141592653589793, ptr inttoptr (i64 2 to ptr))
+  br label %block_20
 block_19:
-  br label %block_16
+  call void @__quantum__qis__rx__body(double 3.141592653589793, ptr inttoptr (i64 2 to ptr))
+  br label %block_20
+block_20:
+  br label %block_17
 }
 
 declare void @__quantum__rt__initialize(ptr)


### PR DESCRIPTION
This change supports the emission of constant `Result` arrays for Adaptive RIFLA QIR generation. To do so, we needed the compiler to see arrays of result values as "dynamic constant" expressions, which required a change to how `Result` values are handled during RCA and Partial Eval. Previously, any `Result` value coming back from an intrinsic operation was treated a dynamic variable, even though they are really just identifiers. This updates that logic to recognized results as identifiers, the same way qubits are identifiers, and moves the source of dynamic variables in RCA to the actual comparison of results rather than being inherent to the result itself. To make sure this quality propagates across function call boundaries appropriately, RCA was updated to differentiate between call arguments that are static vs dynamic constant vs dynamic variable, where previously it only checked for dynamic variable and treated constant and static as the same.

In addition, this also includes an update to RCA that adds a new capability to recognize when a static `Result` value (`One` or `Zero`) is used as the output from a dynamic expression, since that cannot be emitted into QIR. The new check detects this at analysis time so the error is visible in the editor before the user tries to emit QIR (if applicable).