### PR TITLE
Use a single 10-minute timeout for all VS Code integration tests

### DIFF
--- a/source/vscode/test/suites/debugger/index.browser.ts
+++ b/source/vscode/test/suites/debugger/index.browser.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { runMochaTests } from "../runBrowser";
+import { TEST_TIMEOUT_MS } from "../extensionUtils";
 
 export function run(): Promise<void> {
   return runMochaTests(
@@ -12,6 +13,6 @@ export function run(): Promise<void> {
       require("./qsharp.test"); // eslint-disable-line @typescript-eslint/no-require-imports
       require("./openqasm.test"); // eslint-disable-line @typescript-eslint/no-require-imports
     },
-    { timeout: 10_000 },
+    { timeout: TEST_TIMEOUT_MS },
   );
 }

--- a/source/vscode/test/suites/debugger/index.node.ts
+++ b/source/vscode/test/suites/debugger/index.node.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { runMochaTests } from "../runNode";
+import { TEST_TIMEOUT_MS } from "../extensionUtils";
 
 export function run(): Promise<void> {
   return runMochaTests(
@@ -12,6 +13,6 @@ export function run(): Promise<void> {
       require("./qsharp.test"); // eslint-disable-line @typescript-eslint/no-require-imports
       require("./openqasm.test"); // eslint-disable-line @typescript-eslint/no-require-imports
     },
-    { timeout: 10_000 },
+    { timeout: TEST_TIMEOUT_MS },
   );
 }

--- a/source/vscode/test/suites/debugger/openqasm.test.ts
+++ b/source/vscode/test/suites/debugger/openqasm.test.ts
@@ -3,7 +3,11 @@
 
 import * as vscode from "vscode";
 import { assert } from "chai";
-import { activateExtension, waitForCondition } from "../extensionUtils";
+import {
+  activateExtension,
+  waitForCondition,
+  TEST_TIMEOUT_MS,
+} from "../extensionUtils";
 import { DebugProtocol } from "@vscode/debugprotocol";
 import { qsharpExtensionId } from "../../../src/common";
 import { Tracker } from "./tracker";
@@ -80,7 +84,7 @@ suite("OpenQASM Debugger Tests", function suite() {
       setTimeout(
         () =>
           reject(new Error("Timed out waiting for debug session to terminate")),
-        2000,
+        TEST_TIMEOUT_MS,
       );
     });
 
@@ -185,7 +189,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     await waitForCondition(
       () => !vscode.debug.activeDebugSession,
       vscode.debug.onDidChangeActiveDebugSession,
-      9000,
+      TEST_TIMEOUT_MS,
       "timed out waiting for the debugger to be terminated",
     );
   });
@@ -467,7 +471,7 @@ async function terminateSession() {
   await waitForCondition(
     () => !vscode.debug.activeDebugSession,
     vscode.debug.onDidChangeActiveDebugSession,
-    9000,
+    TEST_TIMEOUT_MS,
     "timed out waiting for the debugger to be terminated",
   );
 }
@@ -481,7 +485,7 @@ async function waitForTextEditorOn(uri: vscode.Uri) {
       vscode.window.activeTextEditor?.document.uri.toString() ===
       uri.toString(),
     vscode.window.onDidChangeActiveTextEditor,
-    500,
+    TEST_TIMEOUT_MS,
     `timed out waiting for the text editor to open to ${uri}.\nactive text editor is ${vscode.window.activeTextEditor?.document.uri}`,
   );
 }

--- a/source/vscode/test/suites/debugger/qsharp.test.ts
+++ b/source/vscode/test/suites/debugger/qsharp.test.ts
@@ -3,7 +3,11 @@
 
 import * as vscode from "vscode";
 import { assert } from "chai";
-import { activateExtension, waitForCondition } from "../extensionUtils";
+import {
+  activateExtension,
+  waitForCondition,
+  TEST_TIMEOUT_MS,
+} from "../extensionUtils";
 import { DebugProtocol } from "@vscode/debugprotocol";
 import { qsharpExtensionId } from "../../../src/common";
 import { Tracker } from "./tracker";
