### PR TITLE
Add a code fix for should-have-been-array

### DIFF
--- a/source/compiler/qsc/src/compile.rs
+++ b/source/compiler/qsc/src/compile.rs
@@ -8,7 +8,7 @@ use qsc_data_structures::{
 };
 pub use qsc_frontend::compile::Dependencies;
 use qsc_frontend::compile::{CompileUnit, PackageStore};
-pub use qsc_frontend::typeck::TyInfo;
+pub use qsc_frontend::typeck::{TyInfo, TyInfoKind};
 use qsc_passes::{PackageType, run_core_passes, run_default_passes};
 use thiserror::Error;
 

--- a/source/compiler/qsc/src/compile.rs
+++ b/source/compiler/qsc/src/compile.rs
@@ -8,6 +8,7 @@ use qsc_data_structures::{
 };
 pub use qsc_frontend::compile::Dependencies;
 use qsc_frontend::compile::{CompileUnit, PackageStore};
+pub use qsc_frontend::typeck::TyInfo;
 use qsc_passes::{PackageType, run_core_passes, run_default_passes};
 use thiserror::Error;
 

--- a/source/compiler/qsc_frontend/src/compile.rs
+++ b/source/compiler/qsc_frontend/src/compile.rs
@@ -108,6 +108,16 @@ impl Error {
             _ => None,
         }
     }
+
+    /// If this is a type-mismatch error (diagnostic code `Qsc.TypeCk.TyMismatch`),
+    /// returns (expected, actual, span), otherwise `None`.
+    #[must_use]
+    pub fn ty_mismatch(&self) -> Option<(&typeck::TyInfo, &typeck::TyInfo, Span)> {
+        match &self.0 {
+            ErrorKind::Type(type_error) => type_error.ty_mismatch(),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Diagnostic, Error)]

--- a/source/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
+++ b/source/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
@@ -493,14 +493,18 @@ fn reexports_still_type_check() {
                     Type(
                         Error(
                             TyMismatch(
-                                "Bool",
-                                "Int",
-                                Prim(
-                                    Bool,
-                                ),
-                                Prim(
-                                    Int,
-                                ),
+                                TyInfo {
+                                    kind: Prim(
+                                        Bool,
+                                    ),
+                                    display: "Bool",
+                                },
+                                TyInfo {
+                                    kind: Prim(
+                                        Int,
+                                    ),
+                                    display: "Int",
+                                },
                                 Span {
                                     lo: 137,
                                     hi: 139,

--- a/source/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
+++ b/source/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
@@ -495,6 +495,12 @@ fn reexports_still_type_check() {
                             TyMismatch(
                                 "Bool",
                                 "Int",
+                                Prim(
+                                    Bool,
+                                ),
+                                Prim(
+                                    Int,
+                                ),
                                 Span {
                                     lo: 137,
                                     hi: 139,

--- a/source/compiler/qsc_frontend/src/typeck.rs
+++ b/source/compiler/qsc_frontend/src/typeck.rs
@@ -22,7 +22,7 @@ use qsc_ast::ast::NodeId;
 use qsc_data_structures::{index_map::IndexMap, span::Span};
 use qsc_hir::{
     hir::{CallableKind, ItemId},
-    ty::{FunctorSet, GenericArg, Ty, Udt},
+    ty::{FunctorSet, GenericArg, InferTyId, Prim, Ty, Udt},
 };
 use rustc_hash::FxHashMap;
 use std::fmt::Debug;
@@ -47,11 +47,53 @@ pub struct Table {
 #[error(transparent)]
 pub(super) struct Error(ErrorKind);
 
+/// Simplified type info for error reporting. Same shape as `Ty`, but without `Rc`
+/// so it can be included in `ErrorKind` (which must be `Send + Sync`).
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+pub enum TyInfo {
+    Array(Box<TyInfo>),
+    Arrow,
+    Infer(InferTyId),
+    Param,
+    Prim(Prim),
+    Tuple(Vec<TyInfo>),
+    Udt,
+    #[default]
+    Err,
+}
+
+impl From<&Ty> for TyInfo {
+    fn from(ty: &Ty) -> Self {
+        match ty {
+            Ty::Array(item) => TyInfo::Array(Box::new(TyInfo::from(item.as_ref()))),
+            Ty::Arrow(_) => TyInfo::Arrow,
+            Ty::Infer(id) => TyInfo::Infer(*id),
+            Ty::Param { .. } => TyInfo::Param,
+            Ty::Prim(prim) => TyInfo::Prim(*prim),
+            Ty::Tuple(items) => TyInfo::Tuple(items.iter().map(TyInfo::from).collect()),
+            Ty::Udt(_, _) => TyInfo::Udt,
+            Ty::Err => TyInfo::Err,
+        }
+    }
+}
+
+impl From<Ty> for TyInfo {
+    fn from(ty: Ty) -> Self {
+        TyInfo::from(&ty)
+    }
+}
+
 #[derive(Clone, Debug, Diagnostic, Error)]
 enum ErrorKind {
     #[error("expected {0}, found {1}")]
     #[diagnostic(code("Qsc.TypeCk.TyMismatch"))]
-    TyMismatch(String, String, #[label] Span),
+    TyMismatch(
+        /*expected*/ String,
+        /*actual*/ String,
+        /*expected*/ TyInfo,
+        /*actual*/ TyInfo,
+        #[label] Span,
+    ),
     #[error("expected {0}, found {1}")]
     #[diagnostic(code("Qsc.TypeCk.CallableMismatch"))]
     CallableMismatch(CallableKind, CallableKind, #[label] Span),
@@ -192,6 +234,17 @@ enum ErrorKind {
     ))]
     #[diagnostic(code("Qsc.TypeCk.RecursiveTypeConstraint"))]
     RecursiveTypeConstraint(#[label] Span),
+}
+
+impl Error {
+    /// If this is a type-mismatch error, returns (expected, actual, span).
+    #[must_use]
+    pub fn ty_mismatch(&self) -> Option<(&TyInfo, &TyInfo, Span)> {
+        match &self.0 {
+            ErrorKind::TyMismatch(_, _, expected, actual, span) => Some((expected, actual, *span)),
+            _ => None,
+        }
+    }
 }
 
 impl From<TyConversionError> for Error {

--- a/source/compiler/qsc_frontend/src/typeck.rs
+++ b/source/compiler/qsc_frontend/src/typeck.rs
@@ -49,7 +49,7 @@ pub(super) struct Error(ErrorKind);
 
 /// Simplified type info for error reporting. Same shape as `Ty`, but without `Rc`
 /// so it can be included in `ErrorKind` (which must be `Send + Sync`).
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum TyInfo {
     Array(Box<TyInfo>),
     Arrow,

--- a/source/compiler/qsc_frontend/src/typeck.rs
+++ b/source/compiler/qsc_frontend/src/typeck.rs
@@ -50,29 +50,57 @@ pub(super) struct Error(ErrorKind);
 /// Simplified type info for error reporting. Same shape as `Ty`, but without `Rc`
 /// so it can be included in `ErrorKind` (which must be `Send + Sync`).
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub enum TyInfo {
-    Array(Box<TyInfo>),
+pub enum TyInfoKind {
+    Array(Box<TyInfoKind>),
     Arrow,
     Infer(InferTyId),
     Param,
     Prim(Prim),
-    Tuple(Vec<TyInfo>),
+    Tuple(Vec<TyInfoKind>),
     Udt,
     #[default]
     Err,
 }
 
-impl From<&Ty> for TyInfo {
+/// Type info paired with a display string for error reporting.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TyInfo {
+    pub kind: TyInfoKind,
+    pub display: String,
+}
+
+impl std::fmt::Display for TyInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.display)
+    }
+}
+
+impl From<&Ty> for TyInfoKind {
     fn from(ty: &Ty) -> Self {
         match ty {
-            Ty::Array(item) => TyInfo::Array(Box::new(TyInfo::from(item.as_ref()))),
-            Ty::Arrow(_) => TyInfo::Arrow,
-            Ty::Infer(id) => TyInfo::Infer(*id),
-            Ty::Param { .. } => TyInfo::Param,
-            Ty::Prim(prim) => TyInfo::Prim(*prim),
-            Ty::Tuple(items) => TyInfo::Tuple(items.iter().map(TyInfo::from).collect()),
-            Ty::Udt(_, _) => TyInfo::Udt,
-            Ty::Err => TyInfo::Err,
+            Ty::Array(item) => TyInfoKind::Array(Box::new(TyInfoKind::from(item.as_ref()))),
+            Ty::Arrow(_) => TyInfoKind::Arrow,
+            Ty::Infer(id) => TyInfoKind::Infer(*id),
+            Ty::Param { .. } => TyInfoKind::Param,
+            Ty::Prim(prim) => TyInfoKind::Prim(*prim),
+            Ty::Tuple(items) => TyInfoKind::Tuple(items.iter().map(TyInfoKind::from).collect()),
+            Ty::Udt(_, _) => TyInfoKind::Udt,
+            Ty::Err => TyInfoKind::Err,
+        }
+    }
+}
+
+impl From<Ty> for TyInfoKind {
+    fn from(ty: Ty) -> Self {
+        TyInfoKind::from(&ty)
+    }
+}
+
+impl From<&Ty> for TyInfo {
+    fn from(ty: &Ty) -> Self {
+        TyInfo {
+            kind: TyInfoKind::from(ty),
+            display: ty.display(),
         }
     }
 }
@@ -88,8 +116,6 @@ enum ErrorKind {
     #[error("expected {0}, found {1}")]
     #[diagnostic(code("Qsc.TypeCk.TyMismatch"))]
     TyMismatch(
-        /*expected*/ String,
-        /*actual*/ String,
         /*expected*/ TyInfo,
         /*actual*/ TyInfo,
         #[label] Span,
@@ -241,7 +267,7 @@ impl Error {
     #[must_use]
     pub fn ty_mismatch(&self) -> Option<(&TyInfo, &TyInfo, Span)> {
         match &self.0 {
-            ErrorKind::TyMismatch(_, _, expected, actual, span) => Some((expected, actual, *span)),
+            ErrorKind::TyMismatch(expected, actual, span) => Some((expected, actual, *span)),
             _ => None,
         }
     }

--- a/source/compiler/qsc_frontend/src/typeck/check.rs
+++ b/source/compiler/qsc_frontend/src/typeck/check.rs
@@ -202,8 +202,6 @@ impl Checker {
             match &output {
                 Ty::Tuple(items) if items.is_empty() => {}
                 _ => self.errors.push(Error(ErrorKind::TyMismatch(
-                    Ty::UNIT.display(),
-                    output.display(),
                     Ty::UNIT.into(),
                     output.into(),
                     decl.output.span,

--- a/source/compiler/qsc_frontend/src/typeck/check.rs
+++ b/source/compiler/qsc_frontend/src/typeck/check.rs
@@ -204,6 +204,8 @@ impl Checker {
                 _ => self.errors.push(Error(ErrorKind::TyMismatch(
                     Ty::UNIT.display(),
                     output.display(),
+                    Ty::UNIT.into(),
+                    output.into(),
                     decl.output.span,
                 ))),
             }

--- a/source/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/source/compiler/qsc_frontend/src/typeck/infer.rs
@@ -358,9 +358,13 @@ impl ArgTy {
             (Self::Tuple(args, tuple_span), Ty::Tuple(params)) => {
                 let mut errors = Vec::new();
                 if args.len() != params.len() {
+                    let expected_ty = Ty::Tuple(params.clone());
+                    let actual_ty = self.to_ty();
                     errors.push(Error(ErrorKind::TyMismatch(
-                        Ty::Tuple(params.clone()).display(),
-                        self.to_ty().display(),
+                        expected_ty.display(),
+                        actual_ty.display(),
+                        expected_ty.into(),
+                        actual_ty.into(),
                         *tuple_span,
                     )));
                 }
@@ -400,6 +404,8 @@ impl ArgTy {
                 errors: vec![Error(ErrorKind::TyMismatch(
                     param.display(),
                     self.to_ty().display(),
+                    param.into(),
+                    self.to_ty().into(),
                     *tuple_span,
                 ))],
             },
@@ -793,6 +799,8 @@ impl Solver {
                     self.errors.push(Error(ErrorKind::TyMismatch(
                         ty1.display(),
                         ty2.display(),
+                        ty1.into(),
+                        ty2.into(),
                         span,
                     )));
                 }
@@ -808,6 +816,8 @@ impl Solver {
                 self.errors.push(Error(ErrorKind::TyMismatch(
                     ty1.display(),
                     ty2.display(),
+                    ty1.into(),
+                    ty2.into(),
                     span,
                 )));
                 Vec::new()

--- a/source/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/source/compiler/qsc_frontend/src/typeck/infer.rs
@@ -1477,13 +1477,7 @@ fn check_unwrap(
 
 /// Creates a `TyMismatch` error from expected and actual types at the given span.
 fn ty_mismatch(expected: &Ty, actual: &Ty, span: Span) -> Error {
-    Error(ErrorKind::TyMismatch(
-        expected.display(),
-        actual.display(),
-        expected.into(),
-        actual.into(),
-        span,
-    ))
+    Error(ErrorKind::TyMismatch(expected.into(), actual.into(), span))
 }
 
 /// Given an HIR class constraint, produce an actual type system constraint.

--- a/source/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/source/compiler/qsc_frontend/src/typeck/infer.rs
@@ -360,13 +360,7 @@ impl ArgTy {
                 if args.len() != params.len() {
                     let expected_ty = Ty::Tuple(params.clone());
                     let actual_ty = self.to_ty();
-                    errors.push(Error(ErrorKind::TyMismatch(
-                        expected_ty.display(),
-                        actual_ty.display(),
-                        expected_ty.into(),
-                        actual_ty.into(),
-                        *tuple_span,
-                    )));
+                    errors.push(ty_mismatch(&expected_ty, &actual_ty, *tuple_span));
                 }
 
                 let mut holes = Vec::new();
@@ -401,13 +395,7 @@ impl ArgTy {
             (Self::Tuple(_, tuple_span), _) => App {
                 holes: Vec::new(),
                 constraints: Vec::new(),
-                errors: vec![Error(ErrorKind::TyMismatch(
-                    param.display(),
-                    self.to_ty().display(),
-                    param.into(),
-                    self.to_ty().into(),
-                    *tuple_span,
-                ))],
+                errors: vec![ty_mismatch(param, &self.to_ty(), *tuple_span)],
             },
         }
     }
@@ -796,13 +784,7 @@ impl Solver {
             (Ty::Prim(prim1), Ty::Prim(prim2)) if prim1 == prim2 => Vec::new(),
             (Ty::Tuple(items1), Ty::Tuple(items2)) => {
                 if items1.len() != items2.len() {
-                    self.errors.push(Error(ErrorKind::TyMismatch(
-                        ty1.display(),
-                        ty2.display(),
-                        ty1.into(),
-                        ty2.into(),
-                        span,
-                    )));
+                    self.errors.push(ty_mismatch(ty1, ty2, span));
                 }
 
                 items1
@@ -813,13 +795,7 @@ impl Solver {
             }
             (Ty::Udt(_, res1), Ty::Udt(_, res2)) if res1 == res2 => Vec::new(),
             _ => {
-                self.errors.push(Error(ErrorKind::TyMismatch(
-                    ty1.display(),
-                    ty2.display(),
-                    ty1.into(),
-                    ty2.into(),
-                    span,
-                )));
+                self.errors.push(ty_mismatch(ty1, ty2, span));
                 Vec::new()
             }
         }
@@ -1497,6 +1473,17 @@ fn check_unwrap(
             span,
         ))],
     )
+}
+
+/// Creates a `TyMismatch` error from expected and actual types at the given span.
+fn ty_mismatch(expected: &Ty, actual: &Ty, span: Span) -> Error {
+    Error(ErrorKind::TyMismatch(
+        expected.display(),
+        actual.display(),
+        expected.into(),
+        actual.into(),
+        span,
+    ))
 }
 
 /// Given an HIR class constraint, produce an actual type system constraint.

--- a/source/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests.rs
@@ -222,7 +222,7 @@ fn return_wrong_type() {
             #6 30-32 "()" : Unit
             #10 39-47 "{ true }" : Bool
             #12 41-45 "true" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 41, hi: 45 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Bool), display: "Bool" }, Span { lo: 41, hi: 45 }))))
         "##]],
     );
 }
@@ -240,7 +240,7 @@ fn return_semi() {
             #6 30-32 "()" : Unit
             #10 39-45 "{ 4; }" : Unit
             #12 41-42 "4" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 35, hi: 38 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 35, hi: 38 }))))
         "##]],
     );
 }
@@ -269,7 +269,7 @@ fn incorrect_explicit_type_in_let_binding_error() {
             #2 0-22 "{ let x : Int = 4.0; }" : Unit
             #4 6-13 "x : Int" : Int
             #9 16-19 "4.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 16, hi: 19 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 16, hi: 19 }))))
         "##]],
     );
 }
@@ -287,7 +287,7 @@ fn incorrect_explicit_type_in_let_binding_used_later_correctly() {
             #11 21-26 "x + 1" : Int
             #12 21-22 "x" : Int
             #15 25-26 "1" : Int
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 16, hi: 19 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 16, hi: 19 }))))
         "##]],
     );
 }
@@ -462,7 +462,7 @@ fn add_wrong_types() {
             #13 42-43 "1" : Int
             #14 46-49 "[2]" : Int[]
             #15 47-48 "2" : Int
-            Error(Type(Error(TyMismatch("Int", "Int[]", Prim(Int), Array(Prim(Int)), Span { lo: 46, hi: 49 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Array(Prim(Int)), display: "Int[]" }, Span { lo: 46, hi: 49 }))))
         "##]],
     );
 }
@@ -483,7 +483,7 @@ fn int_as_double_error() {
             #19 103-140 "Microsoft.Quantum.Convert.IntAsDouble" : (Int -> Double)
             #25 140-147 "(false)" : Bool
             #26 141-146 "false" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 141, hi: 146 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Bool), display: "Bool" }, Span { lo: 141, hi: 146 }))))
         "##]],
     );
 }
@@ -507,7 +507,7 @@ fn ty_mismatch_span_tuple1_to_given() {
             #23 76-82 "((1,))" : (Int,)
             #24 77-81 "(1,)" : (Int,)
             #25 78-79 "1" : Int
-            Error(Type(Error(TyMismatch("Int", "(Int,)", Prim(Int), Tuple([Prim(Int)]), Span { lo: 77, hi: 81 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Tuple([Prim(Int)]), display: "(Int,)" }, Span { lo: 77, hi: 81 }))))
         "##]],
     );
 }
@@ -532,7 +532,7 @@ fn ty_mismatch_span_tuple1_to_given_extra_parens() {
             #24 77-83 "((1,))" : (Int,)
             #25 78-82 "(1,)" : (Int,)
             #26 79-80 "1" : Int
-            Error(Type(Error(TyMismatch("Int", "(Int,)", Prim(Int), Tuple([Prim(Int)]), Span { lo: 78, hi: 82 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Tuple([Prim(Int)]), display: "(Int,)" }, Span { lo: 78, hi: 82 }))))
         "##]],
     );
 }
@@ -556,7 +556,7 @@ fn ty_mismatch_span_given_to_tuple1() {
             #20 68-79 "Namespace.F" : ((Int,) -> Double)
             #24 79-82 "(1)" : Int
             #25 80-81 "1" : Int
-            Error(Type(Error(TyMismatch("(Int,)", "Int", Tuple([Prim(Int)]), Prim(Int), Span { lo: 80, hi: 81 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Int)]), display: "(Int,)" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 80, hi: 81 }))))
         "##]],
     );
 }
@@ -581,7 +581,7 @@ fn ty_mismatch_span_tuple1_to_tuple1() {
             #24 79-86 "((1.,))" : (Double,)
             #25 80-85 "(1.,)" : (Double,)
             #26 81-83 "1." : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 81, hi: 83 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 81, hi: 83 }))))
         "##]],
     );
 }
@@ -608,7 +608,7 @@ fn ty_mismatch_span_tuple2_to_tuple2() {
             #30 87-93 "(1.,2)" : (Double, Int)
             #31 88-90 "1." : Double
             #32 91-92 "2" : Int
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 88, hi: 90 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 88, hi: 90 }))))
         "##]],
     );
 }
