### PR TITLE
Propagate diverges flag in non-tuple call args

### DIFF
--- a/source/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/source/compiler/qsc_frontend/src/typeck/rules.rs
@@ -299,7 +299,7 @@ impl<'a> Context<'a> {
                         let arg_span = inner.span;
                         Partial {
                             ty: ArgTy::Given(ty.ty, arg_span),
-                            diverges: false,
+                            diverges: ty.diverges,
                         }
                     }
                 };

--- a/source/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/source/compiler/qsc_frontend/src/typeck/rules.rs
@@ -275,32 +275,28 @@ impl<'a> Context<'a> {
                         inner = unwrapped;
                     }
                     // If the outermost element is a tuple, we must wrap it in an `ArgTy::Tuple`.
-                    if let Partial {
-                        ty: Ty::Tuple(tys),
-                        diverges,
-                    } = ty
-                    {
-                        let spans: Vec<_> = if let ExprKind::Tuple(items) = inner.kind.as_ref() {
-                            items.iter().map(|item| item.span).collect()
-                        } else {
-                            panic!("unexpected syntax kind: {:?}", inner.kind)
-                        };
-                        Partial {
-                            ty: ArgTy::Tuple(
+                    let arg_ty = match ty.ty {
+                        Ty::Tuple(tys) => {
+                            let spans: Vec<_> = if let ExprKind::Tuple(items) = inner.kind.as_ref()
+                            {
+                                items.iter().map(|item| item.span).collect()
+                            } else {
+                                panic!("unexpected syntax kind: {:?}", inner.kind)
+                            };
+                            ArgTy::Tuple(
                                 tys.into_iter()
                                     .zip(spans)
                                     .map(|(ty, span)| ArgTy::Given(ty, span))
                                     .collect(),
                                 inner.span,
-                            ),
-                            diverges,
+                            )
                         }
-                    } else {
-                        let arg_span = inner.span;
-                        Partial {
-                            ty: ArgTy::Given(ty.ty, arg_span),
-                            diverges: ty.diverges,
-                        }
+                        _ => ArgTy::Given(ty.ty, inner.span),
+                    };
+
+                    Partial {
+                        ty: arg_ty,
+                        diverges: ty.diverges,
                     }
                 };
                 let output_ty = if callee.ty == Ty::Err {

--- a/source/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2110,6 +2110,37 @@ fn fail_in_call_args_checks_non_divergent_types() {
 }
 
 #[test]
+fn fail_in_single_call_arg_diverges() {
+    check(
+        "namespace Test { function Foo(a : Int) : Double { 0.0 } }",
+        indoc! {r#"
+            if true {
+                Test.Foo(fail "oops")
+            } else {
+                0
+            }
+        "#},
+        &expect![[r##"
+            #6 29-38 "(a : Int)" : Int
+            #7 30-37 "a : Int" : Int
+            #15 48-55 "{ 0.0 }" : Double
+            #17 50-53 "0.0" : Double
+            #18 57-109 "if true {\n    Test.Foo(fail \"oops\")\n} else {\n    0\n}" : Int
+            #19 60-64 "true" : Bool
+            #20 65-94 "{\n    Test.Foo(fail \"oops\")\n}" : Int
+            #22 71-92 "Test.Foo(fail \"oops\")" : Double
+            #23 71-79 "Test.Foo" : (Int -> Double)
+            #27 79-92 "(fail \"oops\")" : Int
+            #28 80-91 "fail \"oops\"" : Int
+            #29 85-91 "\"oops\"" : String
+            #30 95-109 "else {\n    0\n}" : Int
+            #31 100-109 "{\n    0\n}" : Int
+            #33 106-107 "0" : Int
+        "##]],
+    );
+}
+
+#[test]
 fn fail_in_call_args_alone_diverges() {
     check(
         "",


### PR DESCRIPTION
As for tuples, the value of `diverges` should be propagated when converting from `Partial<Ty>` to `Partial<ArgTy>` - otherwise errors may be reported in cases where (e.g.) `fail` would prevent them from being observed at runtime.