### PR TITLE
Handle missing rparen on call

### DIFF
--- a/source/compiler/qsc_parse/src/expr.rs
+++ b/source/compiler/qsc_parse/src/expr.rs
@@ -16,8 +16,8 @@ use crate::{
         TokenKind,
     },
     prim::{
-        ident, opt, parse_or_else, pat, recovering_parse_or_else, recovering_path, seq, shorten,
-        token,
+        barrier, ident, opt, parse_or_else, pat, recovering_parse_or_else, recovering_path, seq,
+        shorten, token,
     },
     scan::ParserContext,
     stmt,
@@ -786,8 +786,16 @@ fn index_op(s: &mut ParserContext, lhs: Box<Expr>) -> Result<Box<ExprKind>> {
 
 fn call_op(s: &mut ParserContext, lhs: Box<Expr>) -> Result<Box<ExprKind>> {
     let lo = s.span(0).hi - 1;
-    let (args, final_sep) = seq(s, expr)?;
-    token(s, TokenKind::Close(Delim::Paren))?;
+    // If there's a nested object initializer, we want its recovery to know about rparen, so we add a barrier
+    let (args, final_sep) = barrier(s, &[TokenKind::Close(Delim::Paren)], |s| seq(s, expr))?;
+    // If the rparen is missing, we report an error but keep the call node so the language service can offer signature help, etc
+    if token(s, TokenKind::Close(Delim::Paren)).is_err() {
+        s.push_error(Error::new(ErrorKind::Token(
+            TokenKind::Close(Delim::Paren),
+            s.peek().kind,
+            s.peek().span,
+        )));
+    }
     let rhs = Box::new(Expr {
         id: NodeId::default(),
         span: s.span(lo),

--- a/source/compiler/qsc_parse/src/expr.rs
+++ b/source/compiler/qsc_parse/src/expr.rs
@@ -788,13 +788,16 @@ fn call_op(s: &mut ParserContext, lhs: Box<Expr>) -> Result<Box<ExprKind>> {
     let lo = s.span(0).hi - 1;
     // If there's a nested object initializer, we want its recovery to know about rparen, so we add a barrier
     let (args, final_sep) = barrier(s, &[TokenKind::Close(Delim::Paren)], |s| seq(s, expr))?;
-    // If the rparen is missing, we report an error but keep the call node so the language service can offer signature help, etc
+    // If the rparen is missing, we report an error but keep the call node so the language service can offer signature help, etc.
+    // We also skip trivia so that the args span extends to the next token, ensuring the cursor
+    // position is inside the span for language service features like signature help.
     if token(s, TokenKind::Close(Delim::Paren)).is_err() {
         s.push_error(Error::new(ErrorKind::Token(
             TokenKind::Close(Delim::Paren),
             s.peek().kind,
             s.peek().span,
         )));
+        s.skip_trivia();
     }
     let rhs = Box::new(Expr {
         id: NodeId::default(),

--- a/source/compiler/qsc_parse/src/expr/tests.rs
+++ b/source/compiler/qsc_parse/src/expr/tests.rs
@@ -2858,3 +2858,247 @@ fn parenthesized_expr_in_for_is_valid() {
                     Stmt _id_ [16-18]: Expr: Expr _id_ [16-18]: Unit"#]],
     );
 }
+
+// Call expression recovery tests
+
+#[test]
+fn call_missing_close_paren_empty_args() {
+    check(
+        expr,
+        "foo(",
+        &expect![[r#"
+            Expr _id_ [0-4]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-4]: Unit
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 4,
+                            hi: 4,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn call_missing_close_paren_one_arg() {
+    check(
+        expr,
+        "foo(x",
+        &expect![[r#"
+            Expr _id_ [0-5]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-5]: Paren: Expr _id_ [4-5]: Path: Path _id_ [4-5] (Ident _id_ [4-5] "x")
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 5,
+                            hi: 5,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn call_missing_close_paren_trailing_comma() {
+    check(
+        expr,
+        "foo(x,",
+        &expect![[r#"
+            Expr _id_ [0-6]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-6]: Tuple:
+                    Expr _id_ [4-5]: Path: Path _id_ [4-5] (Ident _id_ [4-5] "x")
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 6,
+                            hi: 6,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn call_missing_close_paren_two_args() {
+    check(
+        expr,
+        "foo(x, y",
+        &expect![[r#"
+            Expr _id_ [0-8]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-8]: Tuple:
+                    Expr _id_ [4-5]: Path: Path _id_ [4-5] (Ident _id_ [4-5] "x")
+                    Expr _id_ [7-8]: Path: Path _id_ [7-8] (Ident _id_ [7-8] "y")
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 8,
+                            hi: 8,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn call_nested_missing_close_parens() {
+    check(
+        expr,
+        "foo(bar(",
+        &expect![[r#"
+            Expr _id_ [0-8]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-8]: Paren: Expr _id_ [4-8]: Call:
+                    Expr _id_ [4-7]: Path: Path _id_ [4-7] (Ident _id_ [4-7] "bar")
+                    Expr _id_ [7-8]: Unit
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 8,
+                            hi: 8,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn call_nested_with_arg_missing_close_parens() {
+    check(
+        expr,
+        "foo(x, bar(",
+        &expect![[r#"
+            Expr _id_ [0-11]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-11]: Tuple:
+                    Expr _id_ [4-5]: Path: Path _id_ [4-5] (Ident _id_ [4-5] "x")
+                    Expr _id_ [7-11]: Call:
+                        Expr _id_ [7-10]: Path: Path _id_ [7-10] (Ident _id_ [7-10] "bar")
+                        Expr _id_ [10-11]: Unit
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 11,
+                            hi: 11,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn call_nested_inner_missing_close_paren() {
+    check(
+        expr,
+        "foo(bar(x)",
+        &expect![[r#"
+            Expr _id_ [0-10]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-10]: Paren: Expr _id_ [4-10]: Call:
+                    Expr _id_ [4-7]: Path: Path _id_ [4-7] (Ident _id_ [4-7] "bar")
+                    Expr _id_ [7-10]: Paren: Expr _id_ [8-9]: Path: Path _id_ [8-9] (Ident _id_ [8-9] "x")
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 10,
+                            hi: 10,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn call_with_struct_arg_missing_close_paren() {
+    check(
+        expr,
+        "foo(new Bar { x = 1 })",
+        &expect![[r#"
+            Expr _id_ [0-22]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-22]: Paren: Expr _id_ [4-21]: Struct (Path _id_ [8-11] (Ident _id_ [8-11] "Bar")):
+                    FieldsAssign _id_ [14-19]: (Ident _id_ [14-15] "x") Expr _id_ [18-19]: Lit: Int(1)"#]],
+    );
+}
+
+#[test]
+fn call_with_incomplete_struct_arg() {
+    check(
+        expr,
+        "foo(new Bar { x = 1 )",
+        &expect![[r#"
+            Expr _id_ [0-21]: Call:
+                Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
+                Expr _id_ [3-21]: Paren: Expr _id_ [4-19]: Struct (Path _id_ [8-11] (Ident _id_ [8-11] "Bar")): <empty>
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Brace,
+                        ),
+                        Close(
+                            Paren,
+                        ),
+                        Span {
+                            lo: 20,
+                            hi: 21,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}

--- a/source/compiler/qsc_parse/src/expr/tests.rs
+++ b/source/compiler/qsc_parse/src/expr/tests.rs
@@ -3065,12 +3065,27 @@ fn call_nested_inner_missing_close_paren() {
 fn call_with_struct_arg_missing_close_paren() {
     check(
         expr,
-        "foo(new Bar { x = 1 })",
+        "foo(new Bar { x = 1 }",
         &expect![[r#"
-            Expr _id_ [0-22]: Call:
+            Expr _id_ [0-21]: Call:
                 Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo")
-                Expr _id_ [3-22]: Paren: Expr _id_ [4-21]: Struct (Path _id_ [8-11] (Ident _id_ [8-11] "Bar")):
-                    FieldsAssign _id_ [14-19]: (Ident _id_ [14-15] "x") Expr _id_ [18-19]: Lit: Int(1)"#]],
+                Expr _id_ [3-21]: Paren: Expr _id_ [4-21]: Struct (Path _id_ [8-11] (Ident _id_ [8-11] "Bar")):
+                    FieldsAssign _id_ [14-19]: (Ident _id_ [14-15] "x") Expr _id_ [18-19]: Lit: Int(1)
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 21,
+                            hi: 21,
+                        },
+                    ),
+                ),
+            ]"#]],
     );
 }
 

--- a/source/compiler/qsc_parse/src/prim/tests.rs
+++ b/source/compiler/qsc_parse/src/prim/tests.rs
@@ -408,19 +408,25 @@ fn seq_fail_consume() {
     check_seq(
         |s| seq(s, expr),
         "foo, bar(",
-        &expect![[r"
-            Error(
-                Token(
-                    Close(
-                        Paren,
+        &expect![[r#"
+            (Expr _id_ [0-3]: Path: Path _id_ [0-3] (Ident _id_ [0-3] "foo"),
+            Expr _id_ [5-9]: Call:
+                Expr _id_ [5-8]: Path: Path _id_ [5-8] (Ident _id_ [5-8] "bar")
+                Expr _id_ [8-9]: Unit, Missing)
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 9,
+                            hi: 9,
+                        },
                     ),
-                    Eof,
-                    Span {
-                        lo: 9,
-                        hi: 9,
-                    },
                 ),
-            )
-        "]],
+            ]"#]],
     );
 }

--- a/source/compiler/qsc_parse/src/stmt/tests.rs
+++ b/source/compiler/qsc_parse/src/stmt/tests.rs
@@ -787,10 +787,18 @@ fn recover_statements_before_and_after() {
                     Expr _id_ [22-27]: BinOp (Add):
                         Expr _id_ [22-23]: Lit: Int(2)
                         Expr _id_ [26-27]: Lit: Int(2)
-                Stmt _id_ [41-81]: Local (Immutable):
+                Stmt _id_ [41-54]: Local (Immutable):
                     Pat _id_ [45-46]: Bind:
                         Ident _id_ [45-46] "y"
-                    Expr _id_ [49-80]: Err
+                    Expr _id_ [49-54]: Call:
+                        Expr _id_ [49-52]: Path: Path _id_ [49-52] (Ident _id_ [49-52] "Foo")
+                        Expr _id_ [52-54]: Paren: Expr _id_ [53-54]: Path: Path _id_ [53-54] (Ident _id_ [53-54] "x")
+                Stmt _id_ [67-81]: Local (Immutable):
+                    Pat _id_ [71-72]: Bind:
+                        Ident _id_ [71-72] "z"
+                    Expr _id_ [75-80]: BinOp (Mul):
+                        Expr _id_ [75-76]: Path: Path _id_ [75-76] (Ident _id_ [75-76] "x")
+                        Expr _id_ [79-80]: Lit: Int(3)
                 Stmt _id_ [94-95]: Expr: Expr _id_ [94-95]: Path: Path _id_ [94-95] (Ident _id_ [94-95] "z")
 
             [
@@ -805,6 +813,70 @@ fn recover_statements_before_and_after() {
                         Span {
                             lo: 67,
                             hi: 70,
+                        },
+                    ),
+                ),
+                Error(
+                    Token(
+                        Semi,
+                        Keyword(
+                            Let,
+                        ),
+                        Span {
+                            lo: 67,
+                            hi: 70,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn recover_let_after_unclosed_call() {
+    check(
+        parse_block,
+        "{
+            let y = Foo(x
+            let z = 3;
+        }",
+        &expect![[r#"
+            Block _id_ [0-60]:
+                Stmt _id_ [14-27]: Local (Immutable):
+                    Pat _id_ [18-19]: Bind:
+                        Ident _id_ [18-19] "y"
+                    Expr _id_ [22-27]: Call:
+                        Expr _id_ [22-25]: Path: Path _id_ [22-25] (Ident _id_ [22-25] "Foo")
+                        Expr _id_ [25-27]: Paren: Expr _id_ [26-27]: Path: Path _id_ [26-27] (Ident _id_ [26-27] "x")
+                Stmt _id_ [40-50]: Local (Immutable):
+                    Pat _id_ [44-45]: Bind:
+                        Ident _id_ [44-45] "z"
+                    Expr _id_ [48-49]: Lit: Int(3)
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Keyword(
+                            Let,
+                        ),
+                        Span {
+                            lo: 40,
+                            hi: 43,
+                        },
+                    ),
+                ),
+                Error(
+                    Token(
+                        Semi,
+                        Keyword(
+                            Let,
+                        ),
+                        Span {
+                            lo: 40,
+                            hi: 43,
                         },
                     ),
                 ),
@@ -854,6 +926,66 @@ fn recover_missing_semicolon() {
                         Span {
                             lo: 68,
                             hi: 71,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn recover_call_missing_close_paren_in_block() {
+    check(
+        parse_block,
+        "{ foo( }",
+        &expect![[r#"
+            Block _id_ [0-8]:
+                Stmt _id_ [2-6]: Expr: Expr _id_ [2-6]: Call:
+                    Expr _id_ [2-5]: Path: Path _id_ [2-5] (Ident _id_ [2-5] "foo")
+                    Expr _id_ [5-6]: Unit
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Close(
+                            Brace,
+                        ),
+                        Span {
+                            lo: 7,
+                            hi: 8,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn recover_call_with_arg_missing_close_paren_in_block() {
+    check(
+        parse_block,
+        "{ foo(x }",
+        &expect![[r#"
+            Block _id_ [0-9]:
+                Stmt _id_ [2-7]: Expr: Expr _id_ [2-7]: Call:
+                    Expr _id_ [2-5]: Path: Path _id_ [2-5] (Ident _id_ [2-5] "foo")
+                    Expr _id_ [5-7]: Paren: Expr _id_ [6-7]: Path: Path _id_ [6-7] (Ident _id_ [6-7] "x")
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Close(
+                            Brace,
+                        ),
+                        Span {
+                            lo: 8,
+                            hi: 9,
                         },
                     ),
                 ),

--- a/source/compiler/qsc_parse/src/stmt/tests.rs
+++ b/source/compiler/qsc_parse/src/stmt/tests.rs
@@ -787,12 +787,12 @@ fn recover_statements_before_and_after() {
                     Expr _id_ [22-27]: BinOp (Add):
                         Expr _id_ [22-23]: Lit: Int(2)
                         Expr _id_ [26-27]: Lit: Int(2)
-                Stmt _id_ [41-54]: Local (Immutable):
+                Stmt _id_ [41-67]: Local (Immutable):
                     Pat _id_ [45-46]: Bind:
                         Ident _id_ [45-46] "y"
-                    Expr _id_ [49-54]: Call:
+                    Expr _id_ [49-67]: Call:
                         Expr _id_ [49-52]: Path: Path _id_ [49-52] (Ident _id_ [49-52] "Foo")
-                        Expr _id_ [52-54]: Paren: Expr _id_ [53-54]: Path: Path _id_ [53-54] (Ident _id_ [53-54] "x")
+                        Expr _id_ [52-67]: Paren: Expr _id_ [53-54]: Path: Path _id_ [53-54] (Ident _id_ [53-54] "x")
                 Stmt _id_ [67-81]: Local (Immutable):
                     Pat _id_ [71-72]: Bind:
                         Ident _id_ [71-72] "z"
@@ -842,12 +842,12 @@ fn recover_let_after_unclosed_call() {
         }",
         &expect![[r#"
             Block _id_ [0-60]:
-                Stmt _id_ [14-27]: Local (Immutable):
+                Stmt _id_ [14-40]: Local (Immutable):
                     Pat _id_ [18-19]: Bind:
                         Ident _id_ [18-19] "y"
-                    Expr _id_ [22-27]: Call:
+                    Expr _id_ [22-40]: Call:
                         Expr _id_ [22-25]: Path: Path _id_ [22-25] (Ident _id_ [22-25] "Foo")
-                        Expr _id_ [25-27]: Paren: Expr _id_ [26-27]: Path: Path _id_ [26-27] (Ident _id_ [26-27] "x")
+                        Expr _id_ [25-40]: Paren: Expr _id_ [26-27]: Path: Path _id_ [26-27] (Ident _id_ [26-27] "x")
                 Stmt _id_ [40-50]: Local (Immutable):
                     Pat _id_ [44-45]: Bind:
                         Ident _id_ [44-45] "z"
@@ -940,9 +940,9 @@ fn recover_call_missing_close_paren_in_block() {
         "{ foo( }",
         &expect![[r#"
             Block _id_ [0-8]:
-                Stmt _id_ [2-6]: Expr: Expr _id_ [2-6]: Call:
+                Stmt _id_ [2-7]: Expr: Expr _id_ [2-7]: Call:
                     Expr _id_ [2-5]: Path: Path _id_ [2-5] (Ident _id_ [2-5] "foo")
-                    Expr _id_ [5-6]: Unit
+                    Expr _id_ [5-7]: Unit
 
             [
                 Error(
@@ -970,9 +970,9 @@ fn recover_call_with_arg_missing_close_paren_in_block() {
         "{ foo(x }",
         &expect![[r#"
             Block _id_ [0-9]:
-                Stmt _id_ [2-7]: Expr: Expr _id_ [2-7]: Call:
+                Stmt _id_ [2-8]: Expr: Expr _id_ [2-8]: Call:
                     Expr _id_ [2-5]: Path: Path _id_ [2-5] (Ident _id_ [2-5] "foo")
-                    Expr _id_ [5-7]: Paren: Expr _id_ [6-7]: Path: Path _id_ [6-7] (Ident _id_ [6-7] "x")
+                    Expr _id_ [5-8]: Paren: Expr _id_ [6-7]: Path: Path _id_ [6-7] (Ident _id_ [6-7] "x")
 
             [
                 Error(

--- a/source/language_service/src/signature_help/tests.rs
+++ b/source/language_service/src/signature_help/tests.rs
@@ -3366,3 +3366,154 @@ fn std_callable_with_type_params() {
         "#]],
     );
 }
+
+#[test]
+fn missing_close_paren_empty_args() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Double) : Unit {}
+            operation Bar() : Unit {
+                Foo(↘
+                let z = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "operation Foo(x : Int, y : Double) : Unit",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: (
+                                    13,
+                                    34,
+                                ),
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: (
+                                    14,
+                                    21,
+                                ),
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: (
+                                    23,
+                                    33,
+                                ),
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn missing_close_paren_second_arg() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Double) : Unit {}
+            operation Bar() : Unit {
+                Foo(1, ↘
+                let z = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "operation Foo(x : Int, y : Double) : Unit",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: (
+                                    13,
+                                    34,
+                                ),
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: (
+                                    14,
+                                    21,
+                                ),
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: (
+                                    23,
+                                    33,
+                                ),
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 2,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn missing_close_paren_nested_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int) : Unit {}
+            operation Baz(a : Int, b : Int) : Int { a + b }
+            operation Bar() : Unit {
+                Foo(Baz(1, ↘
+                let z = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "operation Baz(a : Int, b : Int) : Int",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: (
+                                    13,
+                                    31,
+                                ),
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: (
+                                    14,
+                                    21,
+                                ),
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: (
+                                    23,
+                                    30,
+                                ),
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 2,
+            }
+        "#]],
+    );
+}


### PR DESCRIPTION
Without automatic bracket matching, it's quite easy to get into a situation for a function call has an open paren, but no close paren.  When this happens, the entire line is consumed as an error node and there's no language service help (in particular, no signature help).  By pushing an error, but not returning one, we can preserve the call node so that the language service has something to work with.

Bonus: If the argument list contains an initializer (or other expression with recovery), its recovery will now stop at the close paren because we've pushed that as a barrier.  This doesn't help with the missing close paren, it's just nice to have.

I've reviewed the code thoroughly, reviewed the test baselines somewhat, and manually tested in both VS Code and the Playground.