@@ -632,7 +632,7 @@ fn length_type_error() {
             #24 92-93 "1" : Int
             #25 95-96 "2" : Int
             #26 98-99 "3" : Int
-            Error(Type(Error(TyMismatch("?[]", "(Int, Int, Int)", Array(Infer(InferTyId(0))), Tuple([Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 91, hi: 100 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Array(Infer(InferTyId(0))), display: "?[]" }, TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int)" }, Span { lo: 91, hi: 100 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 84, hi: 90 }))))
         "##]],
     );
@@ -663,7 +663,7 @@ fn single_arg_for_tuple() {
             #31 124-126 "Ry" : ((Double, Qubit) => Unit is Adj + Ctl)
             #34 126-129 "(q)" : Qubit
             #35 127-128 "q" : Qubit
-            Error(Type(Error(TyMismatch("(Double, Qubit)", "Qubit", Tuple([Prim(Double), Prim(Qubit)]), Prim(Qubit), Span { lo: 127, hi: 128 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Double), Prim(Qubit)]), display: "(Double, Qubit)" }, TyInfo { kind: Prim(Qubit), display: "Qubit" }, Span { lo: 127, hi: 128 }))))
         "##]],
     );
 }
@@ -695,7 +695,7 @@ fn array_repeat_error() {
             #1 0-16 "[4, size = true]" : Int[]
             #2 1-2 "4" : Int
             #3 11-15 "true" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 11, hi: 15 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Bool), display: "Bool" }, Span { lo: 11, hi: 15 }))))
         "##]],
     );
 }
@@ -720,7 +720,7 @@ fn assignop_error() {
             #9 33-34 "x" : Bool
             #12 38-39 "1" : Int
             #14 45-46 "x" : Bool
-            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 38, hi: 39 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Bool), display: "Bool" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 38, hi: 39 }))))
             Error(Type(Error(MissingClassAdd("Bool", Span { lo: 33, hi: 34 }))))
         "##]],
     );
@@ -737,7 +737,7 @@ fn binop_add_invalid() {
             #3 1-2 "1" : Int
             #4 4-5 "3" : Int
             #5 9-12 "5.4" : Double
-            Error(Type(Error(TyMismatch("(Int, Int)", "Double", Tuple([Prim(Int), Prim(Int)]), Prim(Double), Span { lo: 9, hi: 12 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Int), Prim(Int)]), display: "(Int, Int)" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 9, hi: 12 }))))
             Error(Type(Error(MissingClassAdd("(Int, Int)", Span { lo: 0, hi: 6 }))))
         "##]],
     );
@@ -752,7 +752,7 @@ fn binop_add_mismatch() {
             #1 0-7 "1 + 5.4" : Int
             #2 0-1 "1" : Int
             #3 4-7 "5.4" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 4, hi: 7 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 4, hi: 7 }))))
         "##]],
     );
 }
@@ -780,7 +780,7 @@ fn binop_andb_mismatch() {
             #1 0-10 "28 &&& 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
-            Error(Type(Error(TyMismatch("Int", "BigInt", Prim(Int), Prim(BigInt), Span { lo: 7, hi: 10 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(BigInt), display: "BigInt" }, Span { lo: 7, hi: 10 }))))
         "##]],
     );
 }
@@ -824,7 +824,7 @@ fn binop_equal_tuple_arity_mismatch() {
             #8 17-18 "2" : Int
             #9 20-21 "3" : Int
             #10 23-24 "4" : Int
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, Int, Int, Int)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 13, hi: 25 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int)" }, TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int, Int)" }, Span { lo: 13, hi: 25 }))))
         "##]],
     );
 }
@@ -844,7 +844,7 @@ fn binop_equal_tuple_type_mismatch() {
             #7 14-15 "1" : Int
             #8 17-21 "Zero" : Result
             #9 23-24 "3" : Int
-            Error(Type(Error(TyMismatch("Int", "Result", Prim(Int), Prim(Result), Span { lo: 13, hi: 25 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Result), display: "Result" }, Span { lo: 13, hi: 25 }))))
         "##]],
     );
 }
@@ -858,7 +858,7 @@ fn binop_eq_mismatch() {
             #1 0-9 "18L == 18" : Bool
             #2 0-3 "18L" : BigInt
             #3 7-9 "18" : Int
-            Error(Type(Error(TyMismatch("BigInt", "Int", Prim(BigInt), Prim(Int), Span { lo: 7, hi: 9 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(BigInt), display: "BigInt" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 7, hi: 9 }))))
         "##]],
     );
 }
@@ -872,7 +872,7 @@ fn binop_neq_mismatch() {
             #1 0-9 "18L != 18" : Bool
             #2 0-3 "18L" : BigInt
             #3 7-9 "18" : Int
-            Error(Type(Error(TyMismatch("BigInt", "Int", Prim(BigInt), Prim(Int), Span { lo: 7, hi: 9 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(BigInt), display: "BigInt" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 7, hi: 9 }))))
         "##]],
     );
 }
@@ -892,7 +892,7 @@ fn binop_neq_tuple_type_mismatch() {
             #7 14-15 "1" : Int
             #8 17-21 "Zero" : Result
             #9 23-24 "3" : Int
-            Error(Type(Error(TyMismatch("Int", "Result", Prim(Int), Prim(Result), Span { lo: 13, hi: 25 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Result), display: "Result" }, Span { lo: 13, hi: 25 }))))
         "##]],
     );
 }
@@ -913,7 +913,7 @@ fn binop_neq_tuple_arity_mismatch() {
             #8 17-18 "2" : Int
             #9 20-21 "3" : Int
             #10 23-24 "4" : Int
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, Int, Int, Int)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 13, hi: 25 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int)" }, TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int, Int)" }, Span { lo: 13, hi: 25 }))))
         "##]],
     );
 }
@@ -941,7 +941,7 @@ fn binop_orb_mismatch() {
             #1 0-10 "28 ||| 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
-            Error(Type(Error(TyMismatch("Int", "BigInt", Prim(Int), Prim(BigInt), Span { lo: 7, hi: 10 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(BigInt), display: "BigInt" }, Span { lo: 7, hi: 10 }))))
         "##]],
     );
 }
@@ -969,7 +969,7 @@ fn binop_xorb_mismatch() {
             #1 0-10 "28 ^^^ 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
-            Error(Type(Error(TyMismatch("Int", "BigInt", Prim(Int), Prim(BigInt), Span { lo: 7, hi: 10 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(BigInt), display: "BigInt" }, Span { lo: 7, hi: 10 }))))
         "##]],
     );
 }
@@ -989,7 +989,7 @@ fn let_tuple_arity_error() {
             #11 18-24 "(0, 1)" : (Int, Int)
             #12 19-20 "0" : Int
             #13 22-23 "1" : Int
-            Error(Type(Error(TyMismatch("(?, ?, ?)", "(Int, Int)", Tuple([Infer(InferTyId(0)), Infer(InferTyId(1)), Infer(InferTyId(2))]), Tuple([Prim(Int), Prim(Int)]), Span { lo: 18, hi: 24 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Infer(InferTyId(0)), Infer(InferTyId(1)), Infer(InferTyId(2))]), display: "(?, ?, ?)" }, TyInfo { kind: Tuple([Prim(Int), Prim(Int)]), display: "(Int, Int)" }, Span { lo: 18, hi: 24 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 13, hi: 14 }))))
         "##]],
     );
