### PR TITLE
Move Python API Check in Build Order

### DIFF
--- a/build.py
+++ b/build.py
@@ -458,6 +458,18 @@ if build_qdk:
         build_wheel(python_bin, qdk_python_src, env=pip_env, maturin=True)
     step_end()
 
+    if args.check or run_tests:
+        # The API surface check and the test suite both import the freshly
+        # built qdk in-process, which requires the package (with its native
+        # extension) and its runtime dependencies to be installed. In editable
+        # mode the editable install above already provides an importable
+        # package with the native extension built in-tree. For a wheel build we
+        # install the wheel here. Dependencies (pyqir, etc.) come from
+        # test_requirements; --no-index can't resolve them from PyPI.
+        install_python_test_requirements(qdk_python_src, python_bin)
+        if not args.editable:
+            install_from_wheels(python_bin, "qdk", cwd=qdk_python_src)
+
     if args.check:
         step_start("Checking qdk public API surface for private type leakage")
         run(
@@ -468,14 +480,6 @@ if build_qdk:
 
     if run_tests:
         step_start("Running tests for the qdk python package")
-        # Install per-package test requirements (pytest, etc.)
-        install_python_test_requirements(qdk_python_src, python_bin)
-
-        if not args.editable:
-            # Install qdk from the freshly built wheel. Dependencies (pyqir, etc.)
-            # come from test_requirements; --no-index can't resolve them from PyPI.
-            install_from_wheels(python_bin, "qdk", cwd=qdk_python_src)
-
         # Run its test suite
         run_python_tests(os.path.join(qdk_python_src, "tests"), python_bin, pip_env)
         step_end()

--- a/source/qdk_package/check_api_surface.py
+++ b/source/qdk_package/check_api_surface.py
@@ -31,6 +31,7 @@ import argparse
 import importlib
 import inspect
 import json
+import os
 import pkgutil
 import sys
 import types
@@ -301,9 +302,46 @@ def _check_class(
 # ---------------------------------------------------------------------------
 
 
+def _import_root_package() -> types.ModuleType:
+    """Import the *installed* qdk package, not the in-tree source.
+
+    This script lives inside the ``qdk_package`` source directory, alongside
+    the ``qdk/`` source tree.  When run as ``python check_api_surface.py``,
+    Python puts that directory at ``sys.path[0]``, so a bare ``import qdk``
+    resolves to the *source* package -- which has no compiled native
+    extension (``qdk._native``) and therefore fails to import.
+
+    We attempt the import normally first (this succeeds for editable installs,
+    where the native extension is built in-tree).  If that fails specifically
+    because the native extension is missing, we drop this script's own
+    directory from ``sys.path`` and retry, so the import resolves to the
+    installed (wheel) package instead.
+    """
+    try:
+        return importlib.import_module(ROOT_PACKAGE)
+    except ModuleNotFoundError as exc:
+        if f"{ROOT_PACKAGE}._native" not in str(exc):
+            raise
+
+        here = os.path.dirname(os.path.abspath(__file__))
+        sys.path[:] = [p for p in sys.path if p and os.path.abspath(p) != here]
+
+        # Purge any partially-imported source modules so the retry resolves
+        # cleanly against the installed package.
+        for name in [
+            n
+            for n in sys.modules
+            if n == ROOT_PACKAGE or n.startswith(ROOT_PACKAGE + ".")
+        ]:
+            del sys.modules[name]
+        importlib.invalidate_caches()
+
+        return importlib.import_module(ROOT_PACKAGE)
+
+
 def _iter_qdk_modules() -> list[tuple[str, types.ModuleType]]:
     """Import and yield all public qdk submodules."""
-    root = importlib.import_module(ROOT_PACKAGE)
+    root = _import_root_package()
     result: list[tuple[str, types.ModuleType]] = [(ROOT_PACKAGE, root)]
 
     for importer, modname, ispkg in pkgutil.walk_packages(


### PR DESCRIPTION
Fix qdk API-surface check failing in CI with `ModuleNotFoundError: No module named 'qdk._native'`.

Two causes:
- The check ran before the built qdk wheel was installed. build.py now installs qdk (and test deps) before both the check and tests.
- Running the script by path let the in-tree qdk/ source shadow the installed package. check_api_surface.py now drops its own directory from sys.path and retries against the installed package when the native extension is missing.