### PR TITLE
Support OpenQASM samples in the playground

### DIFF
--- a/source/playground/src/editor.tsx
+++ b/source/playground/src/editor.tsx
@@ -20,6 +20,15 @@ import { codeToCompressedBase64, lsRangeToMonacoRange } from "./utils.js";
 import { ActiveTab } from "./main.js";
 
 import type { KataSection } from "qsharp-lang/katas";
+import type { ProjectType } from "qsharp-lang";
+
+type DiagnosticRelatedInformation = {
+  location: {
+    source: string;
+    span: Parameters<typeof lsRangeToMonacoRange>[0];
+  };
+  message: string;
+};
 
 type ErrCollection = {
   checkDiags: VSDiagnostic[];
@@ -50,14 +59,16 @@ function VSDiagsToMarkers(errors: VSDiagnostic[]): monaco.editor.IMarkerData[] {
       message: err.message,
       // LSP DiagnosticTag values match monaco's MarkerTag (1 = Unnecessary).
       tags: err.tags as monaco.MarkerTag[] | undefined,
-      relatedInformation: err.related?.map((r) => {
-        const range = lsRangeToMonacoRange(r.location.span);
-        return {
-          resource: monaco.Uri.parse(r.location.source),
-          message: r.message,
-          ...range,
-        };
-      }),
+      relatedInformation: err.related?.map(
+        (r: DiagnosticRelatedInformation) => {
+          const range = lsRangeToMonacoRange(r.location.span);
+          return {
+            resource: monaco.Uri.parse(r.location.source),
+            message: r.message,
+            ...range,
+          };
+        },
+      ),
     };
 
     if (err.uri && err.code) {
@@ -75,6 +86,7 @@ function VSDiagsToMarkers(errors: VSDiagnostic[]): monaco.editor.IMarkerData[] {
 
 export function Editor(props: {
   code: string;
+  languageId?: "qsharp" | "openqasm";
   compiler: ICompilerWorker;
   compiler_worker_factory: () => ICompilerWorker;
   compilerState: CompilerState;
@@ -106,6 +118,10 @@ export function Editor(props: {
     { location: string; severity: monaco.MarkerSeverity; msg: string[] }[]
   >([]);
   const [hasCheckErrors, setHasCheckErrors] = useState(false);
+  const languageId = props.languageId ?? "qsharp";
+  const sourceName = languageId === "openqasm" ? "main.qasm" : "main.qs";
+  const projectType: ProjectType = languageId;
+  const canShowQSharpIr = languageId === "qsharp";
 
   function markErrors() {
     const model = editor.current?.getModel();
@@ -117,14 +133,14 @@ export function Editor(props: {
     ];
 
     const markers = VSDiagsToMarkers(errs);
-    monaco.editor.setModelMarkers(model, "qsharp", markers);
+    monaco.editor.setModelMarkers(model, languageId, markers);
 
     const errList = markers
       // Hints (e.g. grayed-out excluded code) are shown inline only, not in the
       // diagnostics list below the editor, mirroring VS Code's Problems view.
       .filter((err) => err.severity !== monaco.MarkerSeverity.Hint)
       .map((err) => ({
-        location: `main.qs@(${err.startLineNumber},${err.startColumn})`,
+        location: `${sourceName}@(${err.startLineNumber},${err.startColumn})`,
         severity: err.severity,
         msg: err.message.split("\n\n"),
       }));
@@ -136,21 +152,26 @@ export function Editor(props: {
     if (code == null) return;
 
     const config = {
-      sources: [["code", code]] as [string, string][],
+      sources: [[sourceName, code]] as [string, string][],
       languageFeatures: [],
       profile:
-        (await getTargetProfileFromEntryPoint("main.qs", code)) ||
-        "adaptive_rif", // Default to adaptive_rif for qir and rir generation
+        (languageId === "qsharp"
+          ? await getTargetProfileFromEntryPoint(sourceName, code)
+          : undefined) || "adaptive_rif", // Default to adaptive_rif for qir and rir generation
+      projectType,
     };
 
-    if (props.activeTab === "ast-tab") {
+    if (props.activeTab === "ast-tab" && canShowQSharpIr) {
       props.setAst(await props.compiler.getAst(code, config.languageFeatures));
     }
-    if (props.activeTab === "hir-tab") {
+    if (props.activeTab === "hir-tab" && canShowQSharpIr) {
       props.setHir(await props.compiler.getHir(code, config.languageFeatures));
     }
     const codeGenTimeout = 1000; // ms
-    if (props.activeTab === "qir-tab" || props.activeTab === "rir-tab") {
+    if (
+      props.activeTab === "qir-tab" ||
+      (props.activeTab === "rir-tab" && canShowQSharpIr)
+    ) {
       let timedOut = false;
       const compiler = props.compiler_worker_factory();
       const compilerTimeout = setTimeout(() => {
@@ -193,9 +214,13 @@ export function Editor(props: {
     if (code == null) return;
     props.evtTarget.clearResults();
     const config = {
-      sources: [["code", code]],
+      sources: [[sourceName, code]],
       languageFeatures: [],
-      profile: await getTargetProfileFromEntryPoint("main.qs", code),
+      profile:
+        languageId === "qsharp"
+          ? await getTargetProfileFromEntryPoint(sourceName, code)
+          : undefined,
+      projectType,
     } as ProgramConfig;
 
     try {
@@ -246,16 +271,23 @@ export function Editor(props: {
     editor.current = newEditor;
     const srcModel =
       monaco.editor.getModel(
-        monaco.Uri.parse(props.kataSection?.id ?? "main.qs"),
+        monaco.Uri.parse(props.kataSection?.id ?? sourceName),
       ) ??
       monaco.editor.createModel(
         "",
-        "qsharp",
-        monaco.Uri.parse(props.kataSection?.id ?? "main.qs"),
+        languageId,
+        monaco.Uri.parse(props.kataSection?.id ?? sourceName),
       );
     srcModel.setValue(props.code);
     newEditor.setModel(srcModel);
     srcModel.onDidChangeContent(() => irRef.current());
+
+    props.languageService.updateDocument(
+      srcModel.uri.toString(),
+      srcModel.getVersionId(),
+      srcModel.getValue(),
+      languageId,
+    );
 
     // TODO: If the language service ever changes, this callback
     // will be invalid as it captures the *original* props.languageService
@@ -272,6 +304,7 @@ export function Editor(props: {
         srcModel.uri.toString(),
         srcModel.getVersionId(),
         srcModel.getValue(),
+        languageId,
       );
       const measure = performance.measure(
         "update-document",
@@ -289,10 +322,10 @@ export function Editor(props: {
     return () => {
       log.info("Disposing a monaco editor");
       window.removeEventListener("resize", onResize);
-      props.languageService.closeDocument(srcModel.uri.toString());
+      props.languageService.closeDocument(srcModel.uri.toString(), languageId);
       newEditor.dispose();
     };
-  }, []);
+  }, [languageId, sourceName]);
 
   useEffect(() => {
     props.languageService.updateConfiguration({
@@ -359,6 +392,7 @@ export function Editor(props: {
       // Update or add the current URL parameter 'code'
       const newURL = new URL(window.location.href);
       newURL.searchParams.set("code", escapedCode);
+      newURL.searchParams.set("language", languageId);
 
       // Copy link to clipboard and update url without reloading the page
       navigator.clipboard.writeText(newURL.toString());
@@ -391,7 +425,7 @@ export function Editor(props: {
   return (
     <div class="editor-column">
       <div style="display: flex; justify-content: space-between; align-items: center;">
-        <div class="file-name">main.qs</div>
+        <div class="file-name">{sourceName}</div>
         <div class="icon-row">
           <svg
             onClick={onGetLink}

--- a/source/playground/src/main.tsx
+++ b/source/playground/src/main.tsx
@@ -12,6 +12,7 @@ import type {
   VSDiagnostic,
   LogLevel,
   ILanguageService,
+  IRange,
 } from "qsharp-lang";
 
 import {
@@ -19,6 +20,7 @@ import {
   getCompilerWorker,
   loadWasmModule,
   log,
+  openqasm_samples,
   samples,
   getLanguageServiceWorker,
 } from "qsharp-lang";
@@ -69,6 +71,35 @@ const modulePath = basePath + "libs/qsharp/qsc_wasm_bg.wasm";
 const compilerWorkerPath = basePath + "libs/compiler-worker.js";
 const languageServiceWorkerPath = basePath + "libs/language-service-worker.js";
 
+type CompletionItem = {
+  label: string;
+  kind:
+    | "function"
+    | "interface"
+    | "keyword"
+    | "module"
+    | "property"
+    | "variable"
+    | "typeParameter"
+    | "field"
+    | "class";
+  sortText?: string;
+  detail?: string;
+  additionalTextEdits?: {
+    range: IRange;
+    newText: string;
+  }[];
+};
+
+type SignatureInformation = {
+  label: string;
+  documentation: string;
+  parameters: {
+    label: string;
+    documentation: string;
+  }[];
+};
+
 function telemetryHandler({ id, data }: { id: string; data?: any }) {
   // NOTE: This is for demo purposes. Wire up to the real telemetry library.
   console.log(`Received telemetry event: "%s" with payload: %o`, id, data);
@@ -81,7 +112,11 @@ function createCompiler(onStateChange: (val: CompilerState) => void) {
   return compiler;
 }
 
-function App(props: { katas: Kata[]; linkedCode?: string }) {
+function App(props: {
+  katas: Kata[];
+  linkedCode?: string;
+  linkedLanguage?: "qsharp" | "openqasm";
+}) {
   const [compilerState, setCompilerState] = useState<CompilerState>("idle");
   const [compiler, setCompiler] = useState(() =>
     createCompiler(setCompilerState),
@@ -101,7 +136,11 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
   });
 
   const [currentNavItem, setCurrentNavItem] = useState(
-    props.linkedCode ? "linked" : "sample-Minimal",
+    props.linkedCode
+      ? props.linkedLanguage === "openqasm"
+        ? "openqasm-linked"
+        : "linked"
+      : "sample-Minimal",
   );
   const [shotError, setShotError] = useState<VSDiagnostic | undefined>(
     undefined,
@@ -122,6 +161,7 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
 
   const kataTitles = props.katas.map((elem) => elem.title);
   const sampleTitles = samples.map((sample) => sample.title);
+  const openQasmSampleTitles = openqasm_samples.map((sample) => sample.title);
 
   const [documentation, setDocumentation] = useState<
     Map<string, string> | undefined
@@ -136,10 +176,35 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
 
   const sampleCode =
     samples.find((sample) => "sample-" + sample.title === currentNavItem)
-      ?.code || props.linkedCode;
+      ?.code ||
+    openqasm_samples.find(
+      (sample) => "openqasm-sample-" + sample.title === currentNavItem,
+    )?.code ||
+    props.linkedCode;
 
   const defaultShots =
-    samples.find((sample) => sample.title === currentNavItem)?.shots || 100;
+    samples.find((sample) => "sample-" + sample.title === currentNavItem)
+      ?.shots ||
+    openqasm_samples.find(
+      (sample) => "openqasm-sample-" + sample.title === currentNavItem,
+    )?.shots ||
+    100;
+
+  const languageId =
+    currentNavItem.startsWith("openqasm-sample-") ||
+    currentNavItem === "openqasm-linked"
+      ? "openqasm"
+      : "qsharp";
+
+  useEffect(() => {
+    if (
+      languageId === "openqasm" &&
+      activeTab !== "results-tab" &&
+      activeTab !== "qir-tab"
+    ) {
+      setActiveTab("results-tab");
+    }
+  }, [activeTab, languageId]);
 
   const activeKata = kataTitles.includes(currentNavItem)
     ? props.katas.find((kata) => kata.title === currentNavItem)
@@ -165,12 +230,14 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
         navSelected={onNavItemSelected}
         katas={kataTitles}
         samples={sampleTitles}
+        openQasmSamples={openQasmSampleTitles}
         namespaces={getNamespaces(documentation)}
       ></Nav>
       {sampleCode ? (
         <>
           <Editor
             code={sampleCode}
+            languageId={languageId}
             compiler={compiler}
             compiler_worker_factory={compiler_worker_factory}
             compilerState={compilerState}
@@ -191,6 +258,7 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
             evtTarget={evtTarget}
             showPanel={true}
             onShotError={(diag?: VSDiagnostic) => setShotError(diag)}
+            languageId={languageId}
             ast={ast}
             hir={hir}
             rir={rir}
@@ -233,92 +301,290 @@ async function loaded() {
   log.setTelemetryCollector(telemetryHandler);
 
   await loadWasmModule(modulePath);
+  registerOpenQasmMonacoLanguage();
 
   const katas = await getAllKatas({ includeUnpublished: true });
 
   // If URL is a sharing link, populate the editor with the code from the link.
   // Otherwise, populate with sample code.
   let linkedCode: string | undefined;
+  let linkedLanguage: "qsharp" | "openqasm" | undefined;
   const paramCode = new URLSearchParams(window.location.search).get("code");
   if (paramCode) {
     try {
       const base64code = decodeURIComponent(paramCode);
       linkedCode = await compressedBase64ToCode(base64code);
+      linkedLanguage =
+        new URLSearchParams(window.location.search).get("language") ===
+        "openqasm"
+          ? "openqasm"
+          : "qsharp";
     } catch {
       linkedCode = "// Unable to decode the code in the URL\n";
     }
   }
 
-  render(<App katas={katas} linkedCode={linkedCode}></App>, document.body);
+  render(
+    <App
+      katas={katas}
+      linkedCode={linkedCode}
+      linkedLanguage={linkedLanguage}
+    ></App>,
+    document.body,
+  );
+}
+
+function registerOpenQasmMonacoLanguage() {
+  monaco.languages.register({
+    id: "openqasm",
+    extensions: [".qasm", ".inc"],
+    aliases: ["OpenQASM", "openqasm"],
+  });
+
+  monaco.languages.setLanguageConfiguration("openqasm", {
+    comments: {
+      lineComment: "//",
+      blockComment: ["/*", "*/"],
+    },
+    brackets: [
+      ["[", "]"],
+      ["(", ")"],
+      ["{", "}"],
+    ],
+    autoClosingPairs: [
+      { open: "[", close: "]" },
+      { open: "(", close: ")" },
+      { open: "{", close: "}" },
+      { open: "'", close: "'" },
+      { open: '"', close: '"', notIn: ["string"] },
+    ],
+    surroundingPairs: [
+      { open: "[", close: "]" },
+      { open: "(", close: ")" },
+      { open: "{", close: "}" },
+      { open: "'", close: "'" },
+      { open: '"', close: '"' },
+    ],
+  });
+
+  monaco.languages.setMonarchTokensProvider("openqasm", {
+    defaultToken: "",
+    tokenPostfix: ".openqasm",
+    keywords: [
+      "OPENQASM",
+      "array",
+      "barrier",
+      "bit",
+      "bool",
+      "box",
+      "cal",
+      "complex",
+      "const",
+      "creg",
+      "def",
+      "defcal",
+      "defcalgrammar",
+      "delay",
+      "duration",
+      "else",
+      "extern",
+      "float",
+      "for",
+      "frame",
+      "gate",
+      "if",
+      "include",
+      "input",
+      "int",
+      "let",
+      "measure",
+      "mutable",
+      "output",
+      "port",
+      "pragma",
+      "qreg",
+      "qubit",
+      "readonly",
+      "reset",
+      "return",
+      "stretch",
+      "switch",
+      "uint",
+      "waveform",
+      "while",
+    ],
+    constants: [
+      "euler",
+      "false",
+      "lambda",
+      "phi",
+      "pi",
+      "tau",
+      "theta",
+      "true",
+    ],
+    typeKeywords: [
+      "angle",
+      "bit",
+      "bool",
+      "complex",
+      "creg",
+      "duration",
+      "float",
+      "int",
+      "qreg",
+      "qubit",
+      "stretch",
+      "uint",
+    ],
+    operators: [
+      "=",
+      ">",
+      "<",
+      "!",
+      "~",
+      "?",
+      ":",
+      "==",
+      "<=",
+      ">=",
+      "!=",
+      "&&",
+      "||",
+      "++",
+      "--",
+      "+",
+      "-",
+      "*",
+      "/",
+      "&",
+      "|",
+      "^",
+      "%",
+      "<<",
+      ">>",
+      "**",
+    ],
+    symbols: /[=><!~?:&|+\-*/^%]+/,
+    escapes: /\\(?:[btnfr"\\]|u[0-9A-Fa-f]{4})/,
+    tokenizer: {
+      root: [
+        [
+          /[a-zA-Z_][\w_]*/,
+          {
+            cases: {
+              "@typeKeywords": "type",
+              "@keywords": "keyword",
+              "@constants": "constant",
+              "@default": "identifier",
+            },
+          },
+        ],
+        [/[{}()[\]]/, "@brackets"],
+        [
+          /@symbols/,
+          {
+            cases: {
+              "@operators": "operator",
+              "@default": "",
+            },
+          },
+        ],
+        [
+          /\d[\d_]*(\.\d[\d_]*)?([eE][+-]?\d[\d_]*)?(im|dt|ns|us|ms|s)?/,
+          "number",
+        ],
+        [/"/, "string", "@string"],
+        [/\/\/.*$/, "comment"],
+        [/\/\*/, "comment", "@comment"],
+      ],
+      comment: [
+        [/[^/*]+/, "comment"],
+        [/\*\//, "comment", "@pop"],
+        [/[/*]/, "comment"],
+      ],
+      string: [
+        [/[^\\"]+/, "string"],
+        [/@escapes/, "string.escape"],
+        [/\\./, "string.escape.invalid"],
+        [/"/, "string", "@pop"],
+      ],
+    },
+  });
 }
 
 function registerMonacoLanguageServiceProviders(
   languageService: ILanguageService,
 ) {
+  async function getCompletionItems(
+    model: monaco.editor.ITextModel,
+    position: monaco.Position,
+  ) {
+    const completions = await languageService.getCompletions(
+      model.uri.toString(),
+      monacoPositionToLsPosition(position),
+    );
+    return {
+      suggestions: completions.items.map((i: CompletionItem) => {
+        let kind;
+        switch (i.kind) {
+          case "function":
+            kind = monaco.languages.CompletionItemKind.Function;
+            break;
+          case "interface":
+            kind = monaco.languages.CompletionItemKind.Interface;
+            break;
+          case "keyword":
+            kind = monaco.languages.CompletionItemKind.Keyword;
+            break;
+          case "variable":
+            kind = monaco.languages.CompletionItemKind.Variable;
+            break;
+          case "typeParameter":
+            kind = monaco.languages.CompletionItemKind.TypeParameter;
+            break;
+          case "module":
+            kind = monaco.languages.CompletionItemKind.Module;
+            break;
+          case "property":
+            kind = monaco.languages.CompletionItemKind.Property;
+            break;
+          case "field":
+            kind = monaco.languages.CompletionItemKind.Field;
+            break;
+          case "class":
+            kind = monaco.languages.CompletionItemKind.Class;
+            break;
+        }
+        return {
+          label: i.label,
+          kind: kind,
+          insertText: i.label,
+          sortText: i.sortText,
+          detail: i.detail,
+          additionalTextEdits: i.additionalTextEdits?.map((edit) => {
+            const range = edit.range;
+            const textEdit: monaco.languages.TextEdit = {
+              range: lsRangeToMonacoRange(range),
+              text: edit.newText,
+            };
+            return textEdit;
+          }),
+          range: undefined,
+        };
+      }),
+    };
+  }
+
   monaco.languages.registerCompletionItemProvider("qsharp", {
-    // @ts-expect-error - Monaco's types expect range to be defined,
-    // but it's actually optional and the default behavior is better
-    provideCompletionItems: async (
-      model: monaco.editor.ITextModel,
-      position: monaco.Position,
-    ) => {
-      const completions = await languageService.getCompletions(
-        model.uri.toString(),
-        monacoPositionToLsPosition(position),
-      );
-      return {
-        suggestions: completions.items.map((i) => {
-          let kind;
-          switch (i.kind) {
-            case "function":
-              kind = monaco.languages.CompletionItemKind.Function;
-              break;
-            case "interface":
-              kind = monaco.languages.CompletionItemKind.Interface;
-              break;
-            case "keyword":
-              kind = monaco.languages.CompletionItemKind.Keyword;
-              break;
-            case "variable":
-              kind = monaco.languages.CompletionItemKind.Variable;
-              break;
-            case "typeParameter":
-              kind = monaco.languages.CompletionItemKind.TypeParameter;
-              break;
-            case "module":
-              kind = monaco.languages.CompletionItemKind.Module;
-              break;
-            case "property":
-              kind = monaco.languages.CompletionItemKind.Property;
-              break;
-            case "field":
-              kind = monaco.languages.CompletionItemKind.Field;
-              break;
-            case "class":
-              kind = monaco.languages.CompletionItemKind.Class;
-              break;
-          }
-          return {
-            label: i.label,
-            kind: kind,
-            insertText: i.label,
-            sortText: i.sortText,
-            detail: i.detail,
-            additionalTextEdits: i.additionalTextEdits?.map((edit) => {
-              const range = edit.range;
-              const textEdit: monaco.languages.TextEdit = {
-                range: lsRangeToMonacoRange(range),
-                text: edit.newText,
-              };
-              return textEdit;
-            }),
-            range: undefined,
-          };
-        }),
-      };
-    },
+    provideCompletionItems: getCompletionItems,
     // Trigger characters should be kept in sync with the ones in `vscode/src/extension.ts`
     triggerCharacters: ["@", "."],
+  });
+
+  monaco.languages.registerCompletionItemProvider("openqasm", {
+    provideCompletionItems: getCompletionItems,
+    triggerCharacters: ["@", "["],
   });
 
   monaco.languages.registerHoverProvider("qsharp", {
@@ -341,7 +607,7 @@ function registerMonacoLanguageServiceProviders(
     },
   });
 
-  monaco.languages.registerDefinitionProvider("qsharp", {
+  monaco.languages.registerDefinitionProvider(["qsharp", "openqasm"], {
     provideDefinition: async (
       model: monaco.editor.ITextModel,
       position: monaco.Position,
@@ -360,7 +626,7 @@ function registerMonacoLanguageServiceProviders(
     },
   });
 
-  monaco.languages.registerReferenceProvider("qsharp", {
+  monaco.languages.registerReferenceProvider(["qsharp", "openqasm"], {
     provideReferences: async (
       model: monaco.editor.ITextModel,
       position: monaco.Position,
@@ -403,7 +669,7 @@ function registerMonacoLanguageServiceProviders(
         value: {
           activeParameter: sigHelpLs.activeParameter,
           activeSignature: sigHelpLs.activeSignature,
-          signatures: sigHelpLs.signatures.map((sig) => {
+          signatures: sigHelpLs.signatures.map((sig: SignatureInformation) => {
             return {
               label: sig.label,
               documentation: {
@@ -424,7 +690,7 @@ function registerMonacoLanguageServiceProviders(
     },
   });
 
-  monaco.languages.registerRenameProvider("qsharp", {
+  monaco.languages.registerRenameProvider(["qsharp", "openqasm"], {
     provideRenameEdits: async (
       model: monaco.editor.ITextModel,
       position: monaco.Position,

--- a/source/playground/src/nav.tsx
+++ b/source/playground/src/nav.tsx
@@ -6,6 +6,7 @@ export function Nav(props: {
   navSelected: (name: string) => void;
   katas: string[];
   samples: string[];
+  openQasmSamples: string[];
   namespaces: string[];
 }) {
   function onSelected(name: string) {
@@ -23,6 +24,19 @@ export function Nav(props: {
             (props.selected === "sample-" + name ? " nav-current" : "")
           }
           onClick={() => onSelected("sample-" + name)}
+        >
+          {name}
+        </div>
+      ))}
+
+      <div class="nav-1">OpenQASM Samples</div>
+      {props.openQasmSamples.map((name) => (
+        <div
+          class={
+            "nav-2 nav-selectable" +
+            (props.selected === "openqasm-sample-" + name ? " nav-current" : "")
+          }
+          onClick={() => onSelected("openqasm-sample-" + name)}
         >
           {name}
         </div>

--- a/source/playground/src/tabs.tsx
+++ b/source/playground/src/tabs.tsx
@@ -57,6 +57,7 @@ export function OutputTabs(props: {
   showPanel: boolean;
   onShotError?: (err?: VSDiagnostic) => void;
   kataMode?: boolean;
+  languageId?: "qsharp" | "openqasm";
   ast: string;
   hir: string;
   rir: string[];
@@ -68,14 +69,21 @@ export function OutputTabs(props: {
     <div class="results-column">
       {props.showPanel ? (
         <div class="results-labels">
-          {tabArray.map((elem) => (
-            <div
-              onClick={() => props.setActiveTab(elem[0])}
-              class={props.activeTab === elem[0] ? "active-tab" : ""}
-            >
-              {elem[1]}
-            </div>
-          ))}
+          {tabArray
+            .filter(
+              ([tab]) =>
+                props.languageId !== "openqasm" ||
+                tab === "results-tab" ||
+                tab === "qir-tab",
+            )
+            .map((elem) => (
+              <div
+                onClick={() => props.setActiveTab(elem[0])}
+                class={props.activeTab === elem[0] ? "active-tab" : ""}
+              >
+                {elem[1]}
+              </div>
+            ))}
         </div>
       ) : null}
       <ResultsTab {...props} />

--- a/source/playground/src/utils.ts
+++ b/source/playground/src/utils.ts
@@ -3,6 +3,8 @@
 
 import { IPosition, IRange, IWorkspaceEdit } from "qsharp-lang";
 
+type WorkspaceChange = [string, { range: IRange; newText: string }[]];
+
 // Utility functions to convert source code to and from base64.
 //
 // The btoa function expects a string of bytes (i.e. in the range x00 - xFF), however
@@ -112,17 +114,19 @@ export function monacoRangetoLsRange(range: monaco.Range): IRange {
 export function lsToMonacoWorkspaceEdit(
   iWorkspaceEdit: IWorkspaceEdit,
 ): monaco.languages.WorkspaceEdit {
-  const edits = iWorkspaceEdit.changes.flatMap(([uri, edits]) => {
-    return edits.map((edit) => {
-      const textEdit: monaco.languages.TextEdit = {
-        range: lsRangeToMonacoRange(edit.range),
-        text: edit.newText,
-      };
-      return {
-        resource: monaco.Uri.parse(uri),
-        textEdit: textEdit,
-      } as monaco.languages.IWorkspaceTextEdit;
-    });
-  });
+  const edits = (iWorkspaceEdit.changes as WorkspaceChange[]).flatMap(
+    ([uri, edits]) => {
+      return edits.map((edit) => {
+        const textEdit: monaco.languages.TextEdit = {
+          range: lsRangeToMonacoRange(edit.range),
+          text: edit.newText,
+        };
+        return {
+          resource: monaco.Uri.parse(uri),
+          textEdit: textEdit,
+        } as monaco.languages.IWorkspaceTextEdit;
+      });
+    },
+  );
   return { edits: edits } as monaco.languages.WorkspaceEdit;
 }


### PR DESCRIPTION
## Summary

Fixes #3233.

This wires the existing OpenQASM support into the browser playground:

- adds OpenQASM samples to the navigation
- registers a basic Monaco OpenQASM language and tokenizer
- passes `languageId: "openqasm"` to the language service
- passes `projectType: "openqasm"` to compiler worker calls
- uses `main.qasm` for OpenQASM editor models
- keeps OpenQASM output tabs to Results and QIR
- preserves the selected language in shared playground links

## Validation

- `npm --workspace ./source/npm/qsharp run generate`
- `npm --workspace ./source/playground run tsc:check`

I also attempted the full local build path. The repository currently expects Node >= 22.14.0; after using Node 22.14.0 locally, the full `python3 ./build.py --wasm --npm --play --no-test` path stopped because this environment does not have the Rust/cargo toolchain installed.

## AI assistance disclosure

I used AI assistance to inspect the existing playground/language-service wiring and draft this patch. I reviewed the code paths and ran the validation commands listed above.