@@ -1024,7 +1024,7 @@ fn set_tuple_arity_error() {
             #23 52-53 "2" : Int
             #24 55-56 "3" : Int
             #26 63-64 "x" : Int
-            Error(Type(Error(TyMismatch("(Int, Int)", "(Int, Int, Int)", Tuple([Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 39, hi: 45 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Int), Prim(Int)]), display: "(Int, Int)" }, TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int)" }, Span { lo: 39, hi: 45 }))))
         "##]],
     );
 }
@@ -1040,7 +1040,7 @@ fn qubit_array_length_error() {
             #4 6-7 "q" : Qubit[]
             #6 10-22 "Qubit[false]" : Qubit[]
             #7 16-21 "false" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 16, hi: 21 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Bool), display: "Bool" }, Span { lo: 16, hi: 21 }))))
         "##]],
     );
 }
@@ -1061,7 +1061,7 @@ fn qubit_tuple_arity_error() {
             #11 23-24 "3" : Int
             #12 27-34 "Qubit()" : Qubit
             #13 36-43 "Qubit()" : Qubit
-            Error(Type(Error(TyMismatch("(Qubit[], Qubit, Qubit)", "(?, ?)", Tuple([Array(Prim(Qubit)), Prim(Qubit), Prim(Qubit)]), Tuple([Infer(InferTyId(0)), Infer(InferTyId(1))]), Span { lo: 6, hi: 13 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Array(Prim(Qubit)), Prim(Qubit), Prim(Qubit)]), display: "(Qubit[], Qubit, Qubit)" }, TyInfo { kind: Tuple([Infer(InferTyId(0)), Infer(InferTyId(1))]), display: "(?, ?)" }, Span { lo: 6, hi: 13 }))))
         "##]],
     );
 }
@@ -1099,7 +1099,7 @@ fn for_loop_body_should_be_unit_error() {
             #7 16-17 "3" : Int
             #8 19-24 "{ 4 }" : Int
             #10 21-22 "4" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 19, hi: 24 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 19, hi: 24 }))))
         "##]],
     );
 }
@@ -1134,7 +1134,7 @@ fn for_loop_incorrect_explicit_type_error() {
             #9 21-22 "1" : Int
             #10 23-29 "{ i; }" : Unit
             #12 25-26 "i" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 18, hi: 22 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 18, hi: 22 }))))
         "##]],
     );
 }
@@ -1148,7 +1148,7 @@ fn repeat_loop_non_bool_condition_error() {
             #1 0-18 "repeat { } until 1" : Unit
             #2 7-10 "{ }" : Unit
             #3 17-18 "1" : Int
-            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 17, hi: 18 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Bool), display: "Bool" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 17, hi: 18 }))))
         "##]],
     );
 }
@@ -1163,7 +1163,7 @@ fn repeat_loop_body_should_be_unit_error() {
             #2 7-12 "{ 1 }" : Int
             #4 9-10 "1" : Int
             #5 19-24 "false" : Bool
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 7, hi: 12 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 7, hi: 12 }))))
         "##]],
     );
 }
@@ -1179,7 +1179,7 @@ fn repeat_loop_fixup_should_be_unit_error() {
             #3 17-22 "false" : Bool
             #4 29-34 "{ 1 }" : Int
             #6 31-32 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 29, hi: 34 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 29, hi: 34 }))))
         "##]],
     );
 }
@@ -1193,7 +1193,7 @@ fn if_cond_error() {
             #1 0-7 "if 4 {}" : Unit
             #2 3-4 "4" : Int
             #3 5-7 "{}" : Unit
-            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 3, hi: 4 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Bool), display: "Bool" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 3, hi: 4 }))))
         "##]],
     );
 }
@@ -1208,7 +1208,7 @@ fn if_no_else_must_be_unit() {
             #2 3-7 "true" : Bool
             #3 8-13 "{ 4 }" : Int
             #5 10-11 "4" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 8, hi: 13 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 8, hi: 13 }))))
         "##]],
     );
 }
@@ -1321,7 +1321,7 @@ fn ternop_cond_error() {
             #2 0-1 "7" : Int
             #3 4-5 "1" : Int
             #4 8-9 "0" : Int
-            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 0, hi: 1 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Bool), display: "Bool" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 0, hi: 1 }))))
         "##]],
     );
 }
@@ -1621,7 +1621,7 @@ fn ternop_update_array_range_with_non_array_error() {
             #24 91-92 "0" : Int
             #25 94-95 "1" : Int
             #26 99-100 "3" : Int
-            Error(Type(Error(TyMismatch("Int[]", "Int", Array(Prim(Int)), Prim(Int), Span { lo: 85, hi: 100 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Array(Prim(Int)), display: "Int[]" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 85, hi: 100 }))))
         "##]],
     );
 }
@@ -1660,7 +1660,7 @@ fn unop_not_int() {
         &expect![[r##"
             #1 0-5 "not 0" : Int
             #2 4-5 "0" : Int
-            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 4, hi: 5 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Bool), display: "Bool" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 4, hi: 5 }))))
         "##]],
     );
 }
@@ -1700,7 +1700,7 @@ fn while_cond_error() {
             #1 0-13 "while Zero {}" : Unit
             #2 6-10 "Zero" : Result
             #3 11-13 "{}" : Unit
-            Error(Type(Error(TyMismatch("Bool", "Result", Prim(Bool), Prim(Result), Span { lo: 6, hi: 10 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Bool), display: "Bool" }, TyInfo { kind: Prim(Result), display: "Result" }, Span { lo: 6, hi: 10 }))))
         "##]],
     );
 }
@@ -1715,7 +1715,7 @@ fn while_body_should_be_unit_error() {
             #2 6-10 "true" : Bool
             #3 11-16 "{ 1 }" : Int
             #5 13-14 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 11, hi: 16 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 11, hi: 16 }))))
         "##]],
     );
 }
@@ -1877,7 +1877,7 @@ fn call_controlled_error() {
             #39 163-166 "[1]" : Int[]
             #40 164-165 "1" : Int
             #41 168-169 "q" : Qubit
-            Error(Type(Error(TyMismatch("Qubit", "Int", Prim(Qubit), Prim(Int), Span { lo: 163, hi: 166 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Qubit), display: "Qubit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 163, hi: 166 }))))
         "##]],
     );
 }
@@ -1895,7 +1895,7 @@ fn adj_requires_unit_return() {
             #6 31-33 "()" : Unit
             #11 47-52 "{ 1 }" : Int
             #13 49-50 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 36, hi: 39 }))))
         "##]],
     );
 }
@@ -1913,7 +1913,7 @@ fn ctl_requires_unit_return() {
             #6 31-33 "()" : Unit
             #11 47-52 "{ 1 }" : Int
             #13 49-50 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 36, hi: 39 }))))
         "##]],
     );
 }
@@ -1931,7 +1931,7 @@ fn adj_ctl_requires_unit_return() {
             #6 31-33 "()" : Unit
             #13 53-58 "{ 1 }" : Int
             #15 55-56 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 36, hi: 39 }))))
         "##]],
     );
 }
@@ -2045,7 +2045,7 @@ fn fail_in_array_still_checks_other_array_elements() {
             #3 4-15 "fail \"true\"" : Int
             #4 9-15 "\"true\"" : String
             #5 17-20 "3.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 17, hi: 20 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 17, hi: 20 }))))
         "##]],
     );
 }
@@ -2074,7 +2074,7 @@ fn fail_in_call_args_checks_arity() {
             #33 64-65 "1" : Int
             #34 67-78 "fail \"true\"" : Int
             #35 72-78 "\"true\"" : String
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, ?)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Infer(InferTyId(0))]), Span { lo: 63, hi: 79 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int)" }, TyInfo { kind: Tuple([Prim(Int), Infer(InferTyId(0))]), display: "(Int, ?)" }, Span { lo: 63, hi: 79 }))))
         "##]],
     );
 }
@@ -2104,7 +2104,7 @@ fn fail_in_call_args_checks_non_divergent_types() {
             #34 67-78 "fail \"true\"" : Int
             #35 72-78 "\"true\"" : String
             #36 80-83 "3.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 80, hi: 83 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 80, hi: 83 }))))
         "##]],
     );
 }
@@ -2301,7 +2301,7 @@ fn return_in_call_args_checks_arity() {
             #33 64-65 "1" : Int
             #34 67-80 "return \"true\"" : Int
             #35 74-80 "\"true\"" : String
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, ?)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Infer(InferTyId(0))]), Span { lo: 63, hi: 81 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([Prim(Int), Prim(Int), Prim(Int)]), display: "(Int, Int, Int)" }, TyInfo { kind: Tuple([Prim(Int), Infer(InferTyId(0))]), display: "(Int, ?)" }, Span { lo: 63, hi: 81 }))))
         "##]],
     );
 }
@@ -2331,7 +2331,7 @@ fn return_in_call_args_checks_non_divergent_types() {
             #34 67-80 "return \"true\"" : Int
             #35 74-80 "\"true\"" : String
             #36 82-85 "3.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 82, hi: 85 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 82, hi: 85 }))))
         "##]],
     );
 }
@@ -2409,7 +2409,7 @@ fn return_mismatch() {
             #15 47-75 "{\n        return true;\n    }" : Int
             #17 57-68 "return true" : Unit
             #18 64-68 "true" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 64, hi: 68 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Bool), display: "Bool" }, Span { lo: 64, hi: 68 }))))
         "##]],
     );
 }
@@ -2923,7 +2923,7 @@ fn newtype_cons_wrong_input() {
             #19 70-76 "NewInt" : (Int -> UDT<"NewInt": Item 1 (Package 2)>)
             #22 76-81 "(5.0)" : Double
             #23 77-80 "5.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 77, hi: 80 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 77, hi: 80 }))))
         "##]],
     );
 }
@@ -2964,7 +2964,7 @@ fn struct_cons_wrong_input() {
             #25 88-124 "new Pair { First = 5.0, Second = 6 }" : UDT<"Pair": Item 1 (Package 2)>
             #30 107-110 "5.0" : Double
             #33 121-122 "6" : Int
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 99, hi: 110 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 99, hi: 110 }))))
         "##]],
     );
 }
@@ -3268,7 +3268,7 @@ fn newtype_does_not_match_base_ty() {
             #19 67-73 "NewInt" : (Int -> UDT<"NewInt": Item 1 (Package 2)>)
             #22 73-76 "(5)" : Int
             #23 74-75 "5" : Int
-            Error(Type(Error(TyMismatch("Int", "NewInt", Prim(Int), Udt, Span { lo: 67, hi: 76 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Udt, display: "NewInt" }, Span { lo: 67, hi: 76 }))))
         "##]],
     );
 }
@@ -3291,7 +3291,7 @@ fn newtype_does_not_match_other_newtype() {
             #25 99-106 "NewInt1" : (Int -> UDT<"NewInt1": Item 1 (Package 2)>)
             #28 106-109 "(5)" : Int
             #29 107-108 "5" : Int
-            Error(Type(Error(TyMismatch("NewInt2", "NewInt1", Udt, Udt, Span { lo: 99, hi: 109 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Udt, display: "NewInt2" }, TyInfo { kind: Udt, display: "NewInt1" }, Span { lo: 99, hi: 109 }))))
         "##]],
     );
 }
@@ -3574,7 +3574,7 @@ fn local_function_error() {
             #23 86-91 "Bar()" : Int
             #24 86-89 "Bar" : (Unit -> Int)
             #27 89-91 "()" : Unit
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 72, hi: 75 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 72, hi: 75 }))))
         "##]],
     );
 }
@@ -3624,7 +3624,7 @@ fn local_function_last_stmt_is_unit_block() {
             #21 76-78 "()" : Unit
             #25 85-90 "{ 4 }" : Int
             #27 87-88 "4" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 35, hi: 38 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 35, hi: 38 }))))
         "##]],
     );
 }