@@ -66,7 +70,7 @@ suite("Q# Debugger Tests", function suite() {
       setTimeout(
         () =>
           reject(new Error("Timed out waiting for debug session to terminate")),
-        2000,
+        TEST_TIMEOUT_MS,
       );
     });
 
@@ -171,7 +175,7 @@ suite("Q# Debugger Tests", function suite() {
     await waitForCondition(
       () => !vscode.debug.activeDebugSession,
       vscode.debug.onDidChangeActiveDebugSession,
-      9000,
+      TEST_TIMEOUT_MS,
       "timed out waiting for the debugger to be terminated",
     );
   });
@@ -531,7 +535,7 @@ async function terminateSession() {
   await waitForCondition(
     () => !vscode.debug.activeDebugSession,
     vscode.debug.onDidChangeActiveDebugSession,
-    9000,
+    TEST_TIMEOUT_MS,
     "timed out waiting for the debugger to be terminated",
   );
 }
@@ -545,7 +549,7 @@ async function waitForTextEditorOn(uri: vscode.Uri) {
       vscode.window.activeTextEditor?.document.uri.toString() ===
       uri.toString(),
     vscode.window.onDidChangeActiveTextEditor,
-    500,
+    TEST_TIMEOUT_MS,
     `timed out waiting for the text editor to open to ${uri}.\nactive text editor is ${vscode.window.activeTextEditor?.document.uri}`,
   );
 }

--- a/source/vscode/test/suites/debugger/tracker.ts
+++ b/source/vscode/test/suites/debugger/tracker.ts
@@ -3,7 +3,7 @@
 
 import * as vscode from "vscode";
 import { assert } from "chai";
-import { waitForCondition } from "../extensionUtils";
+import { waitForCondition, TEST_TIMEOUT_MS } from "../extensionUtils";
 import { DebugProtocol } from "@vscode/debugprotocol";
 
 /**
@@ -54,7 +54,7 @@ class Tracker implements vscode.DebugAdapterTracker {
     await waitForCondition(
       () => this.stoppedCount === 1 && this.stackTrace && this.variables,
       this.onResponse.event,
-      9000,
+      TEST_TIMEOUT_MS,
       "timed out waiting for the debugger to stop",
     );
 
@@ -83,7 +83,6 @@ class Tracker implements vscode.DebugAdapterTracker {
       // Not much we can control here if the debugger is taking too long,
       // but log a warning so that we see it in the test log if we get
       // close to hitting test timeouts.
-      // The mocha test timeout is configured to 10 seconds.
       console.log(`${this.kind}-tests: debugger took ${stepMs}ms to stop`);
     }
     if (logDebugAdapterActivity) {
@@ -116,7 +115,7 @@ class Tracker implements vscode.DebugAdapterTracker {
         return pair !== undefined;
       },
       this.onResponse.event,
-      5000,
+      TEST_TIMEOUT_MS,
       "timed out waiting for a response to " + command,
     );
     // Clear out state so we can use the tracker again.

--- a/source/vscode/test/suites/extensionUtils.ts
+++ b/source/vscode/test/suites/extensionUtils.ts
@@ -7,6 +7,16 @@ import { type ExtensionApi } from "../../src/extension";
 // Q# extension log level. Increase this for debugging.
 const extensionLogLevel = "warn";
 
+/**
+ * The timeout to use for all integration tests, in milliseconds.
+ *
+ * By design, this is set deliberately high (10 minutes) so that even a slow
+ * machine never hits it. Tests that behave correctly will complete well before
+ * this; the timeout only exists to prevent a hung test from blocking the suite
+ * indefinitely.
+ */
+export const TEST_TIMEOUT_MS = 10 * 60 * 1000;
+
 // The code for the document status diagnostic.
 const documentStatusDiagnosticCode = "Qdk.Dev.DocumentStatus";
 
