### PR TITLE
feat(python): load visual circuits directly in Context

### DIFF
--- a/source/compiler/qsc/src/lib.rs
+++ b/source/compiler/qsc/src/lib.rs
@@ -70,7 +70,9 @@ pub use qsc_doc_gen::{display, generate_docs};
 pub mod circuit {
     pub use qsc_circuit::{
         CURRENT_VERSION, Circuit, CircuitGroup, TracerConfig,
-        circuit_to_qsharp::circuits_to_qsharp, json_to_circuit::json_to_circuits, operations::*,
+        circuit_to_qsharp::{circuit_to_standalone_qsharp, circuits_to_qsharp},
+        json_to_circuit::json_to_circuits,
+        operations::*,
     };
 }
 

--- a/source/compiler/qsc_circuit/src/circuit_to_qsharp.rs
+++ b/source/compiler/qsc_circuit/src/circuit_to_qsharp.rs
@@ -18,6 +18,24 @@ pub fn circuits_to_qsharp(file_name: &str, circuits_json: &str) -> Result<String
     json_to_circuits(circuits_json).map(|circuits| build_circuits(file_name, &circuits.circuits))
 }
 
+pub fn circuit_to_standalone_qsharp(
+    file_name: &str,
+    circuits_json: &str,
+    index: usize,
+) -> Result<String, String> {
+    json_to_circuits(circuits_json).and_then(|circuits| {
+        circuits.circuits.get(index).map_or_else(
+            || {
+                Err(format!(
+                    "Circuit index {index} is out of range for {} circuits.",
+                    circuits.circuits.len()
+                ))
+            },
+            |circuit| Ok(build_standalone_operation_def(file_name, circuit)),
+        )
+    })
+}
+
 fn build_circuits(file_name: &str, circuits: &[Circuit]) -> String {
     if circuits.len() == 1 {
         build_operation_def(file_name, &circuits[0])
@@ -33,38 +51,19 @@ fn build_circuits(file_name: &str, circuits: &[Circuit]) -> String {
 }
 
 fn build_operation_def(circuit_name: &str, circuit: &Circuit) -> String {
-    let mut indentation_level = 0;
     let qubits = circuit
         .qubits
         .iter()
         .enumerate()
         .map(|(i, q)| (q.id, format!("qs[{i}]")))
         .collect::<FxHashMap<_, _>>();
-
     let parameter = if qubits.is_empty() {
         String::new()
     } else {
         "qs : Qubit[]".to_string()
     };
-
-    // The return type is determined by the number of qubits "children".
-    // However, the actual return statement is determined by the variables storing measurements.
-    // If there is an inconsistency between these, which would happen if there was a mismatch between
-    // the number of qubit children specified on the circuit and the number of qubit children specified
-    // on the measurements, incorrect Q# could be generated.
-    let return_type = match circuit.qubits.iter().fold(0, |sum, q| sum + q.num_results) {
-        0 => "Unit",
-        1 => "Result",
-        _ => "Result[]",
-    };
-
-    // Check if all operations are Unitary
-    let is_ctl_adj = !circuit.component_grid.iter().any(|col| {
-        col.components
-            .iter()
-            .any(|op| !matches!(op, Operation::Unitary(_)))
-    });
-
+    let return_type = operation_return_type(circuit);
+    let is_ctl_adj = supports_ctl_adj(circuit);
     let characteristics = if is_ctl_adj { "is Ctl + Adj " } else { "" };
     let summary = if qubits.is_empty() {
         String::new()
@@ -78,18 +77,10 @@ fn build_operation_def(circuit_name: &str, circuit: &Circuit) -> String {
     let mut qsharp_str = format!(
         "{summary}operation {circuit_name}({parameter}) : {return_type} {characteristics}{{\n"
     );
-    indentation_level += 1;
-
-    let mut measure_results = vec![];
-    let indent = "    ".repeat(indentation_level);
+    let indentation_level = 1;
 
     // If there are operation, add an assert for the number of qubits
-    if !circuit.component_grid.is_empty()
-        && circuit
-            .component_grid
-            .iter()
-            .any(|col| !col.components.is_empty())
-    {
+    if has_operations(circuit) {
         qsharp_str.push_str(&generate_qubit_validation(
             circuit_name,
             &qubits,
@@ -97,6 +88,81 @@ fn build_operation_def(circuit_name: &str, circuit: &Circuit) -> String {
         ));
     }
 
+    let indent = "    ".repeat(indentation_level);
+    let (body_str, result_expression) = generate_operation_body(circuit, &qubits, &indent);
+    qsharp_str.push_str(body_str.as_str());
+    if let Some(result_expression) = result_expression {
+        writeln!(qsharp_str, "{indent}return {result_expression};")
+            .expect("could not write to qsharp_str");
+    }
+    qsharp_str.push_str("}\n\n");
+    qsharp_str
+}
+
+fn build_standalone_operation_def(circuit_name: &str, circuit: &Circuit) -> String {
+    let qubits = circuit
+        .qubits
+        .iter()
+        .enumerate()
+        .map(|(i, q)| (q.id, format!("qs[{i}]")))
+        .collect::<FxHashMap<_, _>>();
+    let return_type = operation_return_type(circuit);
+    let mut qsharp_str = format!("operation {circuit_name}() : {return_type} {{\n");
+    let indent = "    ";
+
+    if !qubits.is_empty() {
+        writeln!(qsharp_str, "{indent}use qs = Qubit[{}];", qubits.len())
+            .expect("could not write to qsharp_str");
+    }
+
+    let (body_str, result_expression) = generate_operation_body(circuit, &qubits, indent);
+    qsharp_str.push_str(body_str.as_str());
+    if !qubits.is_empty() {
+        writeln!(qsharp_str, "{indent}ResetAll(qs);").expect("could not write to qsharp_str");
+    }
+    if let Some(result_expression) = result_expression {
+        writeln!(qsharp_str, "{indent}return {result_expression};")
+            .expect("could not write to qsharp_str");
+    }
+    qsharp_str.push_str("}\n\n");
+    qsharp_str
+}
+
+fn operation_return_type(circuit: &Circuit) -> &'static str {
+    // The return type is determined by the number of qubits "children".
+    // However, the actual return statement is determined by the variables storing measurements.
+    // If there is an inconsistency between these, which would happen if there was a mismatch between
+    // the number of qubit children specified on the circuit and the number of qubit children specified
+    // on the measurements, incorrect Q# could be generated.
+    match circuit.qubits.iter().fold(0, |sum, q| sum + q.num_results) {
+        0 => "Unit",
+        1 => "Result",
+        _ => "Result[]",
+    }
+}
+
+fn supports_ctl_adj(circuit: &Circuit) -> bool {
+    !circuit.component_grid.iter().any(|col| {
+        col.components
+            .iter()
+            .any(|op| !matches!(op, Operation::Unitary(_)))
+    })
+}
+
+fn has_operations(circuit: &Circuit) -> bool {
+    !circuit.component_grid.is_empty()
+        && circuit
+            .component_grid
+            .iter()
+            .any(|col| !col.components.is_empty())
+}
+
+fn generate_operation_body(
+    circuit: &Circuit,
+    qubits: &FxHashMap<usize, String>,
+    indent: &str,
+) -> (String, Option<String>) {
+    let mut measure_results = vec![];
     let mut body_str = String::new();
     let mut should_add_pi = false;
 
@@ -108,18 +174,18 @@ fn build_operation_def(circuit_name: &str, circuit: &Circuit) -> String {
                     body_str.push_str(
                         generate_measurement_call(
                             measurement,
-                            &qubits,
-                            &indent,
+                            qubits,
+                            indent,
                             &mut measure_results,
                         )
                         .as_str(),
                     );
                 }
                 Operation::Unitary(unitary) => {
-                    body_str.push_str(generate_unitary_call(unitary, &qubits, &indent).as_str());
+                    body_str.push_str(generate_unitary_call(unitary, qubits, indent).as_str());
                 }
                 Operation::Ket(ket) => {
-                    body_str.push_str(generate_ket_call(ket, &qubits, &indent).as_str());
+                    body_str.push_str(generate_ket_call(ket, qubits, indent).as_str());
                 }
             }
 
@@ -133,14 +199,10 @@ fn build_operation_def(circuit_name: &str, circuit: &Circuit) -> String {
 
     if should_add_pi {
         // Add the π constant
-        writeln!(qsharp_str, "{indent}let π = Std.Math.PI();")
-            .expect("could not write to qsharp_str");
+        body_str.insert_str(0, &format!("{indent}let π = Std.Math.PI();\n"));
     }
 
-    qsharp_str.push_str(body_str.as_str());
-    qsharp_str.push_str(&generate_return_statement(&mut measure_results, &indent));
-    qsharp_str.push_str("}\n\n");
-    qsharp_str
+    (body_str, generate_result_expression(&mut measure_results))
 }
 
 fn generate_qubit_validation(
@@ -222,25 +284,22 @@ fn generate_ket_call(ket: &Ket, qubits: &FxHashMap<usize, String>, indent: &str)
     }
 }
 
-fn generate_return_statement(
-    measure_results: &mut [(String, (usize, usize))],
-    indent: &str,
-) -> String {
+fn generate_result_expression(measure_results: &mut [(String, (usize, usize))]) -> Option<String> {
     if measure_results.is_empty() {
-        return String::new();
+        return None;
     }
 
     measure_results.sort_by_key(|(_, (q_id, c_id))| (*q_id, *c_id));
     if measure_results.len() == 1 {
         let (name, _) = measure_results[0].clone();
-        format!("{indent}return {name};\n")
+        Some(name)
     } else {
         let results = measure_results
             .iter()
             .map(|(name, _)| name.as_str())
             .collect::<Vec<_>>()
             .join(", ");
-        format!("{indent}return [{results}];\n")
+        Some(format!("[{results}]"))
     }
 }
 

--- a/source/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
+++ b/source/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
@@ -20,6 +20,14 @@ fn check_circuit_group(contents: &str, expect: &Expect) {
     expect.assert_eq(&actual);
 }
 
+fn check_standalone(contents: &str, index: usize, expect: &Expect) {
+    let actual = match circuit_to_standalone_qsharp("Test", contents, index) {
+        Ok(circuit) => circuit,
+        Err(e) => e,
+    };
+    expect.assert_eq(&actual);
+}
+
 #[test]
 fn qsharp_from_circuit() {
     check_circuit_group(
@@ -56,6 +64,47 @@ fn qsharp_from_circuit() {
                 S(qs[1]);
                 Z(qs[0]);
                 X(qs[1]);
+            }
+
+        "#]],
+    );
+}
+
+#[test]
+fn standalone_qsharp_from_circuit() {
+    check_standalone(
+        r#"
+{
+  "version": 1,
+  "circuits": [
+    {
+      "componentGrid": [
+        {
+          "components": [
+            { "kind": "unitary", "gate": "H", "targets": [{ "qubit": 0 }] },
+            { "kind": "unitary", "gate": "S", "targets": [{ "qubit": 1 }] }
+          ]
+        },
+        {
+          "components": [
+            { "kind": "unitary", "gate": "Z", "targets": [{ "qubit": 0 }] },
+            { "kind": "unitary", "gate": "X", "targets": [{ "qubit": 1 }] }
+          ]
+        }
+      ],
+      "qubits": [{ "id": 0 }, { "id": 1 }]
+    }
+  ]
+}"#,
+        0,
+        &expect![[r#"
+            operation Test() : Unit {
+                use qs = Qubit[2];
+                H(qs[0]);
+                S(qs[1]);
+                Z(qs[0]);
+                X(qs[1]);
+                ResetAll(qs);
             }
 
         "#]],
@@ -366,6 +415,60 @@ fn circuit_with_measurement_gate() {
                 S(qs[1]);
                 Z(qs[0]);
                 let c0_0 = M(qs[0]);
+                return c0_0;
+            }
+
+        "#]],
+    );
+}
+
+#[test]
+fn standalone_circuit_with_measurement_gate() {
+    check_standalone(
+        r#"
+{
+  "version": 1,
+  "circuits": [
+    {
+      "componentGrid": [
+        {
+          "components": [
+            { "kind": "unitary", "gate": "H", "targets": [{ "qubit": 0 }] },
+            { "kind": "unitary", "gate": "S", "targets": [{ "qubit": 1 }] }
+          ]
+        },
+        {
+          "components": [
+            { "kind": "unitary", "gate": "Z", "targets": [{ "qubit": 0 }] }
+          ]
+        },
+        {
+          "components": [
+            {
+              "kind": "measurement",
+              "gate": "Measure",
+              "qubits": [{ "qubit": 0 }],
+              "results": [{ "qubit": 0, "result": 0 }]
+            }
+          ]
+        }
+      ],
+      "qubits": [
+        { "id": 0, "numResults": 1 },
+        { "id": 1 }
+      ]
+    }
+  ]
+}"#,
+        0,
+        &expect![[r#"
+            operation Test() : Result {
+                use qs = Qubit[2];
+                H(qs[0]);
+                S(qs[1]);
+                Z(qs[0]);
+                let c0_0 = M(qs[0]);
+                ResetAll(qs);
                 return c0_0;
             }
 

--- a/source/qdk_package/qdk/__init__.py
+++ b/source/qdk_package/qdk/__init__.py
@@ -27,7 +27,7 @@ convenience: :func:`~qdk.qsharp.init`, :func:`~qdk.qsharp.dump_machine`,
 :class:`~qdk.qsharp.StateDump`, :class:`~qdk.qsharp.ShotResult`,
 :class:`~qdk.qsharp.PauliNoise`, :class:`~qdk.qsharp.DepolarizingNoise`,
 :class:`~qdk.qsharp.BitFlipNoise`, :class:`~qdk.qsharp.PhaseFlipNoise`,
-and :class:`~qdk.Context`.
+:class:`~qdk.qsharp.ProgramType`, and :class:`~qdk.Context`.
 
 Optional extras enable additional submodules:
 
@@ -52,7 +52,7 @@ from ._interpreter import (
     set_classical_seed,
     set_quantum_seed,
 )
-from ._native import Result, TargetProfile
+from ._native import ProgramType, Result, TargetProfile
 from ._types import (
     BitFlipNoise,
     DepolarizingNoise,
@@ -80,6 +80,7 @@ __all__ = [
     "init",
     "Result",
     "TargetProfile",
+    "ProgramType",
     "StateDump",
     "ShotResult",
     "PauliNoise",

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -92,7 +92,7 @@ def _path_stem(path: str) -> str:
     return stem or "circuit"
 
 
-def _visual_circuit_signature(circuit_json: str, index: int) -> tuple[int, str, int]:
+def _visual_circuit_count(circuit_json: str) -> int:
     try:
         data = json.loads(circuit_json)
     except json.JSONDecodeError as err:
@@ -101,40 +101,7 @@ def _visual_circuit_signature(circuit_json: str, index: int) -> tuple[int, str, 
     circuits = data.get("circuits") if isinstance(data, dict) else None
     if not isinstance(circuits, list) or len(circuits) == 0:
         raise QSharpError("Visual circuit files must contain at least one circuit.")
-
-    if not isinstance(index, int) or isinstance(index, bool):
-        raise QSharpError("Visual circuit index must be an integer.")
-    if index < 0 or index >= len(circuits):
-        raise QSharpError(
-            f"Visual circuit index {index} is out of range for {len(circuits)} circuits."
-        )
-
-    circuit = circuits[index]
-    if not isinstance(circuit, dict):
-        raise QSharpError("Visual circuit JSON contains an invalid circuit.")
-
-    qubits = circuit.get("qubits", [])
-    if not isinstance(qubits, list):
-        raise QSharpError("Visual circuit JSON contains an invalid qubit register.")
-
-    result_count = 0
-    for qubit in qubits:
-        if not isinstance(qubit, dict):
-            raise QSharpError("Visual circuit JSON contains an invalid qubit.")
-        num_results = qubit.get("numResults", 0)
-        if (
-            not isinstance(num_results, int)
-            or isinstance(num_results, bool)
-            or num_results < 0
-        ):
-            raise QSharpError("Visual circuit JSON contains an invalid result count.")
-        result_count += num_results
-
-    if result_count == 0:
-        return len(qubits), "Unit", len(circuits)
-    if result_count == 1:
-        return len(qubits), "Result", len(circuits)
-    return len(qubits), "Result[]", len(circuits)
+    return len(circuits)
 
 
 def make_class_rec(qsharp_type: TypeIR) -> type:
@@ -562,7 +529,7 @@ class Context:
         except Exception as err:
             raise QSharpError(f"Error reading visual circuit file {resolved_path}.") from err
 
-        _, _, circuit_count = _visual_circuit_signature(circuit_json, index)
+        circuit_count = _visual_circuit_count(circuit_json)
         operation_base_name = name if name is not None else _path_stem(resolved_path)
 
         operation_name, generated_source = compile_visual_circuit_to_qsharp(

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -138,8 +138,13 @@ def _visual_circuit_signature(circuit_json: str, index: int) -> tuple[int, str, 
 
 
 def _visual_circuit_wrapper_source(
-    operation_name: str, wrapper_name: str, qubit_count: int, return_type: str
+    helper_source: str,
+    operation_name: str,
+    wrapper_name: str,
+    qubit_count: int,
+    return_type: str,
 ) -> str:
+    helper_source = _indent_qsharp_source(helper_source.strip() + "\n\n")
     if qubit_count == 0:
         allocation = ""
         call = f"{operation_name}()"
@@ -152,6 +157,7 @@ def _visual_circuit_wrapper_source(
     if return_type == "Unit":
         return (
             f"operation {wrapper_name}() : Unit {{\n"
+            f"{helper_source}"
             f"{allocation}"
             f"    {call};\n"
             f"{reset}"
@@ -160,6 +166,7 @@ def _visual_circuit_wrapper_source(
 
     return (
         f"operation {wrapper_name}() : {return_type} {{\n"
+        f"{helper_source}"
         f"{allocation}"
         f"    let result = {call};\n"
         f"{reset}"
@@ -168,7 +175,14 @@ def _visual_circuit_wrapper_source(
     )
 
 
-def _mark_visual_circuit_operations_internal(
+def _indent_qsharp_source(source: str) -> str:
+    return "".join(
+        f"    {line}" if line.strip() else line
+        for line in source.splitlines(keepends=True)
+    )
+
+
+def _rename_visual_circuit_operations(
     source: str, operation_name: str, circuit_count: int
 ) -> str:
     for index in range(circuit_count):
@@ -177,7 +191,7 @@ def _mark_visual_circuit_operations_internal(
         )
         source = source.replace(
             f"operation {callable_name}(",
-            f"internal operation {callable_name}_Operation(",
+            f"operation {callable_name}_Operation(",
         )
     return source
 
@@ -620,32 +634,24 @@ class Context:
         )
         eval_source = generated_source
         callable_name = circuit_operation_name
-        helper_callable_names: list[str] = []
         if program_type == ProgramType.File:
             circuit_helper_name = f"{circuit_operation_name}_Operation"
-            helper_callable_names = [
-                (
-                    f"{operation_name}_Operation"
-                    if circuit_count == 1
-                    else f"{operation_name}{helper_index}_Operation"
-                )
-                for helper_index in range(circuit_count)
-            ]
-            generated_source = _mark_visual_circuit_operations_internal(
+            generated_source = _rename_visual_circuit_operations(
                 generated_source, operation_name, circuit_count
             )
             wrapper_source = _visual_circuit_wrapper_source(
-                circuit_helper_name, circuit_operation_name, qubit_count, return_type
+                generated_source,
+                circuit_helper_name,
+                circuit_operation_name,
+                qubit_count,
+                return_type,
             )
-            eval_source = f"{generated_source}\n{wrapper_source}"
+            eval_source = wrapper_source
 
         # generated_source is produced by the native visual-circuit compiler;
         # wrapper_source, when present, is assembled from sanitized operation
         # names and type metadata.
         self.eval(eval_source)  # DevSkim: ignore DS189424
-        for helper_callable_name in helper_callable_names:
-            if hasattr(self.code, helper_callable_name):
-                delattr(self.code, helper_callable_name)
         return getattr(self.code, callable_name)
 
     def eval(

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -240,7 +240,6 @@ class Context:
     code: Any
     _disposed: bool
     _is_global_context: bool
-    _loaded_circuit_count: int
 
     def __init__(
         self,
@@ -276,7 +275,6 @@ class Context:
         self._disposed = False
         self._is_global_context = _is_global_context
         self._target_profile = target_profile
-        self._loaded_circuit_count = 0
 
         if _is_global_context:
             self.code = code
@@ -559,6 +557,7 @@ class Context:
         path: str,
         *,
         index: int = 0,
+        name: Optional[str] = None,
         program_type: ProgramType = ProgramType.File,
     ) -> Callable:
         """
@@ -567,6 +566,8 @@ class Context:
         :param path: Path to a ``.qsc`` visual circuit file.
         :keyword index: Index of the circuit to return when the file contains
             multiple circuits. Defaults to ``0``.
+        :keyword name: Optional Q# operation name to use for the imported
+            circuit. Defaults to the file name stem.
         :keyword program_type: Controls how the circuit is imported:
             ``ProgramType.File`` (default) imports a zero-argument wrapper that
             allocates the circuit qubits, applies the visual circuit, resets the
@@ -595,11 +596,10 @@ class Context:
         qubit_count, return_type, circuit_count = _visual_circuit_signature(
             circuit_json, index
         )
-        unique_name = f"{_path_stem(resolved_path)}_{self._loaded_circuit_count}"
-        self._loaded_circuit_count += 1
+        operation_base_name = name if name is not None else _path_stem(resolved_path)
 
         operation_name, generated_source = compile_visual_circuit_to_qsharp(
-            unique_name, circuit_json
+            operation_base_name, circuit_json
         )
         circuit_operation_name = (
             operation_name if circuit_count == 1 else f"{operation_name}{index}"

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -137,65 +137,6 @@ def _visual_circuit_signature(circuit_json: str, index: int) -> tuple[int, str, 
     return len(qubits), "Result[]", len(circuits)
 
 
-def _visual_circuit_wrapper_source(
-    helper_source: str,
-    operation_name: str,
-    wrapper_name: str,
-    qubit_count: int,
-    return_type: str,
-) -> str:
-    helper_source = _indent_qsharp_source(helper_source.strip() + "\n\n")
-    if qubit_count == 0:
-        allocation = ""
-        call = f"{operation_name}()"
-        reset = ""
-    else:
-        allocation = f"    use qs = Qubit[{qubit_count}];\n"
-        call = f"{operation_name}(qs)"
-        reset = "    ResetAll(qs);\n"
-
-    if return_type == "Unit":
-        return (
-            f"operation {wrapper_name}() : Unit {{\n"
-            f"{helper_source}"
-            f"{allocation}"
-            f"    {call};\n"
-            f"{reset}"
-            "}\n"
-        )
-
-    return (
-        f"operation {wrapper_name}() : {return_type} {{\n"
-        f"{helper_source}"
-        f"{allocation}"
-        f"    let result = {call};\n"
-        f"{reset}"
-        "    return result;\n"
-        "}\n"
-    )
-
-
-def _indent_qsharp_source(source: str) -> str:
-    return "".join(
-        f"    {line}" if line.strip() else line
-        for line in source.splitlines(keepends=True)
-    )
-
-
-def _rename_visual_circuit_operations(
-    source: str, operation_name: str, circuit_count: int
-) -> str:
-    for index in range(circuit_count):
-        callable_name = (
-            operation_name if circuit_count == 1 else f"{operation_name}{index}"
-        )
-        source = source.replace(
-            f"operation {callable_name}(",
-            f"operation {callable_name}_Operation(",
-        )
-    return source
-
-
 def make_class_rec(qsharp_type: TypeIR) -> type:
     class_name = qsharp_type.unwrap_udt().name
     fields = {}
@@ -621,36 +562,19 @@ class Context:
         except Exception as err:
             raise QSharpError(f"Error reading visual circuit file {resolved_path}.") from err
 
-        qubit_count, return_type, circuit_count = _visual_circuit_signature(
-            circuit_json, index
-        )
+        _, _, circuit_count = _visual_circuit_signature(circuit_json, index)
         operation_base_name = name if name is not None else _path_stem(resolved_path)
 
         operation_name, generated_source = compile_visual_circuit_to_qsharp(
-            operation_base_name, circuit_json
-        )
-        circuit_operation_name = (
-            operation_name if circuit_count == 1 else f"{operation_name}{index}"
+            operation_base_name, circuit_json, index, program_type
         )
         eval_source = generated_source
-        callable_name = circuit_operation_name
-        if program_type == ProgramType.File:
-            circuit_helper_name = f"{circuit_operation_name}_Operation"
-            generated_source = _rename_visual_circuit_operations(
-                generated_source, operation_name, circuit_count
-            )
-            wrapper_source = _visual_circuit_wrapper_source(
-                generated_source,
-                circuit_helper_name,
-                circuit_operation_name,
-                qubit_count,
-                return_type,
-            )
-            eval_source = wrapper_source
+        if program_type == ProgramType.Operation and circuit_count > 1:
+            callable_name = f"{operation_name}{index}"
+        else:
+            callable_name = operation_name
 
-        # generated_source is produced by the native visual-circuit compiler;
-        # wrapper_source, when present, is assembled from sanitized operation
-        # names and type metadata.
+        # generated_source is produced by the native visual-circuit compiler.
         self.eval(eval_source)  # DevSkim: ignore DS189424
         return getattr(self.code, callable_name)
 

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -168,6 +168,20 @@ def _visual_circuit_wrapper_source(
     )
 
 
+def _mark_visual_circuit_operations_internal(
+    source: str, operation_name: str, circuit_count: int
+) -> str:
+    for index in range(circuit_count):
+        callable_name = (
+            operation_name if circuit_count == 1 else f"{operation_name}{index}"
+        )
+        source = source.replace(
+            f"operation {callable_name}(",
+            f"internal operation {callable_name}_Operation(",
+        )
+    return source
+
+
 def make_class_rec(qsharp_type: TypeIR) -> type:
     class_name = qsharp_type.unwrap_udt().name
     fields = {}
@@ -607,12 +621,14 @@ class Context:
         eval_source = generated_source
         callable_name = circuit_operation_name
         if program_type == ProgramType.File:
-            wrapper_name = f"{circuit_operation_name}_Entry"
+            circuit_helper_name = f"{circuit_operation_name}_Operation"
+            generated_source = _mark_visual_circuit_operations_internal(
+                generated_source, operation_name, circuit_count
+            )
             wrapper_source = _visual_circuit_wrapper_source(
-                circuit_operation_name, wrapper_name, qubit_count, return_type
+                circuit_helper_name, circuit_operation_name, qubit_count, return_type
             )
             eval_source = f"{generated_source}\n{wrapper_source}"
-            callable_name = wrapper_name
 
         # generated_source is produced by the native visual-circuit compiler;
         # wrapper_source, when present, is assembled from sanitized operation

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -591,7 +591,10 @@ class Context:
             circuit_operation_name, wrapper_name, qubit_count, return_type
         )
 
-        self.eval(f"{generated_source}\n{wrapper_source}")
+        # generated_source is produced by the native visual-circuit compiler;
+        # wrapper_source is assembled from sanitized operation names and type metadata.
+        eval_source = f"{generated_source}\n{wrapper_source}"
+        self.eval(eval_source)  # DevSkim: ignore DS189424
         return getattr(self.code, wrapper_name)
 
     def eval(

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -9,10 +9,12 @@ Each Context instance has its own interpreter and code namespace, allowing multi
 independent Q# environments to coexist.
 """
 
+import json
 import sys
 import types
 import weakref
 from dataclasses import make_dataclass
+from pathlib import PurePath, PureWindowsPath
 from time import monotonic
 from typing import (
     Any,
@@ -46,6 +48,7 @@ from ._native import (  # type: ignore
     TypeIR,
     TypeKind,
     UdtValue,
+    compile_visual_circuit_to_qsharp,
 )
 from ._types import (
     BitFlipNoise,
@@ -80,6 +83,88 @@ def ipython_helper():
             from IPython.display import display
     except NameError:
         pass
+
+
+def _path_stem(path: str) -> str:
+    path_type = PureWindowsPath if "\\" in path else PurePath
+    stem = path_type(path).stem
+    return stem or "circuit"
+
+
+def _visual_circuit_signature(circuit_json: str, index: int) -> tuple[int, str, int]:
+    try:
+        data = json.loads(circuit_json)
+    except json.JSONDecodeError as err:
+        raise QSharpError(f"Failed to parse visual circuit JSON: {err}") from err
+
+    circuits = data.get("circuits") if isinstance(data, dict) else None
+    if not isinstance(circuits, list) or len(circuits) == 0:
+        raise QSharpError("Visual circuit files must contain at least one circuit.")
+
+    if not isinstance(index, int) or isinstance(index, bool):
+        raise QSharpError("Visual circuit index must be an integer.")
+    if index < 0 or index >= len(circuits):
+        raise QSharpError(
+            f"Visual circuit index {index} is out of range for {len(circuits)} circuits."
+        )
+
+    circuit = circuits[index]
+    if not isinstance(circuit, dict):
+        raise QSharpError("Visual circuit JSON contains an invalid circuit.")
+
+    qubits = circuit.get("qubits", [])
+    if not isinstance(qubits, list):
+        raise QSharpError("Visual circuit JSON contains an invalid qubit register.")
+
+    result_count = 0
+    for qubit in qubits:
+        if not isinstance(qubit, dict):
+            raise QSharpError("Visual circuit JSON contains an invalid qubit.")
+        num_results = qubit.get("numResults", 0)
+        if (
+            not isinstance(num_results, int)
+            or isinstance(num_results, bool)
+            or num_results < 0
+        ):
+            raise QSharpError("Visual circuit JSON contains an invalid result count.")
+        result_count += num_results
+
+    if result_count == 0:
+        return len(qubits), "Unit", len(circuits)
+    if result_count == 1:
+        return len(qubits), "Result", len(circuits)
+    return len(qubits), "Result[]", len(circuits)
+
+
+def _visual_circuit_wrapper_source(
+    operation_name: str, wrapper_name: str, qubit_count: int, return_type: str
+) -> str:
+    if qubit_count == 0:
+        allocation = ""
+        call = f"{operation_name}()"
+        reset = ""
+    else:
+        allocation = f"    use qs = Qubit[{qubit_count}];\n"
+        call = f"{operation_name}(qs)"
+        reset = "    ResetAll(qs);\n"
+
+    if return_type == "Unit":
+        return (
+            f"operation {wrapper_name}() : Unit {{\n"
+            f"{allocation}"
+            f"    {call};\n"
+            f"{reset}"
+            "}\n"
+        )
+
+    return (
+        f"operation {wrapper_name}() : {return_type} {{\n"
+        f"{allocation}"
+        f"    let result = {call};\n"
+        f"{reset}"
+        "    return result;\n"
+        "}\n"
+    )
 
 
 def make_class_rec(qsharp_type: TypeIR) -> type:
@@ -154,6 +239,7 @@ class Context:
     code: Any
     _disposed: bool
     _is_global_context: bool
+    _loaded_circuit_count: int
 
     def __init__(
         self,
@@ -189,6 +275,7 @@ class Context:
         self._disposed = False
         self._is_global_context = _is_global_context
         self._target_profile = target_profile
+        self._loaded_circuit_count = 0
 
         if _is_global_context:
             self.code = code
@@ -465,6 +552,47 @@ class Context:
             return
         if getattr(struct_type, "_qdk_context") is not self:
             raise QSharpError("This struct belongs to a different Context. ")
+
+    def load_circuit(self, path: str, *, index: int = 0) -> Callable:
+        """
+        Loads a visual circuit file as a callable in this context.
+
+        :param path: Path to a ``.qsc`` visual circuit file.
+        :keyword index: Index of the circuit to return when the file contains
+            multiple circuits. Defaults to ``0``.
+        :return: A zero-argument Q# callable that allocates the circuit qubits,
+            applies the visual circuit, resets the qubits, and returns any
+            measurement results.
+        :rtype: Callable
+        :raises QSharpError: If the file cannot be read or converted to Q#.
+        """
+        from ._fs import read_file, resolve
+
+        resolved_path = resolve(".", path)
+        try:
+            _, circuit_json = read_file(resolved_path)
+        except Exception as err:
+            raise QSharpError(f"Error reading visual circuit file {resolved_path}.") from err
+
+        qubit_count, return_type, circuit_count = _visual_circuit_signature(
+            circuit_json, index
+        )
+        unique_name = f"{_path_stem(resolved_path)}_{self._loaded_circuit_count}"
+        self._loaded_circuit_count += 1
+
+        operation_name, generated_source = compile_visual_circuit_to_qsharp(
+            unique_name, circuit_json
+        )
+        circuit_operation_name = (
+            operation_name if circuit_count == 1 else f"{operation_name}{index}"
+        )
+        wrapper_name = f"{circuit_operation_name}_Entry"
+        wrapper_source = _visual_circuit_wrapper_source(
+            circuit_operation_name, wrapper_name, qubit_count, return_type
+        )
+
+        self.eval(f"{generated_source}\n{wrapper_source}")
+        return getattr(self.code, wrapper_name)
 
     def eval(
         self,

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -41,6 +41,7 @@ from ._native import (  # type: ignore
     Output,
     Pauli,
     PrimitiveKind,
+    ProgramType,
     QSharpError,
     Result,
     StateDumpData,
@@ -553,20 +554,37 @@ class Context:
         if getattr(struct_type, "_qdk_context") is not self:
             raise QSharpError("This struct belongs to a different Context. ")
 
-    def load_circuit(self, path: str, *, index: int = 0) -> Callable:
+    def import_circuit(
+        self,
+        path: str,
+        *,
+        index: int = 0,
+        program_type: ProgramType = ProgramType.File,
+    ) -> Callable:
         """
-        Loads a visual circuit file as a callable in this context.
+        Imports a visual circuit file as a callable in this context.
 
         :param path: Path to a ``.qsc`` visual circuit file.
         :keyword index: Index of the circuit to return when the file contains
             multiple circuits. Defaults to ``0``.
-        :return: A zero-argument Q# callable that allocates the circuit qubits,
-            applies the visual circuit, resets the qubits, and returns any
-            measurement results.
+        :keyword program_type: Controls how the circuit is imported:
+            ``ProgramType.File`` (default) imports a zero-argument wrapper that
+            allocates the circuit qubits, applies the visual circuit, resets the
+            qubits, and returns any measurement results. ``ProgramType.Operation``
+            imports the visual circuit operation itself, which takes a
+            ``Qubit[]`` argument and is intended for composition from Q# entry
+            expressions.
+        :return: The imported Q# callable.
         :rtype: Callable
         :raises QSharpError: If the file cannot be read or converted to Q#.
         """
         from ._fs import read_file, resolve
+
+        if program_type not in (ProgramType.File, ProgramType.Operation):
+            raise QSharpError(
+                "Visual circuit import supports ProgramType.File and "
+                "ProgramType.Operation only."
+            )
 
         resolved_path = resolve(".", path)
         try:
@@ -586,16 +604,21 @@ class Context:
         circuit_operation_name = (
             operation_name if circuit_count == 1 else f"{operation_name}{index}"
         )
-        wrapper_name = f"{circuit_operation_name}_Entry"
-        wrapper_source = _visual_circuit_wrapper_source(
-            circuit_operation_name, wrapper_name, qubit_count, return_type
-        )
+        eval_source = generated_source
+        callable_name = circuit_operation_name
+        if program_type == ProgramType.File:
+            wrapper_name = f"{circuit_operation_name}_Entry"
+            wrapper_source = _visual_circuit_wrapper_source(
+                circuit_operation_name, wrapper_name, qubit_count, return_type
+            )
+            eval_source = f"{generated_source}\n{wrapper_source}"
+            callable_name = wrapper_name
 
         # generated_source is produced by the native visual-circuit compiler;
-        # wrapper_source is assembled from sanitized operation names and type metadata.
-        eval_source = f"{generated_source}\n{wrapper_source}"
+        # wrapper_source, when present, is assembled from sanitized operation
+        # names and type metadata.
         self.eval(eval_source)  # DevSkim: ignore DS189424
-        return getattr(self.code, wrapper_name)
+        return getattr(self.code, callable_name)
 
     def eval(
         self,

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -620,8 +620,17 @@ class Context:
         )
         eval_source = generated_source
         callable_name = circuit_operation_name
+        helper_callable_names: list[str] = []
         if program_type == ProgramType.File:
             circuit_helper_name = f"{circuit_operation_name}_Operation"
+            helper_callable_names = [
+                (
+                    f"{operation_name}_Operation"
+                    if circuit_count == 1
+                    else f"{operation_name}{helper_index}_Operation"
+                )
+                for helper_index in range(circuit_count)
+            ]
             generated_source = _mark_visual_circuit_operations_internal(
                 generated_source, operation_name, circuit_count
             )
@@ -634,6 +643,9 @@ class Context:
         # wrapper_source, when present, is assembled from sanitized operation
         # names and type metadata.
         self.eval(eval_source)  # DevSkim: ignore DS189424
+        for helper_callable_name in helper_callable_names:
+            if hasattr(self.code, helper_callable_name):
+                delattr(self.code, helper_callable_name)
         return getattr(self.code, callable_name)
 
     def eval(

--- a/source/qdk_package/qdk/_native.pyi
+++ b/source/qdk_package/qdk/_native.pyi
@@ -533,7 +533,10 @@ def physical_estimates(logical_resources: str, params: str) -> str:
     ...
 
 def compile_visual_circuit_to_qsharp(
-    file_name: str, contents: str
+    file_name: str,
+    contents: str,
+    index: int,
+    program_type: ProgramType,
 ) -> Tuple[str, str]:
     """
     Converts a visual circuit file to Q# source.
@@ -545,6 +548,8 @@ def compile_visual_circuit_to_qsharp(
 
     :param file_name: The base name to use for the generated operation.
     :param contents: The visual circuit JSON contents.
+    :param index: The circuit index to import in file mode.
+    :param program_type: The type of Q# source to generate.
     :return: The sanitized operation name and generated Q# source.
     :rtype: Tuple[str, str]
     """

--- a/source/qdk_package/qdk/_native.pyi
+++ b/source/qdk_package/qdk/_native.pyi
@@ -532,6 +532,24 @@ def physical_estimates(logical_resources: str, params: str) -> str:
     """
     ...
 
+def compile_visual_circuit_to_qsharp(
+    file_name: str, contents: str
+) -> Tuple[str, str]:
+    """
+    Converts a visual circuit file to Q# source.
+
+    .. note::
+        This call is not intended to be used directly by the user.
+        It is intended to be used by the Python wrapper which will handle
+        file loading and callable registration.
+
+    :param file_name: The base name to use for the generated operation.
+    :param contents: The visual circuit JSON contents.
+    :return: The sanitized operation name and generated Q# source.
+    :rtype: Tuple[str, str]
+    """
+    ...
+
 def circuit_qasm_program(
     source: str,
     read_file: Callable[[str], Tuple[str, str]],

--- a/source/qdk_package/src/interpreter.rs
+++ b/source/qdk_package/src/interpreter.rs
@@ -15,7 +15,7 @@ use crate::{
     interop::{
         circuit_qasm_program, compile_qasm_program_to_qir, compile_qasm_to_qsharp,
         create_filesystem_from_py, get_operation_name, get_output_semantics, get_program_type,
-        get_search_path, resource_estimate_qasm_program, run_qasm_program,
+        get_search_path, resource_estimate_qasm_program, run_qasm_program, sanitize_name,
     },
     interpreter::data_interop::{
         PrimitiveKind, TypeIR, TypeKind, UdtFields, UdtIR, UdtValue, collect_udt_fields,
@@ -45,7 +45,7 @@ use pyo3::{
 };
 use qsc::{
     LanguageFeatures, PackageType, SourceMap,
-    circuit::TracerConfig,
+    circuit::{TracerConfig, circuits_to_qsharp},
     error::WithSource,
     fir::{self},
     hir::ty::{Prim, Ty},
@@ -152,6 +152,7 @@ fn _native<'a>(py: Python<'a>, m: &Bound<'a, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(circuit_qasm_program, m)?)?;
     m.add_function(wrap_pyfunction!(compile_qasm_program_to_qir, m)?)?;
     m.add_function(wrap_pyfunction!(compile_qasm_to_qsharp, m)?)?;
+    m.add_function(wrap_pyfunction!(compile_visual_circuit_to_qsharp, m)?)?;
     Ok(())
 }
 
@@ -1127,6 +1128,18 @@ fn extract_callable_value(py: Python, callable: &Py<PyAny>) -> PyResult<Value> {
         Err(PyException::new_err(
             "callable must be either a GlobalCallable or a Closure",
         ))
+    }
+}
+
+#[pyfunction]
+pub fn compile_visual_circuit_to_qsharp(
+    file_name: &str,
+    circuit_json: &str,
+) -> PyResult<(String, String)> {
+    let operation_name = sanitize_name(file_name);
+    match circuits_to_qsharp(&operation_name, circuit_json) {
+        Ok(source) => Ok((operation_name, source)),
+        Err(error) => Err(QSharpError::new_err(error)),
     }
 }
 

--- a/source/qdk_package/src/interpreter.rs
+++ b/source/qdk_package/src/interpreter.rs
@@ -45,7 +45,7 @@ use pyo3::{
 };
 use qsc::{
     LanguageFeatures, PackageType, SourceMap,
-    circuit::{TracerConfig, circuits_to_qsharp},
+    circuit::{TracerConfig, circuit_to_standalone_qsharp, circuits_to_qsharp},
     error::WithSource,
     fir::{self},
     hir::ty::{Prim, Ty},
@@ -1135,9 +1135,19 @@ fn extract_callable_value(py: Python, callable: &Py<PyAny>) -> PyResult<Value> {
 pub fn compile_visual_circuit_to_qsharp(
     file_name: &str,
     circuit_json: &str,
+    index: usize,
+    program_type: ProgramType,
 ) -> PyResult<(String, String)> {
     let operation_name = sanitize_name(file_name);
-    match circuits_to_qsharp(&operation_name, circuit_json) {
+    let source = match program_type {
+        ProgramType::File => circuit_to_standalone_qsharp(&operation_name, circuit_json, index),
+        ProgramType::Operation => circuits_to_qsharp(&operation_name, circuit_json),
+        ProgramType::Fragments => Err(
+            "Visual circuit import supports ProgramType.File and ProgramType.Operation only."
+                .to_string(),
+        ),
+    };
+    match source {
         Ok(source) => Ok((operation_name, source)),
         Err(error) => Err(QSharpError::new_err(error)),
     }

--- a/source/qdk_package/tests/test_project.py
+++ b/source/qdk_package/tests/test_project.py
@@ -88,8 +88,6 @@ def test_import_circuit(qsharp) -> None:
     ctx = qdk.Context()
     circuit = ctx.import_circuit("/standalone/circuit.qsc")
     assert circuit is ctx.code.circuit
-    assert not hasattr(ctx.code, "circuit_Entry")
-    assert not hasattr(ctx.code, "circuit_Operation")
     assert ctx.run(circuit, 1) == [qsharp.Result.Zero]
     assert ctx.circuit(circuit) is not None
 
@@ -124,14 +122,31 @@ def test_import_circuit_as_operation(qsharp) -> None:
     assert ctx.run("{ use qs = Qubit[1]; circuit(qs) }", 1) == [qsharp.Result.Zero]
 
 
+def test_import_circuit_as_operation_from_multiple_circuit_file(qsharp) -> None:
+    import qdk
+    from qdk import ProgramType
+
+    ctx = qdk.Context()
+    circuit = ctx.import_circuit(
+        "/standalone/multiple_circuits.qsc",
+        index=1,
+        name="MultiCircuit",
+        program_type=ProgramType.Operation,
+    )
+
+    assert circuit is ctx.code.MultiCircuit1
+    assert ctx.run(
+        "{ use qs = Qubit[1]; MultiCircuit1(qs); let result = M(qs[0]); Reset(qs[0]); result }",
+        1,
+    ) == [qsharp.Result.One]
+
+
 def test_import_circuit_with_name_override(qsharp) -> None:
     import qdk
 
     ctx = qdk.Context()
     circuit = ctx.import_circuit("/standalone/circuit.qsc", name="NamedCircuit")
     assert circuit is ctx.code.NamedCircuit
-    assert not hasattr(ctx.code, "NamedCircuit_Entry")
-    assert not hasattr(ctx.code, "NamedCircuit_Operation")
     assert ctx.run(circuit, 1) == [qsharp.Result.Zero]
     assert ctx.circuit(circuit) is not None
 

--- a/source/qdk_package/tests/test_project.py
+++ b/source/qdk_package/tests/test_project.py
@@ -1,8 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import pytest
+import json
 import os
+
+import pytest
 
 
 @pytest.fixture
@@ -80,6 +82,26 @@ def test_circuit(qsharp) -> None:
     assert result == qsharp.Result.Zero
 
 
+def test_load_circuit(qsharp) -> None:
+    import qdk
+
+    ctx = qdk.Context()
+    circuit = ctx.load_circuit("/standalone/circuit.qsc")
+    assert ctx.run(circuit, 1) == [qsharp.Result.Zero]
+    assert ctx.circuit(circuit) is not None
+
+
+def test_load_circuit_from_multiple_circuit_file(qsharp) -> None:
+    import qdk
+
+    ctx = qdk.Context()
+    first_circuit = ctx.load_circuit("/standalone/multiple_circuits.qsc")
+    second_circuit = ctx.load_circuit("/standalone/multiple_circuits.qsc", index=1)
+
+    assert ctx.run(first_circuit, 1) == [qsharp.Result.Zero]
+    assert ctx.run(second_circuit, 1) == [qsharp.Result.One]
+
+
 def test_src_package_udt(qsharp) -> None:
     import qdk.code
 
@@ -93,6 +115,23 @@ with open(
     os.path.join(os.path.dirname(__file__), "circuit.qsc"), "r", encoding="utf-8"
 ) as f:
     circuit_qsc_contents = f.read()
+
+multiple_circuits = json.loads(circuit_qsc_contents)
+second_circuit = json.loads(circuit_qsc_contents)["circuits"][0]
+second_circuit["componentGrid"].insert(
+    0,
+    {
+        "components": [
+            {
+                "kind": "unitary",
+                "gate": "X",
+                "targets": [{"qubit": 0}],
+            }
+        ]
+    },
+)
+multiple_circuits["circuits"].append(second_circuit)
+multiple_circuits_qsc_contents = json.dumps(multiple_circuits)
 
 memfs = {
     "": {
@@ -181,6 +220,10 @@ memfs = {
                 "circuit.qsc": circuit_qsc_contents,
             },
             "qsharp.json": "{}",
+        },
+        "standalone": {
+            "circuit.qsc": circuit_qsc_contents,
+            "multiple_circuits.qsc": multiple_circuits_qsc_contents,
         },
     }
 }

--- a/source/qdk_package/tests/test_project.py
+++ b/source/qdk_package/tests/test_project.py
@@ -82,24 +82,36 @@ def test_circuit(qsharp) -> None:
     assert result == qsharp.Result.Zero
 
 
-def test_load_circuit(qsharp) -> None:
+def test_import_circuit(qsharp) -> None:
     import qdk
 
     ctx = qdk.Context()
-    circuit = ctx.load_circuit("/standalone/circuit.qsc")
+    circuit = ctx.import_circuit("/standalone/circuit.qsc")
     assert ctx.run(circuit, 1) == [qsharp.Result.Zero]
     assert ctx.circuit(circuit) is not None
 
 
-def test_load_circuit_from_multiple_circuit_file(qsharp) -> None:
+def test_import_circuit_from_multiple_circuit_file(qsharp) -> None:
     import qdk
 
     ctx = qdk.Context()
-    first_circuit = ctx.load_circuit("/standalone/multiple_circuits.qsc")
-    second_circuit = ctx.load_circuit("/standalone/multiple_circuits.qsc", index=1)
+    first_circuit = ctx.import_circuit("/standalone/multiple_circuits.qsc")
+    second_circuit = ctx.import_circuit("/standalone/multiple_circuits.qsc", index=1)
 
     assert ctx.run(first_circuit, 1) == [qsharp.Result.Zero]
     assert ctx.run(second_circuit, 1) == [qsharp.Result.One]
+
+
+def test_import_circuit_as_operation(qsharp) -> None:
+    import qdk
+    from qdk._native import ProgramType
+
+    ctx = qdk.Context()
+    circuit = ctx.import_circuit(
+        "/standalone/circuit.qsc", program_type=ProgramType.Operation
+    )
+    assert circuit is not None
+    assert ctx.run("{ use qs = Qubit[1]; circuit_0(qs) }", 1) == [qsharp.Result.Zero]
 
 
 def test_src_package_udt(qsharp) -> None:

--- a/source/qdk_package/tests/test_project.py
+++ b/source/qdk_package/tests/test_project.py
@@ -98,9 +98,16 @@ def test_import_circuit_from_multiple_circuit_file(qsharp) -> None:
     import qdk
 
     ctx = qdk.Context()
-    first_circuit = ctx.import_circuit("/standalone/multiple_circuits.qsc")
-    second_circuit = ctx.import_circuit("/standalone/multiple_circuits.qsc", index=1)
+    first_circuit = ctx.import_circuit(
+        "/standalone/multiple_circuits.qsc", name="FirstCircuit"
+    )
+    assert first_circuit is ctx.code.FirstCircuit
 
+    second_circuit = ctx.import_circuit(
+        "/standalone/multiple_circuits.qsc", index=1, name="SecondCircuit"
+    )
+
+    assert second_circuit is ctx.code.SecondCircuit
     assert ctx.run(first_circuit, 1) == [qsharp.Result.Zero]
     assert ctx.run(second_circuit, 1) == [qsharp.Result.One]
 

--- a/source/qdk_package/tests/test_project.py
+++ b/source/qdk_package/tests/test_project.py
@@ -87,6 +87,9 @@ def test_import_circuit(qsharp) -> None:
 
     ctx = qdk.Context()
     circuit = ctx.import_circuit("/standalone/circuit.qsc")
+    assert circuit is ctx.code.circuit
+    assert not hasattr(ctx.code, "circuit_Entry")
+    assert not hasattr(ctx.code, "circuit_Operation")
     assert ctx.run(circuit, 1) == [qsharp.Result.Zero]
     assert ctx.circuit(circuit) is not None
 
@@ -110,7 +113,7 @@ def test_import_circuit_as_operation(qsharp) -> None:
     circuit = ctx.import_circuit(
         "/standalone/circuit.qsc", program_type=ProgramType.Operation
     )
-    assert circuit is not None
+    assert circuit is ctx.code.circuit
     assert ctx.run("{ use qs = Qubit[1]; circuit(qs) }", 1) == [qsharp.Result.Zero]
 
 
@@ -119,6 +122,9 @@ def test_import_circuit_with_name_override(qsharp) -> None:
 
     ctx = qdk.Context()
     circuit = ctx.import_circuit("/standalone/circuit.qsc", name="NamedCircuit")
+    assert circuit is ctx.code.NamedCircuit
+    assert not hasattr(ctx.code, "NamedCircuit_Entry")
+    assert not hasattr(ctx.code, "NamedCircuit_Operation")
     assert ctx.run(circuit, 1) == [qsharp.Result.Zero]
     assert ctx.circuit(circuit) is not None
 

--- a/source/qdk_package/tests/test_project.py
+++ b/source/qdk_package/tests/test_project.py
@@ -104,14 +104,23 @@ def test_import_circuit_from_multiple_circuit_file(qsharp) -> None:
 
 def test_import_circuit_as_operation(qsharp) -> None:
     import qdk
-    from qdk._native import ProgramType
+    from qdk import ProgramType
 
     ctx = qdk.Context()
     circuit = ctx.import_circuit(
         "/standalone/circuit.qsc", program_type=ProgramType.Operation
     )
     assert circuit is not None
-    assert ctx.run("{ use qs = Qubit[1]; circuit_0(qs) }", 1) == [qsharp.Result.Zero]
+    assert ctx.run("{ use qs = Qubit[1]; circuit(qs) }", 1) == [qsharp.Result.Zero]
+
+
+def test_import_circuit_with_name_override(qsharp) -> None:
+    import qdk
+
+    ctx = qdk.Context()
+    circuit = ctx.import_circuit("/standalone/circuit.qsc", name="NamedCircuit")
+    assert ctx.run(circuit, 1) == [qsharp.Result.Zero]
+    assert ctx.circuit(circuit) is not None
 
 
 def test_src_package_udt(qsharp) -> None:


### PR DESCRIPTION
Fixes #3232.

## Summary

- add `Context.import_circuit(path, *, index=0, name=None, program_type=ProgramType.File)` for standalone `.qsc` visual-circuit files
- support selecting a circuit from multi-circuit `.qsc` files with `index=0` by default
- default `ProgramType.File` imports a single zero-argument Q# operation named from the file stem, or from the optional `name=` override, suitable for `ctx.run(...)` and `ctx.circuit(...)`
- support `ProgramType.Operation` for registering the qubit-taking circuit operation directly so it can be composed from Q# entry expressions
- generate the standalone File-mode Q# operation in the native Rust layer via `qsc_circuit`, avoiding Python-side helper/wrapper cleanup and avoiding extra public helper callables in `qdk.code`
- re-export `ProgramType` from `qdk` for the new import mode selection
- cover direct visual-circuit import, multi-circuit selection, Operation mode, and explicit name override in Python tests; add native `qsc_circuit` tests for standalone Q# generation

## AI Assistance Disclosure

I used Codex to help inspect the existing QDK visual-circuit conversion path, draft the Python/Rust integration changes, respond to review feedback, and prepare tests. I manually reviewed the patch and verified it locally with the checks below.

## Testing

Latest post-rebase validation on `66e996fe5`:

```bash
./build.py --qdk --test --no-check-prereqs --no-check
```

Result: the QDK Python wheel built successfully, and the Python package test suite completed with `1401 passed, 84 skipped, 1 xfailed`.

Additional targeted checks run during the native Rust-layer refactor:

```bash
RUSTUP_HOME=/Users/bytedance/Library/Caches/puccinialin/rustup CARGO_HOME=/Users/bytedance/Library/Caches/puccinialin/cargo cargo fmt --check --all
cargo test -p qsc_circuit circuit_to_qsharp
source/qdk_package/.venv/bin/python -m pytest source/qdk_package/tests/test_project.py -k import_circuit -q
python3 -m py_compile source/qdk_package/qdk/_context.py source/qdk_package/qdk/__init__.py source/qdk_package/qdk/_native.pyi source/qdk_package/tests/test_project.py
git diff --check
```