@@ -4191,7 +4191,7 @@ fn partial_app_too_many_args() {
             #29 56-57 "1" : Int
             #30 59-60 "_" : ?1
             #31 62-63 "_" : ?2
-            Error(Type(Error(TyMismatch("Int", "(Int, ?, ?)", Prim(Int), Tuple([Prim(Int), Infer(InferTyId(1)), Infer(InferTyId(2))]), Span { lo: 55, hi: 64 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Tuple([Prim(Int), Infer(InferTyId(1)), Infer(InferTyId(2))]), display: "(Int, ?, ?)" }, Span { lo: 55, hi: 64 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 59, hi: 60 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
         "##]],
@@ -4881,11 +4881,11 @@ fn inference_infinite_recursion_should_fail() {
             #50 180-187 "A and B" : (((?2, ?3) -> ?2) -> ?2[])
             #51 180-181 "A" : (((?2, ?3) -> ?2) -> ?2[])
             #54 186-187 "B" : (((?2, ?3) -> ?2) -> ?2)
-            Error(Type(Error(TyMismatch("Unit", "'U1[]", Tuple([]), Array(Param), Span { lo: 62, hi: 67 }))))
-            Error(Type(Error(TyMismatch("Unit", "'T2", Tuple([]), Param, Span { lo: 129, hi: 132 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Array(Param), display: "'U1[]" }, Span { lo: 62, hi: 67 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Param, display: "'T2" }, Span { lo: 129, hi: 132 }))))
             Error(Type(Error(RecursiveTypeConstraint(Span { lo: 186, hi: 187 }))))
-            Error(Type(Error(TyMismatch("Bool", "(((?, ?) -> ?) -> ?[])", Prim(Bool), Arrow, Span { lo: 180, hi: 181 }))))
-            Error(Type(Error(TyMismatch("Unit", "(((?, ?) -> ?) -> ?[])", Tuple([]), Arrow, Span { lo: 180, hi: 187 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Bool), display: "Bool" }, TyInfo { kind: Arrow, display: "(((?, ?) -> ?) -> ?[])" }, Span { lo: 180, hi: 181 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Arrow, display: "(((?, ?) -> ?) -> ?[])" }, Span { lo: 180, hi: 187 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 186, hi: 187 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 186, hi: 187 }))))
         "##]],
@@ -4997,7 +4997,7 @@ fn within_block_should_be_unit_error() {
             #4 9-10 "4" : Int
             #5 19-24 "{ 0 }" : Int
             #7 21-22 "0" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 7, hi: 12 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Tuple([]), display: "Unit" }, TyInfo { kind: Prim(Int), display: "Int" }, Span { lo: 7, hi: 12 }))))
         "##]],
     );
 }
@@ -5389,7 +5389,7 @@ fn complex_literal_with_two_real_parts_error() {
             #3 0-3 "2.0" : Double
             #4 6-9 "3.0" : Double
             #5 12-16 "4.0i" : UDT<"Complex(Test)": Item 3 (Package 0)>
-            Error(Type(Error(TyMismatch("Double", "Complex(Test)", Prim(Double), Udt, Span { lo: 12, hi: 16 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Double), display: "Double" }, TyInfo { kind: Udt, display: "Complex(Test)" }, Span { lo: 12, hi: 16 }))))
         "##]],
     );
 }
@@ -5406,7 +5406,7 @@ fn add_double_and_complex_literal_with_parens_error() {
             #4 7-17 "3.0 + 4.0i" : UDT<"Complex(Test)": Item 3 (Package 0)>
             #5 7-10 "3.0" : Double
             #6 13-17 "4.0i" : UDT<"Complex(Test)": Item 3 (Package 0)>
-            Error(Type(Error(TyMismatch("Double", "Complex(Test)", Prim(Double), Udt, Span { lo: 6, hi: 18 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Double), display: "Double" }, TyInfo { kind: Udt, display: "Complex(Test)" }, Span { lo: 6, hi: 18 }))))
         "##]],
     );
 }
@@ -5704,7 +5704,7 @@ fn call_expr_non_tuple_expr() {
             #27 56-57 "f" : ((Double, Double) -> Double)
             #30 57-60 "(x)" : (Int, Double)
             #31 58-59 "x" : (Int, Double)
-            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 58, hi: 59 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Double), display: "Double" }, Span { lo: 58, hi: 59 }))))
         "##]],
     );
 }

--- a/source/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests.rs
@@ -218,12 +218,12 @@ fn return_wrong_type() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #10 39-47 "{ true }" : Bool
             #12 41-45 "true" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Span { lo: 41, hi: 45 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 41, hi: 45 }))))
+        "##]],
     );
 }
 
@@ -236,12 +236,12 @@ fn return_semi() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #10 39-45 "{ 4; }" : Unit
             #12 41-42 "4" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 35, hi: 38 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 35, hi: 38 }))))
+        "##]],
     );
 }
 
@@ -269,7 +269,7 @@ fn incorrect_explicit_type_in_let_binding_error() {
             #2 0-22 "{ let x : Int = 4.0; }" : Unit
             #4 6-13 "x : Int" : Int
             #9 16-19 "4.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 16, hi: 19 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 16, hi: 19 }))))
         "##]],
     );
 }
@@ -287,7 +287,7 @@ fn incorrect_explicit_type_in_let_binding_used_later_correctly() {
             #11 21-26 "x + 1" : Int
             #12 21-22 "x" : Int
             #15 25-26 "1" : Int
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 16, hi: 19 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 16, hi: 19 }))))
         "##]],
     );
 }
@@ -455,15 +455,15 @@ fn add_wrong_types() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #10 40-52 "{ 1 + [2]; }" : Unit
             #12 42-49 "1 + [2]" : Int
             #13 42-43 "1" : Int
             #14 46-49 "[2]" : Int[]
             #15 47-48 "2" : Int
-            Error(Type(Error(TyMismatch("Int", "Int[]", Span { lo: 46, hi: 49 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Int[]", Prim(Int), Array(Prim(Int)), Span { lo: 46, hi: 49 }))))
+        "##]],
     );
 }
 
@@ -483,7 +483,7 @@ fn int_as_double_error() {
             #19 103-140 "Microsoft.Quantum.Convert.IntAsDouble" : (Int -> Double)
             #25 140-147 "(false)" : Bool
             #26 141-146 "false" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Span { lo: 141, hi: 146 }))))
+            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 141, hi: 146 }))))
         "##]],
     );
 }
@@ -507,7 +507,7 @@ fn ty_mismatch_span_tuple1_to_given() {
             #23 76-82 "((1,))" : (Int,)
             #24 77-81 "(1,)" : (Int,)
             #25 78-79 "1" : Int
-            Error(Type(Error(TyMismatch("Int", "(Int,)", Span { lo: 77, hi: 81 }))))
+            Error(Type(Error(TyMismatch("Int", "(Int,)", Prim(Int), Tuple([Prim(Int)]), Span { lo: 77, hi: 81 }))))
         "##]],
     );
 }
@@ -532,7 +532,7 @@ fn ty_mismatch_span_tuple1_to_given_extra_parens() {
             #24 77-83 "((1,))" : (Int,)
             #25 78-82 "(1,)" : (Int,)
             #26 79-80 "1" : Int
-            Error(Type(Error(TyMismatch("Int", "(Int,)", Span { lo: 78, hi: 82 }))))
+            Error(Type(Error(TyMismatch("Int", "(Int,)", Prim(Int), Tuple([Prim(Int)]), Span { lo: 78, hi: 82 }))))
         "##]],
     );
 }
@@ -556,7 +556,7 @@ fn ty_mismatch_span_given_to_tuple1() {
             #20 68-79 "Namespace.F" : ((Int,) -> Double)
             #24 79-82 "(1)" : Int
             #25 80-81 "1" : Int
-            Error(Type(Error(TyMismatch("(Int,)", "Int", Span { lo: 80, hi: 81 }))))
+            Error(Type(Error(TyMismatch("(Int,)", "Int", Tuple([Prim(Int)]), Prim(Int), Span { lo: 80, hi: 81 }))))
         "##]],
     );
 }
@@ -581,7 +581,7 @@ fn ty_mismatch_span_tuple1_to_tuple1() {
             #24 79-86 "((1.,))" : (Double,)
             #25 80-85 "(1.,)" : (Double,)
             #26 81-83 "1." : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 81, hi: 83 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 81, hi: 83 }))))
         "##]],
     );
 }
@@ -608,7 +608,7 @@ fn ty_mismatch_span_tuple2_to_tuple2() {
             #30 87-93 "(1.,2)" : (Double, Int)
             #31 88-90 "1." : Double
             #32 91-92 "2" : Int
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 88, hi: 90 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 88, hi: 90 }))))
         "##]],
     );
 }
@@ -632,7 +632,7 @@ fn length_type_error() {
             #24 92-93 "1" : Int
             #25 95-96 "2" : Int
             #26 98-99 "3" : Int
-            Error(Type(Error(TyMismatch("?[]", "(Int, Int, Int)", Span { lo: 91, hi: 100 }))))
+            Error(Type(Error(TyMismatch("?[]", "(Int, Int, Int)", Array(Infer(InferTyId(0))), Tuple([Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 91, hi: 100 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 84, hi: 90 }))))
         "##]],
     );
@@ -663,7 +663,7 @@ fn single_arg_for_tuple() {
             #31 124-126 "Ry" : ((Double, Qubit) => Unit is Adj + Ctl)
             #34 126-129 "(q)" : Qubit
             #35 127-128 "q" : Qubit
-            Error(Type(Error(TyMismatch("(Double, Qubit)", "Qubit", Span { lo: 127, hi: 128 }))))
+            Error(Type(Error(TyMismatch("(Double, Qubit)", "Qubit", Tuple([Prim(Double), Prim(Qubit)]), Prim(Qubit), Span { lo: 127, hi: 128 }))))
         "##]],
     );
 }
@@ -691,12 +691,12 @@ fn array_repeat_error() {
     check(
         "",
         "[4, size = true]",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-16 "[4, size = true]" : Int[]
             #2 1-2 "4" : Int
             #3 11-15 "true" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Span { lo: 11, hi: 15 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 11, hi: 15 }))))
+        "##]],
     );
 }
 
@@ -711,7 +711,7 @@ fn assignop_error() {
                 x
             }
         "},
-        &expect![[r#"
+        &expect![[r##"
             #1 0-48 "{\n    mutable x = false;\n    set x += 1;\n    x\n}" : Bool
             #2 0-48 "{\n    mutable x = false;\n    set x += 1;\n    x\n}" : Bool
             #4 14-15 "x" : Bool
@@ -720,9 +720,9 @@ fn assignop_error() {
             #9 33-34 "x" : Bool
             #12 38-39 "1" : Int
             #14 45-46 "x" : Bool
-            Error(Type(Error(TyMismatch("Bool", "Int", Span { lo: 38, hi: 39 }))))
+            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 38, hi: 39 }))))
             Error(Type(Error(MissingClassAdd("Bool", Span { lo: 33, hi: 34 }))))
-        "#]],
+        "##]],
     );
 }
 
@@ -731,15 +731,15 @@ fn binop_add_invalid() {
     check(
         "",
         "(1, 3) + 5.4",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-12 "(1, 3) + 5.4" : (Int, Int)
             #2 0-6 "(1, 3)" : (Int, Int)
             #3 1-2 "1" : Int
             #4 4-5 "3" : Int
             #5 9-12 "5.4" : Double
-            Error(Type(Error(TyMismatch("(Int, Int)", "Double", Span { lo: 9, hi: 12 }))))
+            Error(Type(Error(TyMismatch("(Int, Int)", "Double", Tuple([Prim(Int), Prim(Int)]), Prim(Double), Span { lo: 9, hi: 12 }))))
             Error(Type(Error(MissingClassAdd("(Int, Int)", Span { lo: 0, hi: 6 }))))
-        "#]],
+        "##]],
     );
 }
 
@@ -748,12 +748,12 @@ fn binop_add_mismatch() {
     check(
         "",
         "1 + 5.4",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-7 "1 + 5.4" : Int
             #2 0-1 "1" : Int
             #3 4-7 "5.4" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 4, hi: 7 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 4, hi: 7 }))))
+        "##]],
     );
 }
 
@@ -776,12 +776,12 @@ fn binop_andb_mismatch() {
     check(
         "",
         "28 &&& 54L",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-10 "28 &&& 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
-            Error(Type(Error(TyMismatch("Int", "BigInt", Span { lo: 7, hi: 10 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "BigInt", Prim(Int), Prim(BigInt), Span { lo: 7, hi: 10 }))))
+        "##]],
     );
 }
 
@@ -813,7 +813,7 @@ fn binop_equal_tuple_arity_mismatch() {
     check(
         "",
         "(1, 2, 3) == (1, 2, 3, 4)",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-25 "(1, 2, 3) == (1, 2, 3, 4)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -824,8 +824,8 @@ fn binop_equal_tuple_arity_mismatch() {
             #8 17-18 "2" : Int
             #9 20-21 "3" : Int
             #10 23-24 "4" : Int
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, Int, Int, Int)", Span { lo: 13, hi: 25 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, Int, Int, Int)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 13, hi: 25 }))))
+        "##]],
     );
 }
 
