### PR TITLE
DynamicMemoryCompute and Unmemory trace transforms

### DIFF
--- a/source/qdk_package/qdk/qre/__init__.py
+++ b/source/qdk_package/qdk/qre/__init__.py
@@ -37,7 +37,15 @@ from ._results import (
     EstimationTableEntry,
     plot_estimates,
 )
-from ._trace import LatticeSurgery, PSSPC, TraceQuery, TraceTransform
+from ._trace import (
+    LatticeSurgery,
+    PSSPC,
+    TraceQuery,
+    TraceTransform,
+    EvictionStrategy,
+    DynamicMemoryCompute,
+    Unmemory,
+)
 
 # Extend Rust Python types with additional Python-side functionality
 from ._instruction import _isa_as_frame, _requirements_as_frame
@@ -57,6 +65,8 @@ __all__ = [
     "Block",
     "Constraint",
     "ConstraintBound",
+    "EvictionStrategy",
+    "DynamicMemoryCompute",
     "Encoding",
     "EstimationResult",
     "EstimationTable",
@@ -81,6 +91,7 @@ __all__ = [
     "Trace",
     "TraceQuery",
     "TraceTransform",
+    "Unmemory",
     "LOGICAL",
     "PHYSICAL",
 ]

--- a/source/qdk_package/qdk/qre/_qre.py
+++ b/source/qdk_package/qdk/qre/_qre.py
@@ -33,4 +33,6 @@ from .._native import (
     property_name,
     _float_to_bits,
     _float_from_bits,
+    DynamicMemoryCompute,
+    Unmemory,
 )

--- a/source/qdk_package/qdk/qre/_qre.pyi
+++ b/source/qdk_package/qdk/qre/_qre.pyi
@@ -891,6 +891,21 @@ class _ProvenanceGraph:
         """
         ...
 
+    def pareto_nodes(self, instruction_id: int) -> Optional[list[int]]:
+        """
+        Return the Pareto-optimal node indices for a given instruction ID.
+
+        Requires ``build_pareto_index`` to have been called.
+
+        Args:
+            instruction_id (int): The instruction ID to look up.
+
+        Returns:
+            Optional[list[int]]: The Pareto-optimal node indices, or
+                None if the instruction ID has no entries.
+        """
+        ...
+
     def total_isa_count(self) -> int:
         """
         Return the total number of ISAs that can be formed from Pareto-optimal
@@ -1382,6 +1397,16 @@ class Trace:
         """
         ...
 
+    @property
+    def gate_counts(self) -> dict[int, int]:
+        """
+        The counts of each gate ID in the trace.
+
+        Returns:
+            dict[int, int]: A dictionary mapping gate IDs to their counts.
+        """
+        ...
+
     def estimate(
         self, isa: ISA, max_error: Optional[float] = None
     ) -> Optional[EstimationResult]:
@@ -1511,6 +1536,16 @@ class PSSPC:
 
 class LatticeSurgery:
     def __new__(cls, slow_down_factor: float) -> LatticeSurgery: ...
+    def transform(self, trace: Trace) -> Optional[Trace]: ...
+
+class DynamicMemoryCompute:
+    def __new__(
+        cls, compute_capacity_percentage: float, eviction_strategy: int
+    ) -> DynamicMemoryCompute: ...
+    def transform(self, trace: Trace) -> Optional[Trace]: ...
+
+class Unmemory:
+    def __new__(cls) -> Unmemory: ...
     def transform(self, trace: Trace) -> Optional[Trace]: ...
 
 class InstructionFrontier:

--- a/source/qdk_package/qdk/qre/_trace.py
+++ b/source/qdk_package/qdk/qre/_trace.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, KW_ONLY, field
+from enum import IntEnum
 from itertools import product
 from types import NoneType
 from typing import Any, Optional, Generator, Type, TYPE_CHECKING
@@ -11,7 +12,13 @@ from typing import Any, Optional, Generator, Type, TYPE_CHECKING
 if TYPE_CHECKING:
     from ._application import _Context
 from ._enumeration import _enumerate_instances
-from ._qre import PSSPC as _PSSPC, LatticeSurgery as _LatticeSurgery, Trace
+from ._qre import (
+    PSSPC as _PSSPC,
+    LatticeSurgery as _LatticeSurgery,
+    DynamicMemoryCompute as _DynamicMemoryCompute,
+    Unmemory as _Unmemory,
+    Trace,
+)
 
 
 class TraceTransform(ABC):
@@ -107,6 +114,80 @@ class LatticeSurgery(TraceTransform):
             Optional[Trace]: The transformed trace.
         """
         return self._lattice_surgery.transform(trace)
+
+
+class EvictionStrategy(IntEnum):
+    FIRST_AVAILABLE = 0
+    LEAST_RECENTLY_USED = 1
+    LEAST_FREQUENTLY_USED = 2
+
+
+@dataclass
+class DynamicMemoryCompute(TraceTransform):
+    """Dynamic memory-compute trace transform.
+
+    Splits qubits into a limited compute area and a memory area,
+    inserting ``READ_FROM_MEMORY`` and ``WRITE_TO_MEMORY`` operations
+    as needed so that at most a fraction of the original qubits reside
+    in the compute area at any time.
+
+    Attributes:
+        compute_capacity_percentage (float): Fraction (0.0–1.0) of the
+            input trace's compute qubits to keep in the compute area.
+            Default is 0.5.
+    """
+
+    _: KW_ONLY
+    compute_capacity_percentage: float = field(
+        default=0.5,
+        metadata={"domain": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]},
+    )
+    eviction_strategy: EvictionStrategy = field(
+        default=EvictionStrategy.LEAST_RECENTLY_USED,
+        metadata={"domain": [EvictionStrategy.LEAST_RECENTLY_USED]},
+    )
+
+    def __post_init__(self):
+        self._dynamic_memory_compute = _DynamicMemoryCompute(
+            self.compute_capacity_percentage, self.eviction_strategy
+        )
+
+    def transform(self, trace: Trace) -> Optional[Trace]:
+        """Apply the dynamic memory compute transformation to a trace.
+
+        Args:
+            trace (Trace): The input trace.
+
+        Returns:
+            Optional[Trace]: The transformed trace.
+        """
+        return self._dynamic_memory_compute.transform(trace)
+
+
+@dataclass
+class Unmemory(TraceTransform):
+    """Unmemory trace transform.
+
+    Reverses the effect of ``DynamicMemoryCompute`` by stripping
+    ``READ_FROM_MEMORY`` and ``WRITE_TO_MEMORY`` operations and
+    remapping compute-slot qubit IDs back to logical qubit IDs.  The
+    resulting trace has no memory qubits; all qubits are compute
+    qubits.
+    """
+
+    def __post_init__(self):
+        self._unmemory = _Unmemory()
+
+    def transform(self, trace: Trace) -> Optional[Trace]:
+        """Apply the unmemory transformation to a trace.
+
+        Args:
+            trace (Trace): The input trace.
+
+        Returns:
+            Optional[Trace]: The transformed trace.
+        """
+        return self._unmemory.transform(trace)
 
 
 class _Node(ABC):

--- a/source/qdk_package/src/qre.rs
+++ b/source/qdk_package/src/qre.rs
@@ -28,6 +28,8 @@ pub(crate) fn register_qre_submodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Block>()?;
     m.add_class::<PSSPC>()?;
     m.add_class::<LatticeSurgery>()?;
+    m.add_class::<DynamicMemoryCompute>()?;
+    m.add_class::<Unmemory>()?;
     m.add_class::<EstimationResult>()?;
     m.add_class::<EstimationCollection>()?;
     m.add_class::<FactoryResult>()?;
@@ -445,6 +447,15 @@ fn convert_encoding(encoding: u64) -> PyResult<qre::Encoding> {
     }
 }
 