@@ -139,7 +149,7 @@ export async function delay(timeoutMs: number) {
 async function waitForDiagnostics(
   uri: vscode.Uri,
   condition: (diagnostics: vscode.Diagnostic[]) => boolean,
-  timeoutMs: number = 2000,
+  timeoutMs: number = TEST_TIMEOUT_MS,
   timeoutErrorMsg: string = "Diagnostics condition not met within timeout",
 ): Promise<vscode.Diagnostic[]> {
   await waitForCondition(
@@ -165,7 +175,7 @@ async function waitForDiagnostics(
  */
 export async function waitForDiagnosticsToAppear(
   uri: vscode.Uri,
-  timeoutMs: number = 2000,
+  timeoutMs: number = TEST_TIMEOUT_MS,
 ): Promise<vscode.Diagnostic[]> {
   const diagnostics = await waitForDiagnostics(
     uri,
@@ -189,7 +199,7 @@ export async function waitForDiagnosticsToAppear(
  */
 export async function waitForDiagnosticsToBeEmpty(
   uri: vscode.Uri,
-  timeoutMs: number = 2000,
+  timeoutMs: number = TEST_TIMEOUT_MS,
 ): Promise<void> {
   await waitForDiagnostics(
     uri,
@@ -214,7 +224,7 @@ export async function waitForDiagnosticsToBeEmpty(
  */
 export async function openDocumentAndWaitForProcessing(
   documentUri: vscode.Uri,
-  timeoutMs: number = 2000,
+  timeoutMs: number = TEST_TIMEOUT_MS,
 ): Promise<vscode.TextDocument> {
   const doc = await vscode.workspace.openTextDocument(documentUri);
   const version = doc.version;

--- a/source/vscode/test/suites/language-service/index.browser.ts
+++ b/source/vscode/test/suites/language-service/index.browser.ts
@@ -2,14 +2,17 @@
 // Licensed under the MIT License.
 
 import { runMochaTests } from "../runBrowser";
-import { setTestGithubEndpoint } from "../extensionUtils";
+import { setTestGithubEndpoint, TEST_TIMEOUT_MS } from "../extensionUtils";
 
 export function run(): Promise<void> {
   setTestGithubEndpoint("http://localhost:3000/static/mount/web/github");
-  return runMochaTests(() => {
-    // We can't use any wildcards or dynamically discovered
-    // paths here since ESBuild needs these modules to be
-    // real paths on disk at bundling time.
-    require("./language-service.test"); // eslint-disable-line @typescript-eslint/no-require-imports
-  });
+  return runMochaTests(
+    () => {
+      // We can't use any wildcards or dynamically discovered
+      // paths here since ESBuild needs these modules to be
+      // real paths on disk at bundling time.
+      require("./language-service.test"); // eslint-disable-line @typescript-eslint/no-require-imports
+    },
+    { timeout: TEST_TIMEOUT_MS },
+  );
 }

--- a/source/vscode/test/suites/language-service/index.node.ts
+++ b/source/vscode/test/suites/language-service/index.node.ts
@@ -6,17 +6,20 @@ import * as http from "http";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
-import { setTestGithubEndpoint } from "../extensionUtils";
+import { setTestGithubEndpoint, TEST_TIMEOUT_MS } from "../extensionUtils";
 
 export async function run(): Promise<void> {
   const server = await startFakeGithubServer();
   try {
-    await runMochaTests(() => {
-      // We can't use any wildcards or dynamically discovered
-      // paths here since ESBuild needs these modules to be
-      // real paths on disk at bundling time.
-      require("./language-service.test"); // eslint-disable-line @typescript-eslint/no-require-imports
-    });
+    await runMochaTests(
+      () => {
+        // We can't use any wildcards or dynamically discovered
+        // paths here since ESBuild needs these modules to be
+        // real paths on disk at bundling time.
+        require("./language-service.test"); // eslint-disable-line @typescript-eslint/no-require-imports
+      },
+      { timeout: TEST_TIMEOUT_MS },
+    );
   } finally {
     server.close();
   }


### PR DESCRIPTION
Fixes #3267

Short, ad-hoc timeouts could trip on slow machines and cause flaky failures. Timeouts should only guard against hung tests, never be short enough for a slow machine to hit.