@@ -834,7 +834,7 @@ fn binop_equal_tuple_type_mismatch() {
     check(
         "",
         "(1, 2, 3) == (1, Zero, 3)",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-25 "(1, 2, 3) == (1, Zero, 3)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -844,8 +844,8 @@ fn binop_equal_tuple_type_mismatch() {
             #7 14-15 "1" : Int
             #8 17-21 "Zero" : Result
             #9 23-24 "3" : Int
-            Error(Type(Error(TyMismatch("Int", "Result", Span { lo: 13, hi: 25 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Result", Prim(Int), Prim(Result), Span { lo: 13, hi: 25 }))))
+        "##]],
     );
 }
 
@@ -854,12 +854,12 @@ fn binop_eq_mismatch() {
     check(
         "",
         "18L == 18",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-9 "18L == 18" : Bool
             #2 0-3 "18L" : BigInt
             #3 7-9 "18" : Int
-            Error(Type(Error(TyMismatch("BigInt", "Int", Span { lo: 7, hi: 9 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("BigInt", "Int", Prim(BigInt), Prim(Int), Span { lo: 7, hi: 9 }))))
+        "##]],
     );
 }
 
@@ -868,12 +868,12 @@ fn binop_neq_mismatch() {
     check(
         "",
         "18L != 18",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-9 "18L != 18" : Bool
             #2 0-3 "18L" : BigInt
             #3 7-9 "18" : Int
-            Error(Type(Error(TyMismatch("BigInt", "Int", Span { lo: 7, hi: 9 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("BigInt", "Int", Prim(BigInt), Prim(Int), Span { lo: 7, hi: 9 }))))
+        "##]],
     );
 }
 
@@ -882,7 +882,7 @@ fn binop_neq_tuple_type_mismatch() {
     check(
         "",
         "(1, 2, 3) != (1, Zero, 3)",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-25 "(1, 2, 3) != (1, Zero, 3)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -892,8 +892,8 @@ fn binop_neq_tuple_type_mismatch() {
             #7 14-15 "1" : Int
             #8 17-21 "Zero" : Result
             #9 23-24 "3" : Int
-            Error(Type(Error(TyMismatch("Int", "Result", Span { lo: 13, hi: 25 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Result", Prim(Int), Prim(Result), Span { lo: 13, hi: 25 }))))
+        "##]],
     );
 }
 
@@ -902,7 +902,7 @@ fn binop_neq_tuple_arity_mismatch() {
     check(
         "",
         "(1, 2, 3) != (1, 2, 3, 4)",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-25 "(1, 2, 3) != (1, 2, 3, 4)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -913,8 +913,8 @@ fn binop_neq_tuple_arity_mismatch() {
             #8 17-18 "2" : Int
             #9 20-21 "3" : Int
             #10 23-24 "4" : Int
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, Int, Int, Int)", Span { lo: 13, hi: 25 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, Int, Int, Int)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 13, hi: 25 }))))
+        "##]],
     );
 }
 
@@ -937,12 +937,12 @@ fn binop_orb_mismatch() {
     check(
         "",
         "28 ||| 54L",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-10 "28 ||| 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
-            Error(Type(Error(TyMismatch("Int", "BigInt", Span { lo: 7, hi: 10 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "BigInt", Prim(Int), Prim(BigInt), Span { lo: 7, hi: 10 }))))
+        "##]],
     );
 }
 
@@ -965,12 +965,12 @@ fn binop_xorb_mismatch() {
     check(
         "",
         "28 ^^^ 54L",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-10 "28 ^^^ 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
-            Error(Type(Error(TyMismatch("Int", "BigInt", Span { lo: 7, hi: 10 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "BigInt", Prim(Int), Prim(BigInt), Span { lo: 7, hi: 10 }))))
+        "##]],
     );
 }
 
@@ -979,7 +979,7 @@ fn let_tuple_arity_error() {
     check(
         "",
         "{ let (x, y, z) = (0, 1); }",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-27 "{ let (x, y, z) = (0, 1); }" : Unit
             #2 0-27 "{ let (x, y, z) = (0, 1); }" : Unit
             #4 6-15 "(x, y, z)" : (Int, Int, ?2)
@@ -989,9 +989,9 @@ fn let_tuple_arity_error() {
             #11 18-24 "(0, 1)" : (Int, Int)
             #12 19-20 "0" : Int
             #13 22-23 "1" : Int
-            Error(Type(Error(TyMismatch("(?, ?, ?)", "(Int, Int)", Span { lo: 18, hi: 24 }))))
+            Error(Type(Error(TyMismatch("(?, ?, ?)", "(Int, Int)", Tuple([Infer(InferTyId(0)), Infer(InferTyId(1)), Infer(InferTyId(2))]), Tuple([Prim(Int), Prim(Int)]), Span { lo: 18, hi: 24 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 13, hi: 14 }))))
-        "#]],
+        "##]],
     );
 }
 
@@ -1006,7 +1006,7 @@ fn set_tuple_arity_error() {
                 x
             }
         "},
-        &expect![[r#"
+        &expect![[r##"
             #1 0-66 "{\n    mutable (x, y) = (0, 1);\n    set (x, y) = (1, 2, 3);\n    x\n}" : Int
             #2 0-66 "{\n    mutable (x, y) = (0, 1);\n    set (x, y) = (1, 2, 3);\n    x\n}" : Int
             #4 14-20 "(x, y)" : (Int, Int)
@@ -1024,8 +1024,8 @@ fn set_tuple_arity_error() {
             #23 52-53 "2" : Int
             #24 55-56 "3" : Int
             #26 63-64 "x" : Int
-            Error(Type(Error(TyMismatch("(Int, Int)", "(Int, Int, Int)", Span { lo: 39, hi: 45 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("(Int, Int)", "(Int, Int, Int)", Tuple([Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 39, hi: 45 }))))
+        "##]],
     );
 }
 
@@ -1034,14 +1034,14 @@ fn qubit_array_length_error() {
     check(
         "",
         "{ use q = Qubit[false]; }",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-25 "{ use q = Qubit[false]; }" : Unit
             #2 0-25 "{ use q = Qubit[false]; }" : Unit
             #4 6-7 "q" : Qubit[]
             #6 10-22 "Qubit[false]" : Qubit[]
             #7 16-21 "false" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Span { lo: 16, hi: 21 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 16, hi: 21 }))))
+        "##]],
     );
 }
 
@@ -1050,7 +1050,7 @@ fn qubit_tuple_arity_error() {
     check(
         "",
         "{ use (q, q1) = (Qubit[3], Qubit(), Qubit()); }",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-47 "{ use (q, q1) = (Qubit[3], Qubit(), Qubit()); }" : Unit
             #2 0-47 "{ use (q, q1) = (Qubit[3], Qubit(), Qubit()); }" : Unit
             #4 6-13 "(q, q1)" : (Qubit[], Qubit)
@@ -1061,8 +1061,8 @@ fn qubit_tuple_arity_error() {
             #11 23-24 "3" : Int
             #12 27-34 "Qubit()" : Qubit
             #13 36-43 "Qubit()" : Qubit
-            Error(Type(Error(TyMismatch("(Qubit[], Qubit, Qubit)", "(?, ?)", Span { lo: 6, hi: 13 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("(Qubit[], Qubit, Qubit)", "(?, ?)", Tuple([Array(Prim(Qubit)), Prim(Qubit), Prim(Qubit)]), Tuple([Infer(InferTyId(0)), Infer(InferTyId(1))]), Span { lo: 6, hi: 13 }))))
+        "##]],
     );
 }
 
@@ -1091,16 +1091,16 @@ fn for_loop_body_should_be_unit_error() {
         "",
         "for i in [1, 2, 3] { 4 }",
         &expect![[r##"
-        #1 0-24 "for i in [1, 2, 3] { 4 }" : Unit
-        #2 4-5 "i" : Int
-        #4 9-18 "[1, 2, 3]" : Int[]
-        #5 10-11 "1" : Int
-        #6 13-14 "2" : Int
-        #7 16-17 "3" : Int
-        #8 19-24 "{ 4 }" : Int
-        #10 21-22 "4" : Int
-        Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 19, hi: 24 }))))
-    "##]],
+            #1 0-24 "for i in [1, 2, 3] { 4 }" : Unit
+            #2 4-5 "i" : Int
+            #4 9-18 "[1, 2, 3]" : Int[]
+            #5 10-11 "1" : Int
+            #6 13-14 "2" : Int
+            #7 16-17 "3" : Int
+            #8 19-24 "{ 4 }" : Int
+            #10 21-22 "4" : Int
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 19, hi: 24 }))))
+        "##]],
     );
 }
 
@@ -1134,7 +1134,7 @@ fn for_loop_incorrect_explicit_type_error() {
             #9 21-22 "1" : Int
             #10 23-29 "{ i; }" : Unit
             #12 25-26 "i" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 18, hi: 22 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 18, hi: 22 }))))
         "##]],
     );
 }
@@ -1148,7 +1148,7 @@ fn repeat_loop_non_bool_condition_error() {
             #1 0-18 "repeat { } until 1" : Unit
             #2 7-10 "{ }" : Unit
             #3 17-18 "1" : Int
-            Error(Type(Error(TyMismatch("Bool", "Int", Span { lo: 17, hi: 18 }))))
+            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 17, hi: 18 }))))
         "##]],
     );
 }
@@ -1163,7 +1163,7 @@ fn repeat_loop_body_should_be_unit_error() {
             #2 7-12 "{ 1 }" : Int
             #4 9-10 "1" : Int
             #5 19-24 "false" : Bool
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 7, hi: 12 }))))
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 7, hi: 12 }))))
         "##]],
     );
 }
@@ -1179,7 +1179,7 @@ fn repeat_loop_fixup_should_be_unit_error() {
             #3 17-22 "false" : Bool
             #4 29-34 "{ 1 }" : Int
             #6 31-32 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 29, hi: 34 }))))
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 29, hi: 34 }))))
         "##]],
     );
 }
@@ -1189,12 +1189,12 @@ fn if_cond_error() {
     check(
         "",
         "if 4 {}",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-7 "if 4 {}" : Unit
             #2 3-4 "4" : Int
             #3 5-7 "{}" : Unit
-            Error(Type(Error(TyMismatch("Bool", "Int", Span { lo: 3, hi: 4 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 3, hi: 4 }))))
+        "##]],
     );
 }
 
@@ -1203,13 +1203,13 @@ fn if_no_else_must_be_unit() {
     check(
         "",
         "if true { 4 }",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-13 "if true { 4 }" : Int
             #2 3-7 "true" : Bool
             #3 8-13 "{ 4 }" : Int
             #5 10-11 "4" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 8, hi: 13 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 8, hi: 13 }))))
+        "##]],
     );
 }
 
@@ -1316,13 +1316,13 @@ fn ternop_cond_error() {
     check(
         "",
         "7 ? 1 | 0",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-9 "7 ? 1 | 0" : Int
             #2 0-1 "7" : Int
             #3 4-5 "1" : Int
             #4 8-9 "0" : Int
-            Error(Type(Error(TyMismatch("Bool", "Int", Span { lo: 0, hi: 1 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 0, hi: 1 }))))
+        "##]],
     );
 }
 
@@ -1606,7 +1606,7 @@ fn ternop_update_array_range_with_non_array_error() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #8 38-107 "{\n        let xs = [0, 1, 2];\n        let ys = xs w/ 0..1 <- 3;\n    }" : Unit
             #10 52-54 "xs" : Int[]
@@ -1621,8 +1621,8 @@ fn ternop_update_array_range_with_non_array_error() {
             #24 91-92 "0" : Int
             #25 94-95 "1" : Int
             #26 99-100 "3" : Int
-            Error(Type(Error(TyMismatch("Int[]", "Int", Span { lo: 85, hi: 100 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int[]", "Int", Array(Prim(Int)), Prim(Int), Span { lo: 85, hi: 100 }))))
+        "##]],
     );
 }
 
@@ -1657,11 +1657,11 @@ fn unop_not_int() {
     check(
         "",
         "not 0",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-5 "not 0" : Int
             #2 4-5 "0" : Int
-            Error(Type(Error(TyMismatch("Bool", "Int", Span { lo: 4, hi: 5 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Bool", "Int", Prim(Bool), Prim(Int), Span { lo: 4, hi: 5 }))))
+        "##]],
     );
 }
 
@@ -1696,12 +1696,12 @@ fn while_cond_error() {
     check(
         "",
         "while Zero {}",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-13 "while Zero {}" : Unit
             #2 6-10 "Zero" : Result
             #3 11-13 "{}" : Unit
-            Error(Type(Error(TyMismatch("Bool", "Result", Span { lo: 6, hi: 10 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Bool", "Result", Prim(Bool), Prim(Result), Span { lo: 6, hi: 10 }))))
+        "##]],
     );
 }
 
@@ -1715,7 +1715,7 @@ fn while_body_should_be_unit_error() {
             #2 6-10 "true" : Bool
             #3 11-16 "{ 1 }" : Int
             #5 13-14 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 11, hi: 16 }))))
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 11, hi: 16 }))))
         "##]],
     );
 }
@@ -1877,7 +1877,7 @@ fn call_controlled_error() {
             #39 163-166 "[1]" : Int[]
             #40 164-165 "1" : Int
             #41 168-169 "q" : Qubit
-            Error(Type(Error(TyMismatch("Qubit", "Int", Span { lo: 163, hi: 166 }))))
+            Error(Type(Error(TyMismatch("Qubit", "Int", Prim(Qubit), Prim(Int), Span { lo: 163, hi: 166 }))))
         "##]],
     );
 }
@@ -1891,12 +1891,12 @@ fn adj_requires_unit_return() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 31-33 "()" : Unit
             #11 47-52 "{ 1 }" : Int
             #13 49-50 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 36, hi: 39 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
+        "##]],
     );
 }
 
@@ -1909,12 +1909,12 @@ fn ctl_requires_unit_return() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 31-33 "()" : Unit
             #11 47-52 "{ 1 }" : Int
             #13 49-50 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 36, hi: 39 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
+        "##]],
     );
 }
 
@@ -1927,12 +1927,12 @@ fn adj_ctl_requires_unit_return() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 31-33 "()" : Unit
             #13 53-58 "{ 1 }" : Int
             #15 55-56 "1" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 36, hi: 39 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
+        "##]],
     );
 }
 
@@ -2045,7 +2045,7 @@ fn fail_in_array_still_checks_other_array_elements() {
             #3 4-15 "fail \"true\"" : Int
             #4 9-15 "\"true\"" : String
             #5 17-20 "3.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 17, hi: 20 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 17, hi: 20 }))))
         "##]],
     );
 }
@@ -2074,7 +2074,7 @@ fn fail_in_call_args_checks_arity() {
             #33 64-65 "1" : Int
             #34 67-78 "fail \"true\"" : Int
             #35 72-78 "\"true\"" : String
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, ?)", Span { lo: 63, hi: 79 }))))
+            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, ?)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Infer(InferTyId(0))]), Span { lo: 63, hi: 79 }))))
         "##]],
     );
 }
@@ -2104,7 +2104,7 @@ fn fail_in_call_args_checks_non_divergent_types() {
             #34 67-78 "fail \"true\"" : Int
             #35 72-78 "\"true\"" : String
             #36 80-83 "3.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 80, hi: 83 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 80, hi: 83 }))))
         "##]],
     );
 }
@@ -2301,7 +2301,7 @@ fn return_in_call_args_checks_arity() {
             #33 64-65 "1" : Int
             #34 67-80 "return \"true\"" : Int
             #35 74-80 "\"true\"" : String
-            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, ?)", Span { lo: 63, hi: 81 }))))
+            Error(Type(Error(TyMismatch("(Int, Int, Int)", "(Int, ?)", Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Infer(InferTyId(0))]), Span { lo: 63, hi: 81 }))))
         "##]],
     );
 }
@@ -2331,7 +2331,7 @@ fn return_in_call_args_checks_non_divergent_types() {
             #34 67-80 "return \"true\"" : Int
             #35 74-80 "\"true\"" : String
             #36 82-85 "3.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 82, hi: 85 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 82, hi: 85 }))))
         "##]],
     );
 }
@@ -2403,14 +2403,14 @@ fn return_mismatch() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-40 "(x : Bool)" : Bool
             #7 31-39 "x : Bool" : Bool
             #15 47-75 "{\n        return true;\n    }" : Int
             #17 57-68 "return true" : Unit
             #18 64-68 "true" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Span { lo: 64, hi: 68 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 64, hi: 68 }))))
+        "##]],
     );
 }
 