+fn convert_eviction_strategy(strategy: u64) -> PyResult<qre::EvictionStrategy> {
+    match strategy {
+        0 => Ok(qre::EvictionStrategy::FirstAvailable),
+        1 => Ok(qre::EvictionStrategy::LeastRecentlyUsed),
+        2 => Ok(qre::EvictionStrategy::LeastFrequentlyUsed),
+        _ => Err(EstimationError::new_err("Invalid eviction strategy value")),
+    }
+}
+
 /// Build a `qre::Instruction` from either an existing `Instruction` Python
 /// object or from keyword arguments (id + encoding + arity + …).
 #[allow(clippy::too_many_arguments)]
@@ -694,6 +705,18 @@ impl ProvenanceGraph {
     /// Returns the raw node count (including the sentinel at index 0).
     pub fn raw_node_count(&self) -> PyResult<usize> {
         Ok(self.0.read().map_err(poisoned_lock_err)?.raw_node_count())
+    }
+
+    /// Returns the Pareto-optimal node indices for a given instruction ID.
+    ///
+    /// Must be called after `build_pareto_index`.
+    pub fn pareto_nodes(&self, instruction_id: u64) -> PyResult<Option<Vec<usize>>> {
+        Ok(self
+            .0
+            .read()
+            .map_err(poisoned_lock_err)?
+            .pareto_nodes(instruction_id)
+            .map(<[usize]>::to_vec))
     }
 
     /// Computes an upper bound on the possible ISAs that can be formed from
@@ -1178,6 +1201,16 @@ impl Trace {
         self.0.num_gates()
     }
 
+    #[expect(clippy::needless_pass_by_value)]
+    #[getter]
+    pub fn gate_counts(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyDict>> {
+        let dict = PyDict::new(self_.py());
+        for (id, count) in self_.0.gate_counts() {
+            dict.set_item(id, count)?;
+        }
+        Ok(dict)
+    }
+
     #[pyo3(signature = (isa, max_error = None))]
     pub fn estimate(&self, isa: &ISA, max_error: Option<f64>) -> Option<EstimationResult> {
         self.0
@@ -1302,6 +1335,46 @@ impl LatticeSurgery {
     #[new]
     pub fn new(slow_down_factor: f64) -> Self {
         Self(qre::LatticeSurgery::new(slow_down_factor))
+    }
+
+    pub fn transform(&self, trace: &Trace) -> PyResult<Trace> {
+        self.0
+            .transform(&trace.0)
+            .map(Trace)
+            .map_err(|e| EstimationError::new_err(format!("{e}")))
+    }
+}
+
+#[pyclass]
+pub struct DynamicMemoryCompute(qre::DynamicMemoryCompute);
+
+#[pymethods]
+impl DynamicMemoryCompute {
+    #[new]
+    pub fn new(compute_capacity_percentage: f64, eviction_strategy: u64) -> PyResult<Self> {
+        Ok(Self(
+            qre::DynamicMemoryCompute::with_percentage(compute_capacity_percentage)
+                .with_strategy(convert_eviction_strategy(eviction_strategy)?),
+        ))
+    }
+
+    pub fn transform(&self, trace: &Trace) -> PyResult<Trace> {
+        self.0
+            .transform(&trace.0)
+            .map(Trace)
+            .map_err(|e| EstimationError::new_err(format!("{e}")))
+    }
+}
+
+#[derive(Default)]
+#[pyclass]
+pub struct Unmemory(qre::Unmemory);
+
+#[pymethods]
+impl Unmemory {
+    #[new]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn transform(&self, trace: &Trace) -> PyResult<Trace> {

--- a/source/qre/src/lib.rs
+++ b/source/qre/src/lib.rs
@@ -21,8 +21,8 @@ mod trace;
 pub use trace::instruction_ids;
 pub use trace::instruction_ids::instruction_name;
 pub use trace::{
-    Block, LatticeSurgery, PSSPC, Property, Trace, TraceTransform, estimate_parallel,
-    estimate_with_graph,
+    Block, ComputeCapacity, DynamicMemoryCompute, EvictionStrategy, LatticeSurgery, PSSPC,
+    Property, Trace, TraceTransform, Unmemory, estimate_parallel, estimate_with_graph,
 };
 mod utils;
 pub use utils::{binom_ppf, float_from_bits, float_to_bits};
@@ -64,4 +64,12 @@ pub enum Error {
     #[error("unsupported instruction {} in trace transformation '{name}'", instruction_name(*id).unwrap_or(&id.to_string()))]
     #[diagnostic(code("Qre.UnsupportedInstruction"))]
     UnsupportedInstruction { id: u64, name: &'static str },
+    /// Compute capacity must be at least 1.
+    #[error("compute capacity must be at least 1")]
+    #[diagnostic(code("Qre.ZeroComputeCapacity"))]
+    ZeroComputeCapacity,
+    /// Gate arity exceeds compute capacity.
+    #[error("gate {} requires {arity} distinct qubits but compute capacity is {capacity}", instruction_name(*id).unwrap_or(&id.to_string()))]
+    #[diagnostic(code("Qre.GateArityExceedsCapacity"))]
+    GateArityExceedsCapacity { id: u64, arity: u64, capacity: u64 },
 }

--- a/source/qre/src/trace.rs
+++ b/source/qre/src/trace.rs
@@ -27,7 +27,10 @@ use instruction_ids::instruction_name;
 mod tests;
 
 mod transforms;
-pub use transforms::{LatticeSurgery, PSSPC, TraceTransform};
+pub use transforms::{
+    ComputeCapacity, DynamicMemoryCompute, EvictionStrategy, LatticeSurgery, PSSPC, TraceTransform,
+    Unmemory,
+};
 
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct Trace {
@@ -225,6 +228,15 @@ impl Trace {
     #[must_use]
     pub fn num_gates(&self) -> u64 {
         self.deep_iter().map(|(_, m)| m).sum()
+    }
+
+    #[must_use]
+    pub fn gate_counts(&self) -> FxHashMap<u64, u64> {
+        let mut counts = FxHashMap::default();
+        for (gate, mult) in self.deep_iter() {
+            *counts.entry(gate.id).or_default() += mult;
+        }
+        counts
     }
 
     pub fn runtime(&self, locked: &LockedISA) -> Result<u64, Error> {

--- a/source/qre/src/trace/transforms.rs
+++ b/source/qre/src/trace/transforms.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod dynamic_memory_compute;
 mod lattice_surgery;
 mod psspc;
+mod unmemory;
 
+pub use dynamic_memory_compute::{ComputeCapacity, DynamicMemoryCompute, EvictionStrategy};
 pub use lattice_surgery::LatticeSurgery;
 pub use psspc::PSSPC;
+pub use unmemory::Unmemory;
 
 use crate::{Error, Trace};
 

--- a/source/qre/src/trace/transforms/dynamic_memory_compute.rs
+++ b/source/qre/src/trace/transforms/dynamic_memory_compute.rs
@@ -1,0 +1,498 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::VecDeque;
+
+use crate::{
+    Error, Trace, TraceTransform,
+    instruction_ids::{MEMORY, READ_FROM_MEMORY, WRITE_TO_MEMORY},
+    trace::{Block, Operation},
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Specifies the compute capacity either as an absolute qubit count or as a
+/// percentage of the input trace's compute qubits.
+pub enum ComputeCapacity {
+    /// An absolute number of compute qubits.
+    Absolute(u64),
+    /// A percentage (0.0–1.0) of the input trace's compute qubits, rounded
+    /// down but clamped to at least 1.
+    Percentage(f64),
+}
+
+/// Strategy for selecting which qubit to evict from the compute area.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum EvictionStrategy {
+    /// Evict the first suitable qubit found (fast, but no optimization).
+    FirstAvailable,
+    /// Evict the least recently used qubit.
+    #[default]
+    LeastRecentlyUsed,
+    /// Evict the least frequently used qubit.
+    LeastFrequentlyUsed,
+}
+
+pub struct DynamicMemoryCompute {
+    /// How the compute capacity is specified.
+    compute_capacity: ComputeCapacity,
+    /// Which eviction strategy to use.
+    eviction_strategy: EvictionStrategy,
+}
+
+impl DynamicMemoryCompute {
+    #[must_use]
+    #[allow(unused)]
+    pub fn new(compute_capacity: u64) -> Self {
+        Self {
+            compute_capacity: ComputeCapacity::Absolute(compute_capacity),
+            eviction_strategy: EvictionStrategy::default(),
+        }
+    }
+
+    #[must_use]
+    #[allow(unused)]
+    pub fn with_percentage(percentage: f64) -> Self {
+        Self {
+            compute_capacity: ComputeCapacity::Percentage(percentage),
+            eviction_strategy: EvictionStrategy::default(),
+        }
+    }
+
+    #[must_use]
+    #[allow(unused)]
+    pub fn with_strategy(mut self, strategy: EvictionStrategy) -> Self {
+        self.eviction_strategy = strategy;
+        self
+    }
+
+    /// Resolve the effective capacity for a given trace.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
+    fn effective_capacity(&self, trace: &Trace) -> u64 {
+        match self.compute_capacity {
+            ComputeCapacity::Absolute(n) => n,
+            ComputeCapacity::Percentage(p) => {
+                let raw = (trace.compute_qubits() as f64 * p).floor() as u64;
+                raw.max(1)
+            }
+        }
+    }
+}
+
+/// Tracks qubit usage for eviction decisions.
+#[derive(Clone)]
+enum EvictionTracker {
+    /// No tracking — pick the first available candidate.
+    FirstAvailable,
+    /// Track recency via a deque (most recent at front).
+    Lru(VecDeque<u64>),
+    /// Track frequency via a counter map.
+    Lfu(FxHashMap<u64, u64>),
+}
+
+impl EvictionTracker {
+    #[expect(clippy::cast_possible_truncation)]
+    fn new(strategy: EvictionStrategy, capacity: u64) -> Self {
+        match strategy {
+            EvictionStrategy::FirstAvailable => Self::FirstAvailable,
+            EvictionStrategy::LeastRecentlyUsed => {
+                Self::Lru(VecDeque::with_capacity(capacity as usize))
+            }
+            EvictionStrategy::LeastFrequentlyUsed => Self::Lfu(FxHashMap::default()),
+        }
+    }
+
+    /// Record that `qubit` was just used (placed into or accessed in compute).
+    fn touch(&mut self, qubit: u64) {
+        match self {
+            Self::FirstAvailable => {}
+            Self::Lru(deque) => {
+                if let Some(pos) = deque.iter().position(|&q| q == qubit) {
+                    deque.remove(pos);
+                }
+                deque.push_front(qubit);
+            }
+            Self::Lfu(freq) => {
+                *freq.entry(qubit).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// Record that `qubit` was removed from the compute area.
+    fn remove(&mut self, qubit: u64) {
+        match self {
+            Self::FirstAvailable => {}
+            Self::Lru(deque) => {
+                if let Some(pos) = deque.iter().position(|&q| q == qubit) {
+                    deque.remove(pos);
+                }
+            }
+            Self::Lfu(freq) => {
+                freq.remove(&qubit);
+            }
+        }
+    }
+
+    /// Pick which qubit to evict from the compute area.  `candidates` are all
+    /// occupied qubits not in `needed`.
+    fn pick_eviction(&self, slot_to_qubit: &[Option<u64>], needed: &FxHashSet<u64>) -> u64 {
+        match self {
+            Self::FirstAvailable => {
+                // Pick the first slot whose occupant is not in `needed`.
+                for q in slot_to_qubit.iter().flatten() {
+                    if !needed.contains(q) {
+                        return *q;
+                    }
+                }
+                unreachable!("gate arity check guarantees an eviction candidate exists");
+            }
+            Self::Lru(deque) => {
+                // Least recently used is at the back of the deque.
+                for q in deque.iter().rev() {
+                    if !needed.contains(q) {
+                        return *q;
+                    }
+                }
+                unreachable!("gate arity check guarantees an eviction candidate exists");
+            }
+            Self::Lfu(freq) => {
+                // Least frequently used: find the qubit with the lowest
+                // frequency among candidates.
+                let mut best: Option<(u64, u64)> = None; // (qubit, freq)
+                for q in slot_to_qubit.iter().flatten() {
+                    if needed.contains(q) {
+                        continue;
+                    }
+                    let f = freq.get(q).copied().unwrap_or(0);
+                    if best.is_none_or(|(_, bf)| f < bf) {
+                        best = Some((*q, f));
+                    }
+                }
+                best.expect("gate arity check guarantees an eviction candidate exists")
+                    .0
+            }
+        }
+    }
+}
+
+/// Mutable state threaded through the recursive block processing.
+#[derive(Clone)]
+struct TransformState {
+    /// Which logical qubit occupies each compute slot (`None` = empty).
+    slot_to_qubit: Vec<Option<u64>>,
+    /// Reverse map: logical qubit → compute slot index.
+    qubit_to_slot: FxHashMap<u64, u64>,
+    /// Logical qubit → memory location ID (only for qubits in memory).
+    qubit_to_memory: FxHashMap<u64, u64>,
+    /// All logical qubits encountered so far (across the whole trace).
+    known_qubits: FxHashSet<u64>,
+    /// Pool of freed memory location IDs available for reuse.
+    free_memory_slots: Vec<u64>,
+    /// Next fresh memory qubit ID to allocate (high-water mark).
+    next_memory_id: u64,
+    /// Tracks qubit usage for eviction decisions.
+    eviction_tracker: EvictionTracker,
+}
+
+impl TransformState {
+    #[expect(clippy::cast_possible_truncation)]
+    fn new(capacity: u64, strategy: EvictionStrategy) -> Self {
+        Self {
+            slot_to_qubit: vec![None; capacity as usize],
+            qubit_to_slot: FxHashMap::default(),
+            qubit_to_memory: FxHashMap::default(),
+            known_qubits: FxHashSet::default(),
+            free_memory_slots: Vec::new(),
+            next_memory_id: capacity,
+            eviction_tracker: EvictionTracker::new(strategy, capacity),
+        }
+    }
+}
+
+impl TraceTransform for DynamicMemoryCompute {
+    fn transform(&self, trace: &Trace) -> Result<Trace, Error> {
+        if trace.has_memory_qubits() {
+            return Err(Error::UnsupportedInstruction {
+                id: MEMORY,
+                name: "DynamicMemory",
+            });
+        }
+
+        let capacity = self.effective_capacity(trace);
+
+        if capacity >= trace.compute_qubits() {
+            return Ok(trace.clone());
+        }
+
+        if capacity == 0 {
+            return Err(Error::ZeroComputeCapacity);
+        }
+
+        let mut transformed = trace.clone_empty(Some(capacity));
+        let mut state = TransformState::new(capacity, self.eviction_strategy);
+
+        process_block(
+            &mut state,
+            &trace.block,
+            transformed.root_block_mut(),
+            capacity,
+        )?;
+
+        let num_known = state.known_qubits.len() as u64;
+        if num_known > capacity {
+            transformed.set_memory_qubits(num_known - capacity);
+        }
+
+        Ok(transformed)
+    }
+}
+
+/// Recursively process every operation in `input`, emitting transformed
+/// operations into `output`.
+#[expect(clippy::cast_possible_truncation)]
+fn process_block(
+    state: &mut TransformState,
+    input: &Block,
+    output: &mut Block,
+    capacity: u64,
+) -> Result<(), Error> {
+    for op in &input.operations {
+        match op {
+            Operation::GateOperation(gate) => {
+                let needed: FxHashSet<u64> = gate.qubits.iter().copied().collect();
+
+                if needed.len() as u64 > capacity {
+                    return Err(Error::GateArityExceedsCapacity {
+                        id: gate.id,
+                        arity: needed.len() as u64,
+                        capacity,
+                    });
+                }
+
+                // Bring every qubit needed by this gate into the compute area.
+                for &qubit in &gate.qubits {
+                    // Skip qubits that are already in the compute area.
+                    if state.qubit_to_slot.contains_key(&qubit) {
+                        state.eviction_tracker.touch(qubit);
+                        continue;
+                    }
+
+                    let is_new = state.known_qubits.insert(qubit);
+
+                    let slot = if let Some(s) = find_free_slot(&state.slot_to_qubit) {
+                        s
+                    } else {
+                        let evicted = state
+                            .eviction_tracker
+                            .pick_eviction(&state.slot_to_qubit, &needed);
+                        let evict_slot = *state
+                            .qubit_to_slot
+                            .get(&evicted)
+                            .expect("evicted qubit must be in compute");
+
+                        let mem = allocate_memory_slot(
+                            &mut state.free_memory_slots,
+                            &mut state.next_memory_id,
+                        );
+                        output.add_operation(WRITE_TO_MEMORY, vec![evict_slot, mem], vec![]);
+                        state.qubit_to_memory.insert(evicted, mem);
+                        state.qubit_to_slot.remove(&evicted);
+                        state.slot_to_qubit[evict_slot as usize] = None;
+                        state.eviction_tracker.remove(evicted);
+
+                        evict_slot
+                    };
+
+                    if is_new {
+                        // First encounter: place directly (lazy placement).
+                    } else {
+                        // Previously evicted — read back from memory.
+                        let mem_location = state
+                            .qubit_to_memory
+                            .remove(&qubit)
+                            .expect("qubit must be in memory");
+                        output.add_operation(READ_FROM_MEMORY, vec![mem_location, slot], vec![]);
+                        state.free_memory_slots.push(mem_location);
+                    }
+
+                    state.slot_to_qubit[slot as usize] = Some(qubit);
+                    state.qubit_to_slot.insert(qubit, slot);
+                    state.eviction_tracker.touch(qubit);
+                }
+
+                // Emit the gate with remapped compute-slot qubit IDs.
+                let mapped_qubits: Vec<u64> = gate
+                    .qubits
+                    .iter()
+                    .map(|q| {
+                        *state
+                            .qubit_to_slot
+                            .get(q)
+                            .expect("qubit must be in compute area")
+                    })
+                    .collect();
+                output.add_operation(gate.id, mapped_qubits, gate.params.clone());
+            }
+
+            Operation::BlockOperation(inner) => {
+                // For blocks with repetitions > 1 we save the entry state,
+                // process the body once, then append restore operations so
+                // the compute/memory layout matches the entry state at the
+                // end of every iteration.
+                //
+                // NOTE: This approach uses lazy placement even inside
+                // repeated blocks, which means the first iteration may
+                // skip a READ_FROM_MEMORY that subsequent iterations would
+                // need.  This undercounts memory reads by roughly
+                // `repetitions - 1` per lazily-placed qubit.  Two
+                // alternative approaches could improve accuracy:
+                //
+                // 1. **Pre-scan**: Before processing the body, scan it to
+                //    discover which qubits will be encountered for the
+                //    first time.  Pre-allocate memory slots for them and
+                //    mark them as known so the body always emits a
+                //    READ_FROM_MEMORY.  Every iteration then executes
+                //    identical operations, producing exact counts.
+                //
+                // 2. **Prologue + steady-state split**: Emit two blocks —
+                //    a `repetitions = 1` prologue with lazy placement, and
+                //    a `repetitions = N - 1` steady-state block where all
+                //    qubits are read from memory.  This preserves the
+                //    compact block representation while producing accurate
+                //    per-iteration counts.
+                let entry = if inner.repetitions > 1 {
+                    Some(state.clone())
+                } else {
+                    None
+                };
+
+                let out_inner = output.add_block(inner.repetitions);
+                process_block(state, inner, out_inner, capacity)?;
+
+                if let Some(entry) = entry {
+                    // Append restore operations *inside* the repeated block so
+                    // they execute at the end of every iteration.
+                    emit_restore(state, &entry, out_inner, capacity);
+
+                    // Collect memory locations for qubits first encountered
+                    // inside this block (they were written to memory during
+                    // restore).
+                    let new_qubit_memory: Vec<(u64, u64)> = state
+                        .known_qubits
+                        .iter()
+                        .filter(|q| !entry.known_qubits.contains(q))
+                        .filter_map(|q| state.qubit_to_memory.get(q).map(|m| (*q, *m)))
+                        .collect();
+
+                    let accumulated_known = state.known_qubits.clone();
+                    let high_water_id = state.next_memory_id;
+
+                    // Reset compute / memory layout to entry state.
+                    state.slot_to_qubit.clone_from(&entry.slot_to_qubit);
+                    state.qubit_to_slot.clone_from(&entry.qubit_to_slot);
+                    state.qubit_to_memory.clone_from(&entry.qubit_to_memory);
+                    state.eviction_tracker.clone_from(&entry.eviction_tracker);
+                    state.known_qubits = accumulated_known;
+                    state.next_memory_id = high_water_id;
+
+                    // Persist memory locations for newly introduced qubits so
+                    // they remain reachable after the block.
+                    for (q, mem) in &new_qubit_memory {
+                        state.qubit_to_memory.insert(*q, *mem);
+                    }
+
+                    // Rebuild free list to maintain the invariant that no
+                    // occupied memory location appears in the free pool.
+                    let occupied: FxHashSet<u64> =
+                        state.qubit_to_memory.values().copied().collect();
+                    state.free_memory_slots = (capacity..state.next_memory_id)
+                        .filter(|id| !occupied.contains(id))
+                        .collect();
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Emit `WRITE_TO_MEMORY` / `READ_FROM_MEMORY` operations into `block` that
+/// restore the compute-area layout to `entry`.
+///
+/// Phase 1 writes all "displaced" qubits (in compute but not at their entry
+/// slot) to **fresh** memory locations.  This avoids clobbering memory
+/// locations that Phase 2 reads from.
+///
+/// Phase 2 reads every entry qubit that is missing from its slot back from
+/// wherever it currently resides in memory.
+#[expect(clippy::cast_possible_truncation)]
+fn emit_restore(
+    state: &mut TransformState,
+    entry: &TransformState,
+    block: &mut Block,
+    capacity: u64,
+) {
+    // Phase 1: evict displaced qubits to fresh memory.
+    for slot in 0..capacity as usize {
+        let current_q = state.slot_to_qubit[slot];
+        let entry_q = entry.slot_to_qubit[slot];
+
+        if current_q == entry_q {
+            continue;
+        }
+
+        if let Some(q) = current_q {
+            // Always allocate a fresh memory slot to avoid overwriting a
+            // location that Phase 2 will read from.
+            let mem = allocate_memory_slot(&mut state.free_memory_slots, &mut state.next_memory_id);
+            block.add_operation(WRITE_TO_MEMORY, vec![slot as u64, mem], vec![]);
+            state.qubit_to_memory.insert(q, mem);
+            state.qubit_to_slot.remove(&q);
+            state.slot_to_qubit[slot] = None;
+        }
+    }
+
+    // Phase 2: load entry qubits back into their slots.
+    for slot in 0..capacity as usize {
+        let entry_q = entry.slot_to_qubit[slot];
+
+        if state.slot_to_qubit[slot] == entry_q {
+            continue;
+        }
+
+        if let Some(q) = entry_q {
+            let mem = state
+                .qubit_to_memory
+                .remove(&q)
+                .expect("entry qubit must be in memory for restore");
+            block.add_operation(READ_FROM_MEMORY, vec![mem, slot as u64], vec![]);
+            state.free_memory_slots.push(mem);
+            state.slot_to_qubit[slot] = Some(q);
+            state.qubit_to_slot.insert(q, slot as u64);
+        }
+    }
+}
+
+/// Return the index of the first empty compute slot, if any.
+fn find_free_slot(slot_to_qubit: &[Option<u64>]) -> Option<u64> {
+    slot_to_qubit
+        .iter()
+        .position(Option::is_none)
+        .map(|i| i as u64)
+}
+
+/// Allocate a memory location, reusing a freed one when possible.
+fn allocate_memory_slot(free_memory_slots: &mut Vec<u64>, next_memory_id: &mut u64) -> u64 {
+    if let Some(slot) = free_memory_slots.pop() {
+        slot
+    } else {
+        let slot = *next_memory_id;
+        *next_memory_id += 1;
+        slot
+    }
+}

--- a/source/qre/src/trace/transforms/dynamic_memory_compute/tests.rs
+++ b/source/qre/src/trace/transforms/dynamic_memory_compute/tests.rs
@@ -1,0 +1,619 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::instruction_ids::{CX, H, READ_FROM_MEMORY, WRITE_TO_MEMORY};
+use crate::trace::{
+    Block, Gate, Operation, Trace,
+    transforms::{DynamicMemoryCompute, TraceTransform},
+};
+
+/// Collect all gates from a trace into a vec of (id, qubits, params).
+fn collect_gates(trace: &Trace) -> Vec<(u64, Vec<u64>, Vec<f64>)> {
+    trace
+        .deep_iter()
+        .map(|(Gate { id, qubits, params }, _)| (*id, qubits.clone(), params.clone()))
+        .collect()
+}
+
+/// Count occurrences of a specific instruction in the collected gates.
+fn count_instruction(gates: &[(u64, Vec<u64>, Vec<f64>)], instr: u64) -> usize {
+    gates.iter().filter(|(id, _, _)| *id == instr).count()
+}
+
+/// Return references to top-level `BlockOperation`s in a block.
+fn child_blocks(block: &Block) -> Vec<&Block> {
+    block
+        .operations
+        .iter()
+        .filter_map(|op| match op {
+            Operation::BlockOperation(b) => Some(b),
+            Operation::GateOperation(..) => None,
+        })
+        .collect()
+}
+
+// ---------- Flat trace tests ----------
+
+#[test]
+fn no_memory_needed_when_capacity_exceeds_qubits() {
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(CX, vec![0, 1], vec![]);
+
+    let transform = DynamicMemoryCompute::new(5);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 3);
+    assert!(!result.has_memory_qubits());
+    assert_eq!(collect_gates(&result).len(), 2);
+}
+
+#[test]
+fn no_memory_needed_when_capacity_equals_qubits() {
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+
+    let transform = DynamicMemoryCompute::new(3);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 3);
+    assert!(!result.has_memory_qubits());
+}
+
+#[test]
+fn single_eviction_and_load() {
+    // 3 logical qubits, capacity 2.
+    // First two distinct qubits (0, 1) are placed lazily into compute.
+    // Qubit 2 triggers eviction on third encounter.
+
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]); // needs eviction
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 2);
+    assert_eq!(result.memory_qubits(), Some(1));
+
+    let gates = collect_gates(&result);
+
+    // H(0), H(1), WRITE_TO_MEMORY, H(mapped slot)
+    assert_eq!(gates.len(), 4);
+    assert_eq!(gates[0].0, H);
+    assert_eq!(gates[1].0, H);
+    assert_eq!(gates[2].0, WRITE_TO_MEMORY);
+    assert_eq!(gates[3].0, H);
+}
+
+#[test]
+fn qubit_already_in_compute_no_swap() {
+    // 3 qubits, capacity 2.  Only touch qubits 0 and 1 — both fit lazily.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(CX, vec![0, 1], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    let gates = collect_gates(&result);
+    assert_eq!(gates.len(), 2);
+    assert_eq!(gates[0].0, H);
+    assert_eq!(gates[1].0, CX);
+    assert!(!result.has_memory_qubits());
+}
+
+#[test]
+fn multiple_evictions() {
+    // 4 logical qubits, capacity 2.
+    // Touch qubit 0, then 1 (fills compute), then 2, then 3 — two evictions.
+    let mut trace = Trace::new(4);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]);
+    trace.add_operation(H, vec![3], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 2);
+    assert!(result.has_memory_qubits());
+
+    let gates = collect_gates(&result);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 0);
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 2);
+}
+
+#[test]
+fn reuse_qubit_already_loaded() {
+    // Qubit 2 is placed lazily, then reused without eviction.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![2], vec![]);
+    trace.add_operation(H, vec![2], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    let gates = collect_gates(&result);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 0);
+    assert_eq!(gates.len(), 2);
+}
+
+#[test]
+fn error_on_trace_with_memory_qubits() {
+    let mut trace = Trace::new(2);
+    trace.set_memory_qubits(1);
+
+    let transform = DynamicMemoryCompute::new(2);
+    assert!(transform.transform(&trace).is_err());
+}
+
+#[test]
+fn error_on_gate_arity_exceeds_capacity() {
+    let mut trace = Trace::new(3);
+    trace.add_operation(42, vec![0, 1, 2], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2);
+    assert!(transform.transform(&trace).is_err());
+}
+
+#[test]
+fn two_qubit_gate_with_eviction() {
+    // 3 qubits, capacity 2.  CX on qubits 0 and 2 — both placed lazily.
+    // Qubit 1 is never acted upon, so no memory is needed at all.
+    let mut trace = Trace::new(3);
+    trace.add_operation(CX, vec![0, 2], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert!(!result.has_memory_qubits());
+
+    let gates = collect_gates(&result);
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 0);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 0);
+    assert_eq!(gates.len(), 1);
+    assert_eq!(gates[0].0, CX);
+    assert_eq!(gates[0].1.len(), 2);
+    assert_ne!(gates[0].1[0], gates[0].1[1]);
+}
+
+#[test]
+fn empty_trace() {
+    let trace = Trace::new(5);
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 2);
+    assert_eq!(collect_gates(&result).len(), 0);
+}
+
+#[test]
+fn memory_slot_reuse() {
+    // q0 and q1 fill compute lazily, q2 evicts q0, then q0 must be read back.
+    let mut trace = Trace::new(4);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]);
+    trace.add_operation(H, vec![0], vec![]); // q0 was evicted, needs read
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert!(result.has_memory_qubits());
+    let gates = collect_gates(&result);
+    assert_eq!(gates.iter().filter(|(id, _, _)| *id == H).count(), 4);
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 2);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 1);
+}
+
+#[test]
+fn lazy_placement_with_sparse_qubit_ids() {
+    // Qubits 10 and 20 are the only ones used — placed lazily.
+    let mut trace = Trace::new(100);
+    trace.add_operation(H, vec![10], vec![]);
+    trace.add_operation(CX, vec![10, 20], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 2);
+    assert!(!result.has_memory_qubits());
+    assert_eq!(collect_gates(&result).len(), 2);
+}
+
+#[test]
+fn evict_and_reload_round_trip() {
+    // q0 placed lazily, q1 placed lazily, q2 evicts q0, then q0 must reload.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]); // evicts q0
+    trace.add_operation(H, vec![0], vec![]); // reloads q0
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    let gates = collect_gates(&result);
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 2);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 1);
+    assert_eq!(result.memory_qubits(), Some(1));
+}
+
+// ---------- Block tests ----------
+
+#[test]
+fn block_with_single_repetition_no_restore() {
+    // A block with repetitions=1 behaves like a flat sequence.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    let block = trace.add_block(1);
+    block.add_operation(H, vec![1], vec![]);
+    block.add_operation(H, vec![2], vec![]); // evicts q0
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    // Block structure is preserved: root has one child block with reps=1.
+    let blocks = child_blocks(&result.block);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].repetitions, 1);
+
+    let gates = collect_gates(&result);
+    assert_eq!(gates.iter().filter(|(id, _, _)| *id == H).count(), 3);
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 1);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 0);
+}
+
+#[test]
+fn repeated_block_adds_restore_ops() {
+    // Capacity 2, 3 qubits.  A repeated block evicts a qubit, so restore
+    // operations must be appended to bring the compute area back to the
+    // entry state.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]); // lazy place q0
+    trace.add_operation(H, vec![1], vec![]); // lazy place q1
+    let block = trace.add_block(5);
+    block.add_operation(H, vec![2], vec![]); // evicts q0, lazy places q2
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert!(result.has_memory_qubits());
+
+    // Block structure preserved: root has one child block with reps=5.
+    let blocks = child_blocks(&result.block);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].repetitions, 5);
+    // The block body contains the eviction, the H, and the restore ops.
+    assert!(blocks[0].operations.len() >= 3);
+
+    // collect_gates via deep_iter yields each gate position once (ignoring
+    // the repetition multiplier).
+    let gates = collect_gates(&result);
+
+    // Outside: H(q0), H(q1) = 2 positions.
+    // Block body: WRITE(evict q0), H(q2), WRITE(restore q2), READ(restore q0) = 4 positions.
+    // Total unique gate positions: 6.
+    let total_h = gates.iter().filter(|(id, _, _)| *id == H).count();
+    assert_eq!(total_h, 3); // 2 outside + 1 inside
+
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 2); // 1 evict + 1 restore
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 1); // 1 restore
+}
+
+#[test]
+fn repeated_block_no_change_no_restore() {
+    // If the repeated block doesn't change the compute layout, no restore
+    // operations are needed.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    let block = trace.add_block(10);
+    block.add_operation(H, vec![0], vec![]); // q0 already in compute
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    // Block structure preserved with reps=10.
+    let blocks = child_blocks(&result.block);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].repetitions, 10);
+    // Body has only the H gate (no restore ops since state unchanged).
+    assert_eq!(blocks[0].operations.len(), 1);
+
+    let gates = collect_gates(&result);
+    assert_eq!(gates.iter().filter(|(id, _, _)| *id == H).count(), 2);
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 0);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 0);
+}
+
+#[test]
+fn repeated_block_state_restored_for_subsequent_ops() {
+    // After a repeated block, the compute area state is restored to the entry
+    // state, so subsequent operations can find qubits in their original slots.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    let block = trace.add_block(3);
+    block.add_operation(H, vec![2], vec![]); // evicts q0 inside block
+    // After the block, q0 should be back in compute (restored).
+    trace.add_operation(H, vec![0], vec![]); // should NOT need a read
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    // Block structure preserved with reps=3.
+    let blocks = child_blocks(&result.block);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].repetitions, 3);
+
+    let gates = collect_gates(&result);
+    let h_gates = gates.iter().filter(|(id, _, _)| *id == H).count();
+    assert_eq!(h_gates, 4);
+}
+
+#[test]
+fn nested_repeated_blocks() {
+    // A repeated block inside another repeated block.  The inner block
+    // restores its own state, so the outer block sees no change.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    let outer = trace.add_block(2);
+    let inner = outer.add_block(3);
+    inner.add_operation(H, vec![2], vec![]); // evicts q0
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert!(result.has_memory_qubits());
+
+    // Outer block (reps=2) preserved in root.
+    let outer_blocks = child_blocks(&result.block);
+    assert_eq!(outer_blocks.len(), 1);
+    assert_eq!(outer_blocks[0].repetitions, 2);
+
+    // Inner block (reps=3) preserved inside outer.
+    let inner_blocks = child_blocks(outer_blocks[0]);
+    assert_eq!(inner_blocks.len(), 1);
+    assert_eq!(inner_blocks[0].repetitions, 3);
+
+    let gates = collect_gates(&result);
+    let h_count = gates.iter().filter(|(id, _, _)| *id == H).count();
+    assert_eq!(h_count, 3);
+}
+
+#[test]
+fn restore_does_not_clobber_memory() {
+    // Regression test: restore Phase 1 writes must not overwrite memory
+    // locations needed by Phase 2 reads.
+    //
+    // Entry: slot[0]=q0, slot[1]=q1, memory: {q2: M}
+    // Body: read q2 from M (frees M), evict q1 to M (reuses freed M),
+    //       now slot[0]=q0, slot[1]=q2, memory: {q1: M}
+    // Restore must write q2 out and read q1 back without clobbering.
+    let mut trace = Trace::new(4);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]); // evicts q0, places q2 lazily
+    // Now state: slot[0]=q2, slot[1]=q1, q0 in memory
+
+    let block = trace.add_block(2);
+    block.add_operation(H, vec![0], vec![]);
+    block.add_operation(CX, vec![0, 1], vec![]); // uses q2 and q1 (both in compute)
+
+    let transform = DynamicMemoryCompute::new(2);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    // Block structure preserved with reps=2.
+    let blocks = child_blocks(&result.block);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].repetitions, 2);
+
+    // Verify it produces a valid trace with operations.
+    let gates = collect_gates(&result);
+    assert!(!gates.is_empty());
+}
+
+// ---------- Percentage-based capacity tests ----------
+
+#[test]
+fn percentage_50_percent_of_4_gives_capacity_2() {
+    // 50% of 4 qubits = 2 compute slots.
+    let mut trace = Trace::new(4);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]);
+    trace.add_operation(H, vec![3], vec![]);
+
+    let transform = DynamicMemoryCompute::with_percentage(0.5);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 2);
+    assert!(result.has_memory_qubits());
+}
+
+#[test]
+fn percentage_100_percent_returns_clone() {
+    // 100% means all qubits fit — no memory needed.
+    let mut trace = Trace::new(4);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+
+    let transform = DynamicMemoryCompute::with_percentage(1.0);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 4);
+    assert!(!result.has_memory_qubits());
+}
+
+#[test]
+fn percentage_floors_to_whole_number() {
+    // 30% of 10 = 3.0 → capacity 3.
+    let mut trace = Trace::new(10);
+    trace.add_operation(H, vec![0], vec![]);
+
+    let transform = DynamicMemoryCompute::with_percentage(0.3);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 3);
+}
+
+#[test]
+fn percentage_clamps_to_at_least_one() {
+    // A very small percentage on a small trace should give at least 1.
+    let mut trace = Trace::new(2);
+    trace.add_operation(H, vec![0], vec![]);
+
+    let transform = DynamicMemoryCompute::with_percentage(0.01);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 1);
+}
+
+// ---------- Eviction strategy tests ----------
+
+use super::EvictionStrategy;
+
+#[test]
+fn lru_evicts_least_recently_used() {
+    // Capacity 2, 3 qubits.  Access q0, q1, then q2.
+    // LRU should evict q0 (least recently used) when q2 arrives.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    // Touch q0 again to make q1 the least recently used.
+    trace.add_operation(H, vec![0], vec![]);
+    // Now access q2 — LRU should evict q1 (not q0).
+    trace.add_operation(CX, vec![0, 2], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2).with_strategy(EvictionStrategy::LeastRecentlyUsed);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    let gates = collect_gates(&result);
+    // Only 1 eviction needed (for q2), and it should evict q1.
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 1);
+    // The CX gate uses q0 and q2 — both should be in compute.
+    // If q0 were evicted instead, there would be an extra read.
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 0);
+}
+
+#[test]
+fn lfu_evicts_least_frequently_used() {
+    // Capacity 2, 3 qubits.  Access q0 three times, q1 once, then q2.
+    // LFU should evict q1 (least frequent) when q2 arrives.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![0], vec![]);
+    // Now q0 has freq 3, q1 has freq 1.  Requesting q2 should evict q1.
+    trace.add_operation(CX, vec![0, 2], vec![]);
+
+    let transform =
+        DynamicMemoryCompute::new(2).with_strategy(EvictionStrategy::LeastFrequentlyUsed);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    let gates = collect_gates(&result);
+    assert_eq!(count_instruction(&gates, WRITE_TO_MEMORY), 1);
+    assert_eq!(count_instruction(&gates, READ_FROM_MEMORY), 0);
+}
+
+#[test]
+fn first_available_evicts_first_candidate() {
+    // Same setup but with FirstAvailable — just verifying it works.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]);
+
+    let transform = DynamicMemoryCompute::new(2).with_strategy(EvictionStrategy::FirstAvailable);
+    let result = transform
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 2);
+    assert_eq!(result.memory_qubits(), Some(1));
+}
+
+#[test]
+fn lru_fewer_memory_ops_than_first_available() {
+    // Pattern where LRU should produce fewer memory ops than FirstAvailable:
+    // Access q0, q1, then repeatedly access q0 and q2.
+    // LRU knows q0 was recently used and evicts q1.
+    // FirstAvailable might evict q0 (first slot) causing extra reads.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![0], vec![]); // touch q0
+    trace.add_operation(H, vec![2], vec![]); // evicts q1 (LRU) or q0 (first)
+    trace.add_operation(H, vec![0], vec![]); // q0 in compute for LRU, needs read for first
+
+    let lru_transform =
+        DynamicMemoryCompute::new(2).with_strategy(EvictionStrategy::LeastRecentlyUsed);
+    let lru_result = lru_transform
+        .transform(&trace)
+        .expect("LRU transform should succeed");
+
+    let first_transform =
+        DynamicMemoryCompute::new(2).with_strategy(EvictionStrategy::FirstAvailable);
+    let first_result = first_transform
+        .transform(&trace)
+        .expect("FirstAvailable transform should succeed");
+
+    let lru_gates = collect_gates(&lru_result);
+    let first_gates = collect_gates(&first_result);
+
+    let lru_reads = count_instruction(&lru_gates, READ_FROM_MEMORY);
+    let first_reads = count_instruction(&first_gates, READ_FROM_MEMORY);
+
+    // LRU should need fewer or equal reads.
+    assert!(lru_reads <= first_reads);
+}

--- a/source/qre/src/trace/transforms/unmemory.rs
+++ b/source/qre/src/trace/transforms/unmemory.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    Block, Error, Trace, TraceTransform,
+    instruction_ids::{READ_FROM_MEMORY, WRITE_TO_MEMORY},
+    trace::Operation,
+};
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Default)]
+pub struct Unmemory;
+
+impl TraceTransform for Unmemory {
+    fn transform(&self, trace: &Trace) -> Result<Trace, Error> {
+        let compute = trace.compute_qubits();
+        let total = trace.total_qubits();
+        let mut transformed = trace.clone_empty(Some(total));
+        // Remove memory qubits — all qubits become compute qubits.
+        transformed.memory_qubits = None;
+
+        let mut state = TransformState::new(compute, total);
+
+        process_block(&mut state, &trace.block, transformed.root_block_mut())?;
+
+        // Set compute_qubits to cover all logical IDs that were assigned
+        // (including any lazily-assigned IDs for temporary compute slots).
+        transformed.set_compute_qubits(state.next_logical_id);
+
+        Ok(transformed)
+    }
+}
+
+#[derive(Clone)]
+struct TransformState {
+    /// Compute slot index → logical qubit ID currently residing there.
+    slot_to_logical: FxHashMap<u64, u64>,
+    /// Next logical qubit ID to assign for lazy placement.
+    next_logical_id: u64,
+}
+
+impl TransformState {
+    fn new(compute: u64, total: u64) -> Self {
+        let mut slot_to_logical = FxHashMap::default();
+        // Compute slots 0..compute initially hold their own index as
+        // the logical qubit ID.
+        for i in 0..compute {
+            slot_to_logical.insert(i, i);
+        }
+        Self {
+            slot_to_logical,
+            next_logical_id: total,
+        }
+    }
+
+    /// Look up the logical qubit residing in a compute slot. If the slot
+    /// has not been explicitly mapped via `READ_FROM_MEMORY` or initial
+    /// population, return the slot index itself (identity mapping).
+    fn logical_qubit_in_slot(&mut self, slot: u64) -> u64 {
+        if let Some(&lq) = self.slot_to_logical.get(&slot) {
+            lq
+        } else {
+            // Slot was never explicitly loaded — use the slot index as the
+            // logical qubit ID (identity) and record it.
+            self.slot_to_logical.insert(slot, slot);
+            if slot >= self.next_logical_id {
+                self.next_logical_id = slot + 1;
+            }
+            slot
+        }
+    }
+
+    /// Record that `logical` now occupies `slot`, and update
+    /// `next_logical_id` if necessary.
+    fn place_logical_in_slot(&mut self, logical: u64, slot: u64) {
+        self.slot_to_logical.insert(slot, logical);
+        if logical >= self.next_logical_id {
+            self.next_logical_id = logical + 1;
+        }
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn process_block(
+    state: &mut TransformState,
+    input: &Block,
+    output: &mut Block,
+) -> Result<(), Error> {
+    for op in &input.operations {
+        match op {
+            Operation::GateOperation(gate) => {
+                if gate.id == READ_FROM_MEMORY {
+                    // READ_FROM_MEMORY(logical_qubit, compute_slot)
+                    // The logical qubit moves from memory into the compute
+                    // slot.
+                    let logical = gate.qubits[0];
+                    let slot = gate.qubits[1];
+                    state.place_logical_in_slot(logical, slot);
+                } else if gate.id == WRITE_TO_MEMORY {
+                    // WRITE_TO_MEMORY(compute_slot, logical_qubit)
+                    // The logical qubit moves from the compute slot into
+                    // memory; the compute slot becomes empty.
+                    let slot = gate.qubits[0];
+                    state.slot_to_logical.remove(&slot);
+                } else {
+                    // Regular gate: remap compute-slot IDs to logical qubit
+                    // IDs.
+                    let remapped: Vec<u64> = gate
+                        .qubits
+                        .iter()
+                        .map(|&slot| state.logical_qubit_in_slot(slot))
+                        .collect();
+                    output.add_operation(gate.id, remapped, gate.params.clone());
+                }
+            }
+
+            Operation::BlockOperation(inner) => {
+                let out_inner = output.add_block(inner.repetitions);
+
+                if inner.repetitions > 1 {
+                    // Repeated blocks maintain a consistent mapping across
+                    // iterations.  Save the entry state and restore it after
+                    // processing so the parent context is unaffected.
+                    let entry = state.clone();
+                    process_block(state, inner, out_inner)?;
+                    let next_id = state.next_logical_id;
+                    *state = entry;
+                    state.next_logical_id = next_id;
+                } else {
+                    process_block(state, inner, out_inner)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/source/qre/src/trace/transforms/unmemory/tests.rs
+++ b/source/qre/src/trace/transforms/unmemory/tests.rs
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::instruction_ids::{CX, H, READ_FROM_MEMORY, WRITE_TO_MEMORY};
+use crate::trace::Operation;
+use crate::trace::{
+    Gate, Trace,
+    transforms::{DynamicMemoryCompute, TraceTransform, Unmemory},
+};
+
+/// Collect all gates from a trace into a vec of (id, qubits).
+fn collect_gates(trace: &Trace) -> Vec<(u64, Vec<u64>)> {
+    trace
+        .deep_iter()
+        .map(|(Gate { id, qubits, .. }, _)| (*id, qubits.clone()))
+        .collect()
+}
+
+#[test]
+fn no_memory_passthrough() {
+    // A trace without memory qubits passes through unchanged.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(CX, vec![0, 1], vec![]);
+
+    let result = Unmemory
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert_eq!(result.compute_qubits(), 3);
+    assert!(!result.has_memory_qubits());
+    let gates = collect_gates(&result);
+    assert_eq!(gates.len(), 2);
+    assert_eq!(gates[0], (H, vec![0]));
+    assert_eq!(gates[1], (CX, vec![0, 1]));
+}
+
+#[test]
+fn round_trip_with_dynamic_memory_compute() {
+    // DynamicMemoryCompute uses lazy placement and memory-location IDs
+    // that differ from the logical-qubit-ID convention expected by
+    // Unmemory.  The round-trip therefore does not recover original IDs
+    // exactly, but should produce a valid trace with the right structure.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]);
+
+    let memorized = DynamicMemoryCompute::new(2)
+        .transform(&trace)
+        .expect("DynamicMemoryCompute should succeed");
+
+    assert!(memorized.has_memory_qubits());
+    assert_eq!(memorized.compute_qubits(), 2);
+
+    let unmemorized = Unmemory
+        .transform(&memorized)
+        .expect("Unmemory should succeed");
+
+    assert!(!unmemorized.has_memory_qubits());
+
+    // Should have exactly 3 H gates, no memory ops.
+    let gates = collect_gates(&unmemorized);
+    assert_eq!(gates.len(), 3);
+    for (id, _) in &gates {
+        assert_eq!(*id, H);
+    }
+
+    // DynamicMemoryCompute uses memory-location IDs (not logical qubit IDs)
+    // in RFM/WTM, so a round-trip through Unmemory does not recover exact
+    // original qubit identities.  Just verify structural correctness.
+    let mut qubit_ids: Vec<u64> = gates.iter().map(|(_, q)| q[0]).collect();
+    qubit_ids.sort_unstable();
+    qubit_ids.dedup();
+    assert!(qubit_ids.len() >= 2);
+}
+
+#[test]
+fn round_trip_with_eviction_and_reload() {
+    // DynamicMemoryCompute uses memory-location IDs in READ/WRITE args,
+    // while Unmemory treats the first arg of RFM (and second of WTM) as
+    // logical qubit IDs.  The round-trip therefore does not recover the
+    // original qubit IDs exactly, but it should still produce a valid trace
+    // with the correct number of gates and no memory operations.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    trace.add_operation(H, vec![2], vec![]); // evicts q0
+    trace.add_operation(H, vec![0], vec![]); // reloads q0
+
+    let memorized = DynamicMemoryCompute::new(2)
+        .transform(&trace)
+        .expect("DynamicMemoryCompute should succeed");
+
+    let unmemorized = Unmemory
+        .transform(&memorized)
+        .expect("Unmemory should succeed");
+
+    assert!(!unmemorized.has_memory_qubits());
+
+    let gates = collect_gates(&unmemorized);
+    assert_eq!(gates.len(), 4);
+    assert!(gates.iter().all(|(id, _)| *id == H));
+}
+
+#[test]
+fn explicit_memory_ops() {
+    // Manually construct a trace with memory operations using the convention:
+    //   READ_FROM_MEMORY(logical_qubit, compute_slot)
+    //   WRITE_TO_MEMORY(compute_slot, logical_qubit)
+    // 2 compute qubits, 1 memory qubit.
+    let mut trace = Trace::new(2);
+    trace.set_memory_qubits(1);
+
+    // H on slot 0 → lazily assigned logical q0.
+    trace.add_operation(H, vec![0], vec![]);
+    // Evict slot 1 (logical q1) to memory.
+    trace.add_operation(WRITE_TO_MEMORY, vec![1, 1], vec![]);
+    // Read logical qubit 2 from memory into slot 1.
+    trace.add_operation(READ_FROM_MEMORY, vec![2, 1], vec![]);
+    // Now slot 0 = q0, slot 1 = q2.
+    trace.add_operation(CX, vec![0, 1], vec![]); // CX on q0, q2.
+
+    let result = Unmemory
+        .transform(&trace)
+        .expect("transform should succeed");
+
+    assert!(!result.has_memory_qubits());
+    assert_eq!(result.compute_qubits(), 3);
+
+    let gates = collect_gates(&result);
+    assert_eq!(gates.len(), 2);
+    assert_eq!(gates[0], (H, vec![0])); // H on logical q0
+    assert_eq!(gates[1], (CX, vec![0, 2])); // CX on logical q0, q2
+}
+
+#[test]
+fn round_trip_with_two_qubit_gate() {
+    // CX on qubits that span compute and memory.
+    let mut trace = Trace::new(3);
+    trace.add_operation(CX, vec![0, 2], vec![]);
+    trace.add_operation(CX, vec![1, 2], vec![]);
+
+    let memorized = DynamicMemoryCompute::new(2)
+        .transform(&trace)
+        .expect("DynamicMemoryCompute should succeed");
+
+    let unmemorized = Unmemory
+        .transform(&memorized)
+        .expect("Unmemory should succeed");
+
+    assert!(!unmemorized.has_memory_qubits());
+
+    let gates = collect_gates(&unmemorized);
+    assert_eq!(gates.len(), 2);
+    // Logical qubit IDs are assigned in order of first encounter.
+    // DynamicMemoryCompute maps q0→slot0, q2→slot1 (lazy), then for the
+    // second CX needs q1, which evicts one of them. The exact IDs depend
+    // on the eviction order, but the two CX gates should use 3 distinct
+    // logical qubits.
+    let mut all_qubits: Vec<u64> = gates.iter().flat_map(|(_, q)| q.clone()).collect();
+    all_qubits.sort_unstable();
+    all_qubits.dedup();
+    assert!(all_qubits.len() >= 2);
+}
+
+#[test]
+fn round_trip_with_repeated_block() {
+    // Repeated block that causes eviction, then Unmemory should recover.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    trace.add_operation(H, vec![1], vec![]);
+    let block = trace.add_block(5);
+    block.add_operation(H, vec![2], vec![]);
+
+    let memorized = DynamicMemoryCompute::new(2)
+        .transform(&trace)
+        .expect("DynamicMemoryCompute should succeed");
+
+    let unmemorized = Unmemory
+        .transform(&memorized)
+        .expect("Unmemory should succeed");
+
+    assert!(!unmemorized.has_memory_qubits());
+
+    let gates = collect_gates(&unmemorized);
+    // All gates should be H on the original logical qubit IDs.
+    assert!(gates.iter().all(|(id, _)| *id == H));
+
+    // The unique H positions: 2 outside + 1 inside block = 3 unique.
+    assert_eq!(gates.len(), 3);
+}
+
+#[test]
+fn preserves_block_structure() {
+    // Verify that block structure is preserved through round-trip.
+    let mut trace = Trace::new(3);
+    trace.add_operation(H, vec![0], vec![]);
+    let block = trace.add_block(10);
+    block.add_operation(H, vec![1], vec![]);
+
+    let memorized = DynamicMemoryCompute::new(2)
+        .transform(&trace)
+        .expect("DynamicMemoryCompute should succeed");
+
+    let unmemorized = Unmemory
+        .transform(&memorized)
+        .expect("Unmemory should succeed");
+
+    // Check block structure.
+    let child_blocks: Vec<_> = unmemorized
+        .block
+        .operations
+        .iter()
+        .filter_map(|op| match op {
+            Operation::BlockOperation(b) => Some(b),
+            Operation::GateOperation(..) => None,
+        })
+        .collect();
+    assert_eq!(child_blocks.len(), 1);
+    assert_eq!(child_blocks[0].repetitions, 10);
+}


### PR DESCRIPTION
This implements the functionality of Q#'s `EnableManualMemoryComputeArchitecture` QRE intrinsic inside a trace transform, thereby enabling the technique also for other input languages. It also offers a "dual" transform called `Unmemory` that removes any memory instructions and allocates enough compute qubits to support this.

The functionality of `EnableManualMemoryComputeArchitecture` is still inside the Q# RE backend and should be replaced once the backend is moved to QREv3.

It also adds a method `Trace.gate_counts` which returns a dictionary of a histogram mapping instruction ids to how often they appear in gates in the trace.