@@ -2923,7 +2923,7 @@ fn newtype_cons_wrong_input() {
             #19 70-76 "NewInt" : (Int -> UDT<"NewInt": Item 1 (Package 2)>)
             #22 76-81 "(5.0)" : Double
             #23 77-80 "5.0" : Double
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 77, hi: 80 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 77, hi: 80 }))))
         "##]],
     );
 }
@@ -2964,7 +2964,7 @@ fn struct_cons_wrong_input() {
             #25 88-124 "new Pair { First = 5.0, Second = 6 }" : UDT<"Pair": Item 1 (Package 2)>
             #30 107-110 "5.0" : Double
             #33 121-122 "6" : Int
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 99, hi: 110 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 99, hi: 110 }))))
         "##]],
     );
 }
@@ -3268,7 +3268,7 @@ fn newtype_does_not_match_base_ty() {
             #19 67-73 "NewInt" : (Int -> UDT<"NewInt": Item 1 (Package 2)>)
             #22 73-76 "(5)" : Int
             #23 74-75 "5" : Int
-            Error(Type(Error(TyMismatch("Int", "NewInt", Span { lo: 67, hi: 76 }))))
+            Error(Type(Error(TyMismatch("Int", "NewInt", Prim(Int), Udt, Span { lo: 67, hi: 76 }))))
         "##]],
     );
 }
@@ -3291,7 +3291,7 @@ fn newtype_does_not_match_other_newtype() {
             #25 99-106 "NewInt1" : (Int -> UDT<"NewInt1": Item 1 (Package 2)>)
             #28 106-109 "(5)" : Int
             #29 107-108 "5" : Int
-            Error(Type(Error(TyMismatch("NewInt2", "NewInt1", Span { lo: 99, hi: 109 }))))
+            Error(Type(Error(TyMismatch("NewInt2", "NewInt1", Udt, Udt, Span { lo: 99, hi: 109 }))))
         "##]],
     );
 }
@@ -3565,7 +3565,7 @@ fn local_function_error() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #10 39-97 "{\n        function Bar() : Int { 2.0 }\n        Bar()\n    }" : Int
             #15 61-63 "()" : Unit
@@ -3574,8 +3574,8 @@ fn local_function_error() {
             #23 86-91 "Bar()" : Int
             #24 86-89 "Bar" : (Unit -> Int)
             #27 89-91 "()" : Unit
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 72, hi: 75 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 72, hi: 75 }))))
+        "##]],
     );
 }
 
@@ -3615,7 +3615,7 @@ fn local_function_last_stmt_is_unit_block() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #10 39-96 "{\n        Bar();\n        function Bar() : Int { 4 }\n    }" : Unit
             #12 49-54 "Bar()" : Int
@@ -3624,8 +3624,8 @@ fn local_function_last_stmt_is_unit_block() {
             #21 76-78 "()" : Unit
             #25 85-90 "{ 4 }" : Int
             #27 87-88 "4" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 35, hi: 38 }))))
-        "#]],
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 35, hi: 38 }))))
+        "##]],
     );
 }
 
@@ -4191,7 +4191,7 @@ fn partial_app_too_many_args() {
             #29 56-57 "1" : Int
             #30 59-60 "_" : ?1
             #31 62-63 "_" : ?2
-            Error(Type(Error(TyMismatch("Int", "(Int, ?, ?)", Span { lo: 55, hi: 64 }))))
+            Error(Type(Error(TyMismatch("Int", "(Int, ?, ?)", Prim(Int), Tuple([Prim(Int), Infer(InferTyId(1)), Infer(InferTyId(2))]), Span { lo: 55, hi: 64 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 59, hi: 60 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
         "##]],
@@ -4881,11 +4881,11 @@ fn inference_infinite_recursion_should_fail() {
             #50 180-187 "A and B" : (((?2, ?3) -> ?2) -> ?2[])
             #51 180-181 "A" : (((?2, ?3) -> ?2) -> ?2[])
             #54 186-187 "B" : (((?2, ?3) -> ?2) -> ?2)
-            Error(Type(Error(TyMismatch("Unit", "'U1[]", Span { lo: 62, hi: 67 }))))
-            Error(Type(Error(TyMismatch("Unit", "'T2", Span { lo: 129, hi: 132 }))))
+            Error(Type(Error(TyMismatch("Unit", "'U1[]", Tuple([]), Array(Param), Span { lo: 62, hi: 67 }))))
+            Error(Type(Error(TyMismatch("Unit", "'T2", Tuple([]), Param, Span { lo: 129, hi: 132 }))))
             Error(Type(Error(RecursiveTypeConstraint(Span { lo: 186, hi: 187 }))))
-            Error(Type(Error(TyMismatch("Bool", "(((?, ?) -> ?) -> ?[])", Span { lo: 180, hi: 181 }))))
-            Error(Type(Error(TyMismatch("Unit", "(((?, ?) -> ?) -> ?[])", Span { lo: 180, hi: 187 }))))
+            Error(Type(Error(TyMismatch("Bool", "(((?, ?) -> ?) -> ?[])", Prim(Bool), Arrow, Span { lo: 180, hi: 181 }))))
+            Error(Type(Error(TyMismatch("Unit", "(((?, ?) -> ?) -> ?[])", Tuple([]), Arrow, Span { lo: 180, hi: 187 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 186, hi: 187 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 186, hi: 187 }))))
         "##]],
@@ -4997,7 +4997,7 @@ fn within_block_should_be_unit_error() {
             #4 9-10 "4" : Int
             #5 19-24 "{ 0 }" : Int
             #7 21-22 "0" : Int
-            Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 7, hi: 12 }))))
+            Error(Type(Error(TyMismatch("Unit", "Int", Tuple([]), Prim(Int), Span { lo: 7, hi: 12 }))))
         "##]],
     );
 }
@@ -5389,7 +5389,7 @@ fn complex_literal_with_two_real_parts_error() {
             #3 0-3 "2.0" : Double
             #4 6-9 "3.0" : Double
             #5 12-16 "4.0i" : UDT<"Complex(Test)": Item 3 (Package 0)>
-            Error(Type(Error(TyMismatch("Double", "Complex(Test)", Span { lo: 12, hi: 16 }))))
+            Error(Type(Error(TyMismatch("Double", "Complex(Test)", Prim(Double), Udt, Span { lo: 12, hi: 16 }))))
         "##]],
     );
 }
@@ -5406,7 +5406,7 @@ fn add_double_and_complex_literal_with_parens_error() {
             #4 7-17 "3.0 + 4.0i" : UDT<"Complex(Test)": Item 3 (Package 0)>
             #5 7-10 "3.0" : Double
             #6 13-17 "4.0i" : UDT<"Complex(Test)": Item 3 (Package 0)>
-            Error(Type(Error(TyMismatch("Double", "Complex(Test)", Span { lo: 6, hi: 18 }))))
+            Error(Type(Error(TyMismatch("Double", "Complex(Test)", Prim(Double), Udt, Span { lo: 6, hi: 18 }))))
         "##]],
     );
 }
@@ -5704,7 +5704,7 @@ fn call_expr_non_tuple_expr() {
             #27 56-57 "f" : ((Double, Double) -> Double)
             #30 57-60 "(x)" : (Int, Double)
             #31 58-59 "x" : (Int, Double)
-            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 58, hi: 59 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Prim(Int), Prim(Double), Span { lo: 58, hi: 59 }))))
         "##]],
     );
 }

--- a/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
@@ -70,7 +70,7 @@ fn exp_fail() {
             #25 101-106 "a ^ b" : Param<"'T": 0>
             #26 101-102 "a" : Param<"'T": 0>
             #29 105-106 "b" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Span { lo: 101, hi: 106 }))))
+            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 101, hi: 106 }))))
         "##]],
     );
 }
@@ -108,9 +108,9 @@ fn extra_arg_to_exp() {
             Error(Type(Error(IncorrectNumberOfConstraintParameters { expected: 1, found: 0, span: Span { lo: 162, hi: 165 } })))
             Error(Type(Error(IncorrectNumberOfConstraintParameters { expected: 1, found: 0, span: Span { lo: 162, hi: 165 } })))
             Error(Type(Error(MissingClassExp("'E", Span { lo: 108, hi: 113 }))))
-            Error(Type(Error(TyMismatch("'T", "'E", Span { lo: 108, hi: 113 }))))
+            Error(Type(Error(TyMismatch("'T", "'E", Param, Param, Span { lo: 108, hi: 113 }))))
             Error(Type(Error(MissingClassExp("'E", Span { lo: 205, hi: 210 }))))
-            Error(Type(Error(TyMismatch("'T", "'E", Span { lo: 205, hi: 210 }))))
+            Error(Type(Error(TyMismatch("'T", "'E", Param, Param, Span { lo: 205, hi: 210 }))))
         "##]],
     );
 }
@@ -135,7 +135,7 @@ fn example_should_fail() {
             #24 175-181 "a == b" : Bool
             #25 175-176 "a" : Param<"'T": 0>
             #28 180-181 "b" : Param<"'O": 1>
-            Error(Type(Error(TyMismatch("'T", "'O", Span { lo: 180, hi: 181 }))))
+            Error(Type(Error(TyMismatch("'T", "'O", Param, Param, Span { lo: 180, hi: 181 }))))
         "##]],
     );
 }
@@ -736,8 +736,8 @@ fn show_and_eq_should_fail() {
             #69 344-352 "(1, \"2\")" : (Int, String)
             #70 345-346 "1" : Int
             #71 348-351 "\"2\"" : String
-            Error(Type(Error(TyMismatch("Int", "Bool", Span { lo: 310, hi: 314 }))))
-            Error(Type(Error(TyMismatch("Int", "String", Span { lo: 348, hi: 351 }))))
+            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 310, hi: 314 }))))
+            Error(Type(Error(TyMismatch("Int", "String", Prim(Int), Prim(String), Span { lo: 348, hi: 351 }))))
         "##]],
     );
 }

--- a/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
@@ -70,7 +70,7 @@ fn exp_fail() {
             #25 101-106 "a ^ b" : Param<"'T": 0>
             #26 101-102 "a" : Param<"'T": 0>
             #29 105-106 "b" : Bool
-            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 101, hi: 106 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Bool), display: "Bool" }, Span { lo: 101, hi: 106 }))))
         "##]],
     );
 }
@@ -108,9 +108,9 @@ fn extra_arg_to_exp() {
             Error(Type(Error(IncorrectNumberOfConstraintParameters { expected: 1, found: 0, span: Span { lo: 162, hi: 165 } })))
             Error(Type(Error(IncorrectNumberOfConstraintParameters { expected: 1, found: 0, span: Span { lo: 162, hi: 165 } })))
             Error(Type(Error(MissingClassExp("'E", Span { lo: 108, hi: 113 }))))
-            Error(Type(Error(TyMismatch("'T", "'E", Param, Param, Span { lo: 108, hi: 113 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Param, display: "'T" }, TyInfo { kind: Param, display: "'E" }, Span { lo: 108, hi: 113 }))))
             Error(Type(Error(MissingClassExp("'E", Span { lo: 205, hi: 210 }))))
-            Error(Type(Error(TyMismatch("'T", "'E", Param, Param, Span { lo: 205, hi: 210 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Param, display: "'T" }, TyInfo { kind: Param, display: "'E" }, Span { lo: 205, hi: 210 }))))
         "##]],
     );
 }
@@ -135,7 +135,7 @@ fn example_should_fail() {
             #24 175-181 "a == b" : Bool
             #25 175-176 "a" : Param<"'T": 0>
             #28 180-181 "b" : Param<"'O": 1>
-            Error(Type(Error(TyMismatch("'T", "'O", Param, Param, Span { lo: 180, hi: 181 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Param, display: "'T" }, TyInfo { kind: Param, display: "'O" }, Span { lo: 180, hi: 181 }))))
         "##]],
     );
 }
@@ -736,8 +736,8 @@ fn show_and_eq_should_fail() {
             #69 344-352 "(1, \"2\")" : (Int, String)
             #70 345-346 "1" : Int
             #71 348-351 "\"2\"" : String
-            Error(Type(Error(TyMismatch("Int", "Bool", Prim(Int), Prim(Bool), Span { lo: 310, hi: 314 }))))
-            Error(Type(Error(TyMismatch("Int", "String", Prim(Int), Prim(String), Span { lo: 348, hi: 351 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(Bool), display: "Bool" }, Span { lo: 310, hi: 314 }))))
+            Error(Type(Error(TyMismatch(TyInfo { kind: Prim(Int), display: "Int" }, TyInfo { kind: Prim(String), display: "String" }, Span { lo: 348, hi: 351 }))))
         "##]],
     );
 }

--- a/source/language_service/src/code_action.rs
+++ b/source/language_service/src/code_action.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 mod auto_import;
+mod wrap_in_array;
 mod wrapper_refactor;
 
 use miette::Diagnostic;
@@ -36,6 +37,12 @@ pub(crate) fn get_code_actions(
     // Add operation refactor actions (wrapper generation, etc.). Additional refactor providers
     // should be added here, each returning their own Vec<CodeAction>.
     actions.extend(wrapper_refactor::operation_refactors(
+        compilation,
+        source_name,
+        span,
+        position_encoding,
+    ));
+    actions.extend(wrap_in_array::wrap_in_array_fixes(
         compilation,
         source_name,
         span,

--- a/source/language_service/src/code_action/auto_import/tests.rs
+++ b/source/language_service/src/code_action/auto_import/tests.rs
@@ -6,9 +6,10 @@ use crate::test_utils::{
     compile_notebook_with_fake_stdlib, compile_project_with_markers_no_cursor,
 };
 use expect_test::{Expect, expect};
-use qsc::{Span, line_column::{Encoding, Range}};
-
-
+use qsc::{
+    Span,
+    line_column::{Encoding, Range},
+};
 
 /// Collects the titles of the auto-import code actions offered for `source`.
 fn import_action_titles(source: &str) -> Vec<String> {

--- a/source/language_service/src/code_action/auto_import/tests.rs
+++ b/source/language_service/src/code_action/auto_import/tests.rs
@@ -6,33 +6,16 @@ use crate::test_utils::{
     compile_notebook_with_fake_stdlib, compile_project_with_markers_no_cursor,
 };
 use expect_test::{Expect, expect};
-use qsc::line_column::{Encoding, Position, Range};
+use qsc::{Span, line_column::{Encoding, Range}};
 
-/// Returns a range that spans the entire source, so all diagnostics are considered relevant.
-fn whole_document_range(source: &str) -> Range {
-    let newline_count = u32::try_from(source.matches('\n').count()).expect("count fits");
-    let end = if newline_count == 0 {
-        Position {
-            line: 0,
-            column: u32::try_from(source.len()).expect("len fits"),
-        }
-    } else {
-        Position {
-            line: newline_count + 1,
-            column: 0,
-        }
-    };
-    Range {
-        start: Position { line: 0, column: 0 },
-        end,
-    }
-}
+
 
 /// Collects the titles of the auto-import code actions offered for `source`.
 fn import_action_titles(source: &str) -> Vec<String> {
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], true);
-    let range = whole_document_range(source);
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     actions
         .into_iter()
@@ -137,7 +120,8 @@ fn import_edit_inserts_at_namespace_start() {
         }";
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], true);
-    let range = whole_document_range(source);
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     let action = actions
         .iter()
@@ -162,7 +146,9 @@ fn import_edit_inserts_at_namespace_start() {
 #[test]
 fn notebook_unresolved_term_offers_import() {
     let compilation = compile_notebook_with_fake_stdlib([("cell1", "Fake();")].into_iter());
-    let range = whole_document_range("Fake();");
+    let source = "Fake();";
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
     let actions = code_action::get_code_actions(&compilation, "cell1", range, Encoding::Utf8);
     let titles: Vec<String> = actions
         .into_iter()

--- a/source/language_service/src/code_action/auto_import/tests.rs
+++ b/source/language_service/src/code_action/auto_import/tests.rs
@@ -3,20 +3,16 @@
 
 use crate::code_action;
 use crate::test_utils::{
-    compile_notebook_with_fake_stdlib, compile_project_with_markers_no_cursor,
+    compile_notebook_with_fake_stdlib, compile_project_with_markers_no_cursor, whole_document_range,
 };
 use expect_test::{Expect, expect};
-use qsc::{
-    Span,
-    line_column::{Encoding, Range},
-};
+use qsc::line_column::Encoding;
 
 /// Collects the titles of the auto-import code actions offered for `source`.
 fn import_action_titles(source: &str) -> Vec<String> {
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], true);
-    let len = u32::try_from(source.len()).expect("source length fits in u32");
-    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
+    let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     actions
         .into_iter()
@@ -121,8 +117,7 @@ fn import_edit_inserts_at_namespace_start() {
         }";
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], true);
-    let len = u32::try_from(source.len()).expect("source length fits in u32");
-    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
+    let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     let action = actions
         .iter()
@@ -148,8 +143,7 @@ fn import_edit_inserts_at_namespace_start() {
 fn notebook_unresolved_term_offers_import() {
     let compilation = compile_notebook_with_fake_stdlib([("cell1", "Fake();")].into_iter());
     let source = "Fake();";
-    let len = u32::try_from(source.len()).expect("source length fits in u32");
-    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
+    let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, "cell1", range, Encoding::Utf8);
     let titles: Vec<String> = actions
         .into_iter()

--- a/source/language_service/src/code_action/wrap_in_array.rs
+++ b/source/language_service/src/code_action/wrap_in_array.rs
@@ -11,7 +11,7 @@ mod tests;
 use qsc::{
     Span,
     ast::{self, Expr},
-    compile::{ErrorKind, TyInfo},
+    compile::{ErrorKind, TyInfoKind},
     display::Lookup,
     hir::ty::Ty,
     line_column::Encoding,
@@ -48,9 +48,9 @@ pub(crate) fn wrap_in_array_fixes(
     for (expected, actual, error_span) in ty_mismatches {
         // Check if expected is Array(T) and actual is a matching primitive T.
         // Scoped to primitives to include Qubit, exclude tuples, and provide an intelligible stopping point.
-        if let TyInfo::Array(item_ty) = expected
-            && item_ty.as_ref() == actual
-            && matches!(actual, TyInfo::Prim(_))
+        if let TyInfoKind::Array(item_ty) = &expected.kind
+            && item_ty.as_ref() == &actual.kind
+            && matches!(actual.kind, TyInfoKind::Prim(_))
         {
             // Verify via the type table that the expression is truly a primitive type.
             // The error's `actual` field can be simplified (e.g. an array mismatch

--- a/source/language_service/src/code_action/wrap_in_array.rs
+++ b/source/language_service/src/code_action/wrap_in_array.rs
@@ -58,11 +58,13 @@ pub(crate) fn wrap_in_array_fixes(
             // Verify via the type table that the expression is truly a primitive type.
             // The error's `actual` field can be simplified (e.g. an array mismatch
             // decomposes to element-level), so we check the real expression type.
-            let expr_id = find_expr_at(package, error_span);
-            if let Some(id) = expr_id
-                && let Some(ty) = compilation.get_ty(id)
-                && !matches!(ty, Ty::Prim(_))
-            {
+            let Some(expr_id) = find_expr_at(package, error_span) else {
+                continue;
+            };
+            let Some(ty) = compilation.get_ty(expr_id) else {
+                continue;
+            };
+            if !matches!(ty, Ty::Prim(_)) {
                 continue;
             }
 

--- a/source/language_service/src/code_action/wrap_in_array.rs
+++ b/source/language_service/src/code_action/wrap_in_array.rs
@@ -14,13 +14,14 @@ use qsc::{
     compile::{ErrorKind, TyInfo},
     display::Lookup,
     hir::ty::Ty,
-    line_column::{Encoding, Range},
+    line_column::Encoding,
 };
 
 use super::is_error_relevant;
 use crate::{
     compilation::Compilation,
     protocol::{CodeAction, CodeActionKind, TextEdit, WorkspaceEdit},
+    qsc_utils::into_range,
 };
 
 pub(crate) fn wrap_in_array_fixes(
@@ -33,11 +34,7 @@ pub(crate) fn wrap_in_array_fixes(
 
     let unit = compilation.user_unit();
     let package = &unit.ast.package;
-
-    let source = unit
-        .sources
-        .find_by_name(source_name)
-        .expect("source should exist");
+    let source_map = &unit.sources;
 
     let ty_mismatches = compilation
         .compile_errors
@@ -71,17 +68,13 @@ pub(crate) fn wrap_in_array_fixes(
             // Generate the fix: wrap the expression in [...]
             // Note that this depends on the error span excluding surrounding parens
             // so we don't end up with something like `F[(q)]`.
-            let lo = (error_span.lo - source.offset) as usize;
-            let hi = (error_span.hi - source.offset) as usize;
-            let arg_text = &source.contents[lo..hi];
-            let new_text = format!("[{arg_text}]");
             let open_range = into_range(
                 encoding,
                 Span {
                     lo: error_span.lo,
                     hi: error_span.lo,
                 },
-                &unit.sources,
+                source_map,
             );
 
             let close_range = into_range(
@@ -90,7 +83,7 @@ pub(crate) fn wrap_in_array_fixes(
                     lo: error_span.hi,
                     hi: error_span.hi,
                 },
-                &unit.sources,
+                source_map,
             );
 
             code_actions.push(CodeAction {

--- a/source/language_service/src/code_action/wrap_in_array.rs
+++ b/source/language_service/src/code_action/wrap_in_array.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Code action: "Convert to single-element array"
-// Detects when a value is passed where an array of that type is expected,
-// and offers to wrap it in `[...]`.
+//! Code action: "Convert to single-element array"
+//! Detects when a value is passed where an array of that type is expected,
+//! and offers to wrap it in `[...]`.
 
 #[cfg(test)]
 mod tests;
@@ -75,11 +75,40 @@ pub(crate) fn wrap_in_array_fixes(
             let hi = (error_span.hi - source.offset) as usize;
             let arg_text = &source.contents[lo..hi];
             let new_text = format!("[{arg_text}]");
-            let range = Range::from_span(encoding, &source.contents, &(error_span - source.offset));
+            let open_range = into_range(
+                encoding,
+                Span {
+                    lo: error_span.lo,
+                    hi: error_span.lo,
+                },
+                &unit.sources,
+            );
+
+            let close_range = into_range(
+                encoding,
+                Span {
+                    lo: error_span.hi,
+                    hi: error_span.hi,
+                },
+                &unit.sources,
+            );
+
             code_actions.push(CodeAction {
                 title: "Convert to single-element array".to_string(),
                 edit: Some(WorkspaceEdit {
-                    changes: vec![(source_name.to_string(), vec![TextEdit { new_text, range }])],
+                    changes: vec![(
+                        source_name.to_string(),
+                        vec![
+                            TextEdit {
+                                new_text: "[".to_string(),
+                                range: open_range,
+                            },
+                            TextEdit {
+                                new_text: "]".to_string(),
+                                range: close_range,
+                            },
+                        ],
+                    )],
                 }),
                 kind: Some(CodeActionKind::QuickFix),
                 is_preferred: None,

--- a/source/language_service/src/code_action/wrap_in_array.rs
+++ b/source/language_service/src/code_action/wrap_in_array.rs
@@ -10,7 +10,10 @@ mod tests;
 
 use qsc::{
     Span,
+    ast::{self, Expr},
     compile::{ErrorKind, TyInfo},
+    display::Lookup,
+    hir::ty::Ty,
     line_column::{Encoding, Range},
 };
 
@@ -28,8 +31,10 @@ pub(crate) fn wrap_in_array_fixes(
 ) -> Vec<CodeAction> {
     let mut code_actions = Vec::new();
 
-    let source = compilation
-        .user_unit()
+    let unit = compilation.user_unit();
+    let package = &unit.ast.package;
+
+    let source = unit
         .sources
         .find_by_name(source_name)
         .expect("source should exist");
@@ -50,6 +55,17 @@ pub(crate) fn wrap_in_array_fixes(
             && item_ty.as_ref() == actual
             && matches!(actual, TyInfo::Prim(_))
         {
+            // Verify via the type table that the expression is truly a primitive type.
+            // The error's `actual` field can be simplified (e.g. an array mismatch
+            // decomposes to element-level), so we check the real expression type.
+            let expr_id = find_expr_at(package, error_span);
+            if let Some(id) = expr_id
+                && let Some(ty) = compilation.get_ty(id)
+                && !matches!(ty, Ty::Prim(_))
+            {
+                continue;
+            }
+
             // Generate the fix: wrap the expression in [...]
             // Note that this depends on the error span excluding surrounding parens
             // so we don't end up with something like `F[(q)]`.
@@ -70,4 +86,29 @@ pub(crate) fn wrap_in_array_fixes(
     }
 
     code_actions
+}
+
+/// Finds the AST expression whose span exactly matches `target` and returns its `NodeId`.
+fn find_expr_at(package: &ast::Package, target: Span) -> Option<ast::NodeId> {
+    let mut finder = ExprSpanFinder {
+        target,
+        found: None,
+    };
+    ast::visit::Visitor::visit_package(&mut finder, package);
+    finder.found
+}
+
+struct ExprSpanFinder {
+    target: Span,
+    found: Option<ast::NodeId>,
+}
+
+impl<'a> ast::visit::Visitor<'a> for ExprSpanFinder {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if expr.span == self.target {
+            self.found = Some(expr.id);
+        } else if self.target.intersection(&expr.span).is_some() {
+            ast::visit::walk_expr(self, expr);
+        }
+    }
 }

--- a/source/language_service/src/code_action/wrap_in_array.rs
+++ b/source/language_service/src/code_action/wrap_in_array.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Code action: "Convert to single-element array"
+// Detects when a value is passed where an array of that type is expected,
+// and offers to wrap it in `[...]`.
+
+#[cfg(test)]
+mod tests;
+
+use qsc::{
+    Span,
+    compile::{ErrorKind, TyInfo},
+    line_column::{Encoding, Range},
+};
+
+use super::is_error_relevant;
+use crate::{
+    compilation::Compilation,
+    protocol::{CodeAction, CodeActionKind, TextEdit, WorkspaceEdit},
+};
+
+pub(crate) fn wrap_in_array_fixes(
+    compilation: &Compilation,
+    source_name: &str,
+    span: Span,
+    encoding: Encoding,
+) -> Vec<CodeAction> {
+    let mut code_actions = Vec::new();
+
+    let source = compilation
+        .user_unit()
+        .sources
+        .find_by_name(source_name)
+        .expect("source should exist");
+
+    let ty_mismatches = compilation
+        .compile_errors
+        .iter()
+        .filter(|error| is_error_relevant(error, span))
+        .filter_map(|error| match error.error() {
+            ErrorKind::Frontend(frontend_error) => frontend_error.ty_mismatch(),
+            _ => None,
+        });
+
+    for (expected, actual, error_span) in ty_mismatches {
+        // Check if expected is Array(T) and actual is a matching primitive T.
+        // Scoped to primitives to include Qubit, exclude tuples, and provide an intelligible stopping point.
+        if let TyInfo::Array(item_ty) = expected
+            && item_ty.as_ref() == actual
+            && matches!(actual, TyInfo::Prim(_))
+        {
+            // Generate the fix: wrap the expression in [...]
+            // Note that this depends on the error span excluding surrounding parens
+            // so we don't end up with something like `F[(q)]`.
+            let lo = (error_span.lo - source.offset) as usize;
+            let hi = (error_span.hi - source.offset) as usize;
+            let arg_text = &source.contents[lo..hi];
+            let new_text = format!("[{arg_text}]");
+            let range = Range::from_span(encoding, &source.contents, &(error_span - source.offset));
+            code_actions.push(CodeAction {
+                title: "Convert to single-element array".to_string(),
+                edit: Some(WorkspaceEdit {
+                    changes: vec![(source_name.to_string(), vec![TextEdit { new_text, range }])],
+                }),
+                kind: Some(CodeActionKind::QuickFix),
+                is_preferred: None,
+            });
+        }
+    }
+
+    code_actions
+}

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -109,10 +109,9 @@ fn no_action_for_tuple_to_tuple_array() {
 }
 
 #[test]
-fn array_to_nested_array() {
-    // Qubit[] passed where Qubit[][] expected - wrapping in [...] is valid.
-    // Qubit[] isn't a primitive type, but it's actually complaining at the element
-    // level so the error contains Qubit and Qubit[].
+fn no_action_for_array_to_nested_array() {
+    // Qubit[] passed where Qubit[][] expected - the expression type is Qubit[] (not
+    // a primitive), so the code action should not be offered.
     let source = "namespace A {
     operation Foo(qs: Qubit[][]) : Unit {}
     operation Bar(qs: Qubit[]) : Unit {
@@ -121,10 +120,5 @@ fn array_to_nested_array() {
 }
 ";
     let actions = get_wrap_in_array_actions(source);
-    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
-    let action = &actions[0];
-    let edit = action.edit.as_ref().expect("expected edit");
-    let (_, text_edits) = &edit.changes[0];
-    assert_eq!(text_edits.len(), 1);
-    assert_eq!(text_edits[0].new_text, "[qs]");
+    assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -2,27 +2,16 @@
 // Licensed under the MIT License.
 
 use crate::{code_action, test_utils::compile_project_with_markers_no_cursor};
-use qsc::line_column::{Encoding, Position, Range};
+use qsc::{
+    Span,
+    line_column::{Encoding, Range},
+};
 
 fn get_wrap_in_array_actions(source: &str) -> Vec<crate::protocol::CodeAction> {
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
-    let newline_count = u32::try_from(source.matches('\n').count()).expect("count fits");
-    let end = if newline_count == 0 {
-        Position {
-            line: 0,
-            column: u32::try_from(source.len()).expect("len fits"),
-        }
-    } else {
-        Position {
-            line: newline_count,
-            column: 0,
-        }
-    };
-    let range = Range {
-        start: Position { line: 0, column: 0 },
-        end,
-    };
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     actions
         .into_iter()

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::{code_action, test_utils::compile_project_with_markers_no_cursor};
+use qsc::line_column::{Encoding, Position, Range};
+
+fn get_wrap_in_array_actions(source: &str) -> Vec<crate::protocol::CodeAction> {
+    let (compilation, _targets) =
+        compile_project_with_markers_no_cursor(&[("<source>", source)], false);
+    let newline_count = u32::try_from(source.matches('\n').count()).expect("count fits");
+    let end = if newline_count == 0 {
+        Position {
+            line: 0,
+            column: u32::try_from(source.len()).expect("len fits"),
+        }
+    } else {
+        Position {
+            line: newline_count,
+            column: 0,
+        }
+    };
+    let range = Range {
+        start: Position { line: 0, column: 0 },
+        end,
+    };
+    let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
+    actions
+        .into_iter()
+        .filter(|a| a.title == "Convert to single-element array")
+        .collect()
+}
+
+#[test]
+fn single_arg_qubit_to_qubit_array() {
+    let source = "namespace A {
+    operation Foo(qs: Qubit[]) : Unit is Adj {
+        use q = Qubit();
+        Foo(q);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
+    let action = &actions[0];
+    let edit = action.edit.as_ref().expect("expected edit");
+    let (_, text_edits) = &edit.changes[0];
+    assert_eq!(text_edits.len(), 1);
+    assert_eq!(text_edits[0].new_text, "[q]");
+}
+
+#[test]
+fn multi_arg_second_param_is_array() {
+    let source = "namespace A {
+    operation Bar(x: Int, qs: Qubit[]) : Unit {
+        use q = Qubit();
+        Bar(1, q);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
+    let action = &actions[0];
+    let edit = action.edit.as_ref().expect("expected edit");
+    let (_, text_edits) = &edit.changes[0];
+    assert_eq!(text_edits.len(), 1);
+    assert_eq!(text_edits[0].new_text, "[q]");
+}
+
+#[test]
+fn no_action_when_types_already_match() {
+    let source = "namespace A {
+    operation Foo(qs: Qubit[]) : Unit is Adj {
+        use q = Qubit();
+        Foo([q]);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
+}
+
+#[test]
+fn no_action_for_unrelated_mismatch() {
+    // Int passed where String expected - should NOT offer wrap in array.
+    let source = "namespace A {
+    function Foo(s: String) : Unit {}
+    function Bar() : Unit {
+        Foo(42);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
+}
+
+#[test]
+fn no_action_for_tuple_to_tuple_array() {
+    // (Qubit, Qubit) passed where (Qubit, Qubit)[] expected - not a primitive type.
+    let source = "namespace A {
+    operation Foo(qs: (Qubit, Qubit)[]) : Unit {}
+    operation Bar() : Unit {
+        use (q1, q2) = (Qubit(), Qubit());
+        Foo((q1, q2));
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
+}
+
+#[test]
+fn array_to_nested_array() {
+    // Qubit[] passed where Qubit[][] expected - wrapping in [...] is valid.
+    // Qubit[] isn't a primitive type, but it's actually complaining at the element
+    // level so the error contains Qubit and Qubit[].
+    let source = "namespace A {
+    operation Foo(qs: Qubit[][]) : Unit {}
+    operation Bar(qs: Qubit[]) : Unit {
+        Foo(qs);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
+    let action = &actions[0];
+    let edit = action.edit.as_ref().expect("expected edit");
+    let (_, text_edits) = &edit.changes[0];
+    assert_eq!(text_edits.len(), 1);
+    assert_eq!(text_edits[0].new_text, "[qs]");
+}

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -33,8 +33,9 @@ fn single_arg_qubit_to_qubit_array() {
     let action = &actions[0];
     let edit = action.edit.as_ref().expect("expected edit");
     let (_, text_edits) = &edit.changes[0];
-    assert_eq!(text_edits.len(), 1);
-    assert_eq!(text_edits[0].new_text, "[q]");
+    assert_eq!(text_edits.len(), 2);
+    assert_eq!(text_edits[0].new_text, "[");
+    assert_eq!(text_edits[1].new_text, "]");
 }
 
 #[test]
@@ -51,8 +52,9 @@ fn multi_arg_second_param_is_array() {
     let action = &actions[0];
     let edit = action.edit.as_ref().expect("expected edit");
     let (_, text_edits) = &edit.changes[0];
-    assert_eq!(text_edits.len(), 1);
-    assert_eq!(text_edits[0].new_text, "[q]");
+    assert_eq!(text_edits.len(), 2);
+    assert_eq!(text_edits[0].new_text, "[");
+    assert_eq!(text_edits[1].new_text, "]");
 }
 
 #[test]

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -1,17 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::{code_action, test_utils::compile_project_with_markers_no_cursor};
-use qsc::{
-    Span,
-    line_column::{Encoding, Range},
+use crate::{
+    code_action,
+    test_utils::{compile_project_with_markers_no_cursor, whole_document_range},
 };
+use qsc::line_column::Encoding;
 
 fn get_wrap_in_array_actions(source: &str) -> Vec<crate::protocol::CodeAction> {
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
-    let len = u32::try_from(source.len()).expect("source length fits in u32");
-    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
+    let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     actions
         .into_iter()

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -122,3 +122,47 @@ fn no_action_for_array_to_nested_array() {
     let actions = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }
+
+#[test]
+fn no_action_for_arrow_to_arrow_array() {
+    // An operation value passed where ((Qubit) => Unit)[] expected - not a primitive type.
+    let source = "namespace A {
+    operation MyOp(q: Qubit) : Unit {}
+    operation Foo(ops: ((Qubit) => Unit)[]) : Unit {}
+    operation Bar() : Unit {
+        Foo(MyOp);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
+}
+
+#[test]
+fn no_action_for_param_to_param_array() {
+    // A generic type parameter passed where 'T[] expected - not a primitive type.
+    let source = "namespace A {
+    operation Foo<'T>(ts: 'T[]) : Unit {}
+    operation Bar<'T>(x: 'T) : Unit {
+        Foo(x);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
+}
+
+#[test]
+fn no_action_for_udt_to_udt_array() {
+    // A UDT value passed where MyType[] expected - not a primitive type.
+    let source = "namespace A {
+    newtype MyType = Int;
+    function Foo(xs: MyType[]) : Unit {}
+    function Bar(x: MyType) : Unit {
+        Foo(x);
+    }
+}
+";
+    let actions = get_wrap_in_array_actions(source);
+    assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
+}

--- a/source/language_service/src/code_action/wrapper_refactor/tests.rs
+++ b/source/language_service/src/code_action/wrapper_refactor/tests.rs
@@ -2,18 +2,14 @@
 // Licensed under the MIT License.
 
 use crate::test_utils::compile_notebook_with_markers;
-use crate::{code_action, test_utils::compile_project_with_markers_no_cursor};
+use crate::{code_action, test_utils::{compile_project_with_markers_no_cursor, whole_document_range}};
 use expect_test::expect;
-use qsc::{
-    Span,
-    line_column::{Encoding, Range},
-};
+use qsc::line_column::Encoding;
 
 fn get_wrapper_text(source: &str, op_name: &str) -> String {
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
-    let len = u32::try_from(source.len()).expect("source length fits in u32");
-    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
+    let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     let action = actions
         .iter()
@@ -365,8 +361,7 @@ fn no_code_action_for_lambdas_() {
     let source = "namespace Test { operation Named(x : Int) : Unit { let l = (y) => { x + y }; let e = (y) => { x + y }; l(2); } }";
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
-    let len = u32::try_from(source.len()).expect("source length fits in u32");
-    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
+    let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     let titles = actions
         .iter()
@@ -403,8 +398,7 @@ fn notebook_cell_wrapper_action() {
     let source = "operation Op(a : Int, b : Bool) : Unit {↘ }";
     let cells = [("cell1", source)];
     let (compilation, cell_uri, _, _) = compile_notebook_with_markers(&cells);
-    let len = u32::try_from(source.len()).expect("source length fits in u32");
-    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
+    let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, &cell_uri, range, Encoding::Utf8);
     let wrapper = actions
         .iter()

--- a/source/language_service/src/code_action/wrapper_refactor/tests.rs
+++ b/source/language_service/src/code_action/wrapper_refactor/tests.rs
@@ -4,27 +4,16 @@
 use crate::test_utils::compile_notebook_with_markers;
 use crate::{code_action, test_utils::compile_project_with_markers_no_cursor};
 use expect_test::expect;
-use qsc::line_column::{Encoding, Position, Range};
+use qsc::{
+    Span,
+    line_column::{Encoding, Range},
+};
 
 fn get_wrapper_text(source: &str, op_name: &str) -> String {
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
-    let newline_count = u32::try_from(source.matches('\n').count()).expect("count fits");
-    let end = if newline_count == 0 {
-        Position {
-            line: 0,
-            column: u32::try_from(source.len()).expect("len fits"),
-        }
-    } else {
-        Position {
-            line: newline_count,
-            column: 0,
-        }
-    };
-    let range = Range {
-        start: Position { line: 0, column: 0 },
-        end,
-    };
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     let action = actions
         .iter()
@@ -376,13 +365,8 @@ fn no_code_action_for_lambdas_() {
     let source = "namespace Test { operation Named(x : Int) : Unit { let l = (y) => { x + y }; let e = (y) => { x + y }; l(2); } }";
     let (compilation, _targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
-    let range = Range {
-        start: Position { line: 0, column: 0 },
-        end: Position {
-            line: 0,
-            column: u32::try_from(source.len()).expect("len fits"),
-        },
-    };
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
     let titles = actions
         .iter()
@@ -419,13 +403,8 @@ fn notebook_cell_wrapper_action() {
     let source = "operation Op(a : Int, b : Bool) : Unit {↘ }";
     let cells = [("cell1", source)];
     let (compilation, cell_uri, _, _) = compile_notebook_with_markers(&cells);
-    let range = Range {
-        start: Position { line: 0, column: 0 },
-        end: Position {
-            line: 0,
-            column: u32::try_from(source.len()).expect("len fits"),
-        },
-    };
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    let range = Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len });
     let actions = code_action::get_code_actions(&compilation, &cell_uri, range, Encoding::Utf8);
     let wrapper = actions
         .iter()

--- a/source/language_service/src/code_action/wrapper_refactor/tests.rs
+++ b/source/language_service/src/code_action/wrapper_refactor/tests.rs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 use crate::test_utils::compile_notebook_with_markers;
-use crate::{code_action, test_utils::{compile_project_with_markers_no_cursor, whole_document_range}};
+use crate::{
+    code_action,
+    test_utils::{compile_project_with_markers_no_cursor, whole_document_range},
+};
 use expect_test::expect;
 use qsc::line_column::Encoding;
 

--- a/source/language_service/src/test_utils.rs
+++ b/source/language_service/src/test_utils.rs
@@ -399,3 +399,8 @@ fn target_offsets_to_spans(target_offsets: &[u32]) -> Vec<Span> {
     }
     spans
 }
+
+pub(crate) fn whole_document_range(source: &str) -> Range {
+    let len = u32::try_from(source.len()).expect("source length fits in u32");
+    Range::from_span(Encoding::Utf8, source, &Span { lo: 0, hi: len })
+}


### PR DESCRIPTION
It's a pretty common mistake to pass a single control qubit to a function or functor that expects an array of them.  Add a code fix detecting that this has occurred and offering to add square brackets.

To make this possible, attach info about the expected and actual types to the ErrorKind.  (Unfortunately, Ty is hard to share, so create a simpler TyInfo that can accompany the ErrorKind.)