### PR TITLE
Implement `PostSelectZ` for Clifford simulation

### DIFF
--- a/library/src/tests/diagnostics.rs
+++ b/library/src/tests/diagnostics.rs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::tests::test_expression_fails;
+use crate::tests::{
+    test_expression_fails, test_expression_fails_with_lib_and_profile_and_sim,
+    test_expression_with_lib_and_profile_and_sim,
+};
 
 use super::test_expression;
 use expect_test::expect;
-use qsc::interpret::Value;
+use qsc::{interpret::Value, target::Profile};
 
 #[test]
 fn check_operations_are_equal() {
@@ -536,6 +539,24 @@ fn check_post_select_collapses_superposition_to_zero() {
 }
 
 #[test]
+fn check_post_select_collapses_superposition_to_zero_on_clifford() {
+    test_expression_with_lib_and_profile_and_sim(
+        "{
+            import Std.Diagnostics.PostSelectZ;
+            import Std.Diagnostics.CheckZero;
+            use q = Qubit();
+            H(q);
+            PostSelectZ(Zero, q);
+            // Qubit must be zero on release.
+        }",
+        "",
+        Profile::Unrestricted,
+        &mut qsc::CliffordSim::new(1),
+        &Value::unit(),
+    );
+}
+
+#[test]
 fn check_post_select_collapses_superposition_to_one() {
     test_expression(
         "{
@@ -553,6 +574,24 @@ fn check_post_select_collapses_superposition_to_one() {
 }
 
 #[test]
+fn check_post_select_collapses_superposition_to_one_on_clifford() {
+    test_expression_with_lib_and_profile_and_sim(
+        "{
+            import Std.Diagnostics.PostSelectZ;
+            import Std.Diagnostics.CheckZero;
+            use q = Qubit();
+            H(q);
+            PostSelectZ(One, q);
+            X(q); // Resets the qubit back to zero for release.
+        }",
+        "",
+        Profile::Unrestricted,
+        &mut qsc::CliffordSim::new(1),
+        &Value::unit(),
+    );
+}
+
+#[test]
 fn check_post_select_fails_with_non_existent_state() {
     let err = test_expression_fails(
         "{
@@ -561,6 +600,25 @@ fn check_post_select_fails_with_non_existent_state() {
             use q = Qubit();
             PostSelectZ(One, q);
         }",
+    );
+    expect![
+        "intrinsic callable `PostSelectZ` failed: post-selection condition has zero probability"
+    ]
+    .assert_eq(&err);
+}
+
+#[test]
+fn check_post_select_fails_with_non_existent_state_on_clifford() {
+    let err = test_expression_fails_with_lib_and_profile_and_sim(
+        "{
+            import Std.Diagnostics.PostSelectZ;
+            import Std.Diagnostics.CheckZero;
+            use q = Qubit();
+            PostSelectZ(One, q);
+        }",
+        "",
+        Profile::Unrestricted,
+        &mut qsc::CliffordSim::new(1),
     );
     expect![
         "intrinsic callable `PostSelectZ` failed: post-selection condition has zero probability"

--- a/library/std/src/Std/OpenQASM/Intrinsic.qs
+++ b/library/std/src/Std/OpenQASM/Intrinsic.qs
@@ -38,7 +38,7 @@ export rxx, ryy, rzz;
 // that Qiskit wont emit correctly.
 export dcx, ecr, r, rzx, cs, csdg, sxdg, csx, rccx, c3sqrtx, c3x, rc3x, xx_minus_yy, xx_plus_yy, ccz;
 
-export mresetz_checked;
+export mresetz_checked, postselectz;
 
 export __quantum__qis__barrier__body;
 
@@ -645,6 +645,10 @@ operation mresetz_checked(q : Qubit) : Int {
     } else {
         Std.OpenQASM.Convert.ResultAsInt(r)
     }
+}
+
+operation postselectz(r : Result, q : Qubit) : Unit {
+    Std.Diagnostics.PostSelectZ(r, q);
 }
 
 /// The ``BARRIER`` function is used to implement the `barrier` statement in QASM.

--- a/source/compiler/qsc_eval/src/backend.rs
+++ b/source/compiler/qsc_eval/src/backend.rs
@@ -1390,7 +1390,7 @@ impl Backend for CliffordSim {
         Err("adjoint T gate is not supported in Clifford simulation".to_string())
     }
 
-    fn custom_intrinsic(&mut self, name: &str, _arg: Value) -> Option<Result<Value, String>> {
+    fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Result<Value, String>> {
         match name {
             "BeginEstimateCaching" => Some(Ok(Value::Bool(true))),
             "GlobalPhase"
@@ -1413,9 +1413,14 @@ impl Backend for CliffordSim {
             "Apply" => Some(Err(
                 "arbitrary unitary application not supported in Clifford simulation".to_string(),
             )),
-            "PostSelectZ" => Some(Err(
-                "post-selection not supported in Clifford simulation".to_string()
-            )),
+            "PostSelectZ" => {
+                let [result, qubit] = unwrap_tuple(arg);
+                let id = qubit.unwrap_qubit().deref().0;
+                let Value::Result(val::Result::Val(val)) = result else {
+                    panic!("first argument to PostSelectZ should be a measurement result");
+                };
+                Some(self.sim.post_select_z(val, id).map(|()| Value::unit()))
+            }
             _ => None,
         }
     }

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
@@ -512,8 +512,8 @@ fn analysis_apply_operation_power_ca_consumer() {
         &expect![[r#"
             callable_params: 3
               param: callable_id=<item 4 in package 2>, path=[0], ty=((Qubit)[] => Unit is Adj + Ctl)
+              param: callable_id=<item 1018 in package 1>, path=[1], ty=((Qubit)[] => Unit is Adj + Ctl)
               param: callable_id=<item 5 in package 2>, path=[0], ty=((Int, (Qubit)[]) => Unit is Adj + Ctl)
-              param: callable_id=<item 1016 in package 1>, path=[1], ty=((Qubit)[] => Unit is Adj + Ctl)
             call_sites: 5
               site: hof=ApplyOperationPowerCA<(Qubit)[], AdjCtl>, arg=Dynamic
               site: hof=ApplyOperationPowerCA<(Qubit)[], AdjCtl>, arg=Dynamic
@@ -624,18 +624,18 @@ fn analysis_apply_operation_power_ca_consumer() {
             operation ApplyOperationPowerCA__Qubit_____AdjCtl__U_(power : Int, target : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _range_id_48101 : Range = 1..AbsI(power);
-                        mutable _index_id_48104 : Int = _range_id_48101::Start;
-                        let _step_id_48109 : Int = _range_id_48101::Step;
-                        let _end_id_48114 : Int = _range_id_48101::End;
-                        while _step_id_48109 > 0 and _index_id_48104 <= _end_id_48114 or _step_id_48109 < 0 and _index_id_48104 >= _end_id_48114 {
-                            let _ : Int = _index_id_48104;
+                        let _range_id_48117 : Range = 1..AbsI(power);
+                        mutable _index_id_48120 : Int = _range_id_48117::Start;
+                        let _step_id_48125 : Int = _range_id_48117::Step;
+                        let _end_id_48130 : Int = _range_id_48117::End;
+                        while _step_id_48125 > 0 and _index_id_48120 <= _end_id_48130 or _step_id_48125 < 0 and _index_id_48120 >= _end_id_48130 {
+                            let _ : Int = _index_id_48120;
                             if power >= 0 {
                                 U(target)
                             } else {
                                 Adjoint U(target)
                             };
-                            _index_id_48104 += _step_id_48109;
+                            _index_id_48120 += _step_id_48125;
                         }
 
                     }
@@ -645,18 +645,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                     {
                         let _range : Range = 1..AbsI(power);
                         {
-                            let _range_id_48144 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                            mutable _index_id_48147 : Int = _range_id_48144::Start;
-                            let _step_id_48152 : Int = _range_id_48144::Step;
-                            let _end_id_48157 : Int = _range_id_48144::End;
-                            while _step_id_48152 > 0 and _index_id_48147 <= _end_id_48157 or _step_id_48152 < 0 and _index_id_48147 >= _end_id_48157 {
-                                let _ : Int = _index_id_48147;
+                            let _range_id_48160 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                            mutable _index_id_48163 : Int = _range_id_48160::Start;
+                            let _step_id_48168 : Int = _range_id_48160::Step;
+                            let _end_id_48173 : Int = _range_id_48160::End;
+                            while _step_id_48168 > 0 and _index_id_48163 <= _end_id_48173 or _step_id_48168 < 0 and _index_id_48163 >= _end_id_48173 {
+                                let _ : Int = _index_id_48163;
                                 if power >= 0 {
                                     Adjoint U(target)
                                 } else {
                                     U(target)
                                 };
-                                _index_id_48147 += _step_id_48152;
+                                _index_id_48163 += _step_id_48168;
                             }
 
                         }
@@ -666,18 +666,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _range_id_48187 : Range = 1..AbsI(power);
-                        mutable _index_id_48190 : Int = _range_id_48187::Start;
-                        let _step_id_48195 : Int = _range_id_48187::Step;
-                        let _end_id_48200 : Int = _range_id_48187::End;
-                        while _step_id_48195 > 0 and _index_id_48190 <= _end_id_48200 or _step_id_48195 < 0 and _index_id_48190 >= _end_id_48200 {
-                            let _ : Int = _index_id_48190;
+                        let _range_id_48203 : Range = 1..AbsI(power);
+                        mutable _index_id_48206 : Int = _range_id_48203::Start;
+                        let _step_id_48211 : Int = _range_id_48203::Step;
+                        let _end_id_48216 : Int = _range_id_48203::End;
+                        while _step_id_48211 > 0 and _index_id_48206 <= _end_id_48216 or _step_id_48211 < 0 and _index_id_48206 >= _end_id_48216 {
+                            let _ : Int = _index_id_48206;
                             if power >= 0 {
                                 Controlled U(ctls, target)
                             } else {
                                 Controlled Adjoint U(ctls, target)
                             };
-                            _index_id_48190 += _step_id_48195;
+                            _index_id_48206 += _step_id_48211;
                         }
 
                     }
@@ -687,18 +687,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                     {
                         let _range : Range = 1..AbsI(power);
                         {
-                            let _range_id_48230 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                            mutable _index_id_48233 : Int = _range_id_48230::Start;
-                            let _step_id_48238 : Int = _range_id_48230::Step;
-                            let _end_id_48243 : Int = _range_id_48230::End;
-                            while _step_id_48238 > 0 and _index_id_48233 <= _end_id_48243 or _step_id_48238 < 0 and _index_id_48233 >= _end_id_48243 {
-                                let _ : Int = _index_id_48233;
+                            let _range_id_48246 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                            mutable _index_id_48249 : Int = _range_id_48246::Start;
+                            let _step_id_48254 : Int = _range_id_48246::Step;
+                            let _end_id_48259 : Int = _range_id_48246::End;
+                            while _step_id_48254 > 0 and _index_id_48249 <= _end_id_48259 or _step_id_48254 < 0 and _index_id_48249 >= _end_id_48259 {
+                                let _ : Int = _index_id_48249;
                                 if power >= 0 {
                                     Controlled Adjoint U(ctls, target)
                                 } else {
                                     Controlled U(ctls, target)
                                 };
-                                _index_id_48233 += _step_id_48238;
+                                _index_id_48249 += _step_id_48254;
                             }
 
                         }
@@ -766,7 +766,7 @@ fn analysis_bernstein_vazirani_sample_shape() {
         adaptive_qirgen_capabilities(),
         &expect![[r#"
             callable_params: 2
-              param: callable_id=<item 1016 in package 1>, path=[0], ty=(Qubit => Unit is Adj + Ctl)
+              param: callable_id=<item 1018 in package 1>, path=[0], ty=(Qubit => Unit is Adj + Ctl)
               param: callable_id=<item 6 in package 2>, path=[0], ty=(((Qubit)[], Qubit) => Unit)
             call_sites: 3
               site: hof=BernsteinVazirani<Empty>, arg=Closure(target=5, Body)
@@ -1016,13 +1016,13 @@ fn analysis_bernstein_vazirani_sample_shape() {
             operation ApplyToEachA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46318 : Qubit[] = register;
-                        let _len_id_46322 : Int = Length(_array_id_46318);
-                        mutable _index_id_46327 : Int = 0;
-                        while _index_id_46327 < _len_id_46322 {
-                            let item : Qubit = _array_id_46318[_index_id_46327];
+                        let _array_id_46334 : Qubit[] = register;
+                        let _len_id_46338 : Int = Length(_array_id_46334);
+                        mutable _index_id_46343 : Int = 0;
+                        while _index_id_46343 < _len_id_46338 {
+                            let item : Qubit = _array_id_46334[_index_id_46343];
                             H(item);
-                            _index_id_46327 += 1;
+                            _index_id_46343 += 1;
                         }
 
                     }
@@ -1032,15 +1032,15 @@ fn analysis_bernstein_vazirani_sample_shape() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46346 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46349 : Int = _range_id_46346::Start;
-                            let _step_id_46354 : Int = _range_id_46346::Step;
-                            let _end_id_46359 : Int = _range_id_46346::End;
-                            while _step_id_46354 > 0 and _index_id_46349 <= _end_id_46359 or _step_id_46354 < 0 and _index_id_46349 >= _end_id_46359 {
-                                let _index : Int = _index_id_46349;
+                            let _range_id_46362 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46365 : Int = _range_id_46362::Start;
+                            let _step_id_46370 : Int = _range_id_46362::Step;
+                            let _end_id_46375 : Int = _range_id_46362::End;
+                            while _step_id_46370 > 0 and _index_id_46365 <= _end_id_46375 or _step_id_46370 < 0 and _index_id_46365 >= _end_id_46375 {
+                                let _index : Int = _index_id_46365;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46349 += _step_id_46354;
+                                _index_id_46365 += _step_id_46370;
                             }
 
                         }
@@ -1052,13 +1052,13 @@ fn analysis_bernstein_vazirani_sample_shape() {
             operation ApplyToEachA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46318 : Qubit[] = register;
-                        let _len_id_46322 : Int = Length(_array_id_46318);
-                        mutable _index_id_46327 : Int = 0;
-                        while _index_id_46327 < _len_id_46322 {
-                            let item : Qubit = _array_id_46318[_index_id_46327];
+                        let _array_id_46334 : Qubit[] = register;
+                        let _len_id_46338 : Int = Length(_array_id_46334);
+                        mutable _index_id_46343 : Int = 0;
+                        while _index_id_46343 < _len_id_46338 {
+                            let item : Qubit = _array_id_46334[_index_id_46343];
                             H(item);
-                            _index_id_46327 += 1;
+                            _index_id_46343 += 1;
                         }
 
                     }
@@ -1068,15 +1068,15 @@ fn analysis_bernstein_vazirani_sample_shape() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46346 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46349 : Int = _range_id_46346::Start;
-                            let _step_id_46354 : Int = _range_id_46346::Step;
-                            let _end_id_46359 : Int = _range_id_46346::End;
-                            while _step_id_46354 > 0 and _index_id_46349 <= _end_id_46359 or _step_id_46354 < 0 and _index_id_46349 >= _end_id_46359 {
-                                let _index : Int = _index_id_46349;
+                            let _range_id_46362 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46365 : Int = _range_id_46362::Start;
+                            let _step_id_46370 : Int = _range_id_46362::Step;
+                            let _end_id_46375 : Int = _range_id_46362::End;
+                            while _step_id_46370 > 0 and _index_id_46365 <= _end_id_46375 or _step_id_46370 < 0 and _index_id_46365 >= _end_id_46375 {
+                                let _index : Int = _index_id_46365;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46349 += _step_id_46354;
+                                _index_id_46365 += _step_id_46370;
                             }
 
                         }
@@ -1152,7 +1152,7 @@ fn analysis_deutsch_jozsa_sample_shape() {
         adaptive_qirgen_capabilities(),
         &expect![[r#"
             callable_params: 2
-              param: callable_id=<item 1016 in package 1>, path=[1], ty=(Qubit => Unit is Adj + Ctl)
+              param: callable_id=<item 1018 in package 1>, path=[1], ty=(Qubit => Unit is Adj + Ctl)
               param: callable_id=<item 7 in package 2>, path=[0], ty=(((Qubit)[], Qubit) => Unit)
             call_sites: 6
               site: hof=ApplyControlledOnInt<Qubit, AdjCtl>, arg=Global(X, Body)
@@ -1951,13 +1951,13 @@ fn full_pipeline_handles_stdlib_apply_to_each() {
             }
             operation ApplyToEach_Qubit__AdjCtl__H_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46296 : Qubit[] = register;
+                    let _len_id_46300 : Int = Length(_array_id_46296);
+                    mutable _index_id_46305 : Int = 0;
+                    while _index_id_46305 < _len_id_46300 {
+                        let item : Qubit = _array_id_46296[_index_id_46305];
                         H(item);
-                        _index_id_46289 += 1;
+                        _index_id_46305 += 1;
                     }
 
                 }
@@ -1999,13 +1999,13 @@ fn full_pipeline_handles_stdlib_apply_to_each_with_custom_intrinsic() {
             }
             operation ApplyToEach_Qubit__AdjCtl__SX_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46296 : Qubit[] = register;
+                    let _len_id_46300 : Int = Length(_array_id_46296);
+                    mutable _index_id_46305 : Int = 0;
+                    while _index_id_46305 < _len_id_46300 {
+                        let item : Qubit = _array_id_46296[_index_id_46305];
                         SX(item);
-                        _index_id_46289 += 1;
+                        _index_id_46305 += 1;
                     }
 
                 }
@@ -2047,13 +2047,13 @@ fn apply_to_each_body_callable_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__AdjCtl__H_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46296 : Qubit[] = register;
+                    let _len_id_46300 : Int = Length(_array_id_46296);
+                    mutable _index_id_46305 : Int = 0;
+                    while _index_id_46305 < _len_id_46300 {
+                        let item : Qubit = _array_id_46296[_index_id_46305];
                         H(item);
-                        _index_id_46289 += 1;
+                        _index_id_46305 += 1;
                     }
 
                 }
@@ -2099,13 +2099,13 @@ fn apply_to_each_a_adjoint_callable_defunctionalizes() {
             operation ApplyToEachA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46308 : Qubit[] = register;
-                        let _len_id_46312 : Int = Length(_array_id_46308);
-                        mutable _index_id_46317 : Int = 0;
-                        while _index_id_46317 < _len_id_46312 {
-                            let item : Qubit = _array_id_46308[_index_id_46317];
+                        let _array_id_46324 : Qubit[] = register;
+                        let _len_id_46328 : Int = Length(_array_id_46324);
+                        mutable _index_id_46333 : Int = 0;
+                        while _index_id_46333 < _len_id_46328 {
+                            let item : Qubit = _array_id_46324[_index_id_46333];
                             S(item);
-                            _index_id_46317 += 1;
+                            _index_id_46333 += 1;
                         }
 
                     }
@@ -2115,15 +2115,15 @@ fn apply_to_each_a_adjoint_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46336 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46339 : Int = _range_id_46336::Start;
-                            let _step_id_46344 : Int = _range_id_46336::Step;
-                            let _end_id_46349 : Int = _range_id_46336::End;
-                            while _step_id_46344 > 0 and _index_id_46339 <= _end_id_46349 or _step_id_46344 < 0 and _index_id_46339 >= _end_id_46349 {
-                                let _index : Int = _index_id_46339;
+                            let _range_id_46352 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46355 : Int = _range_id_46352::Start;
+                            let _step_id_46360 : Int = _range_id_46352::Step;
+                            let _end_id_46365 : Int = _range_id_46352::End;
+                            while _step_id_46360 > 0 and _index_id_46355 <= _end_id_46365 or _step_id_46360 < 0 and _index_id_46355 >= _end_id_46365 {
+                                let _index : Int = _index_id_46355;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46339 += _step_id_46344;
+                                _index_id_46355 += _step_id_46360;
                             }
 
                         }
@@ -2175,13 +2175,13 @@ fn apply_to_each_c_controlled_callable_defunctionalizes() {
             operation ApplyToEachC_Qubit__AdjCtl__X_(register : Qubit[]) : Unit is Ctl {
                 body ... {
                     {
-                        let _array_id_46379 : Qubit[] = register;
-                        let _len_id_46383 : Int = Length(_array_id_46379);
-                        mutable _index_id_46388 : Int = 0;
-                        while _index_id_46388 < _len_id_46383 {
-                            let item : Qubit = _array_id_46379[_index_id_46388];
+                        let _array_id_46395 : Qubit[] = register;
+                        let _len_id_46399 : Int = Length(_array_id_46395);
+                        mutable _index_id_46404 : Int = 0;
+                        while _index_id_46404 < _len_id_46399 {
+                            let item : Qubit = _array_id_46395[_index_id_46404];
                             X(item);
-                            _index_id_46388 += 1;
+                            _index_id_46404 += 1;
                         }
 
                     }
@@ -2189,13 +2189,13 @@ fn apply_to_each_c_controlled_callable_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46407 : Qubit[] = register;
-                        let _len_id_46411 : Int = Length(_array_id_46407);
-                        mutable _index_id_46416 : Int = 0;
-                        while _index_id_46416 < _len_id_46411 {
-                            let item : Qubit = _array_id_46407[_index_id_46416];
+                        let _array_id_46423 : Qubit[] = register;
+                        let _len_id_46427 : Int = Length(_array_id_46423);
+                        mutable _index_id_46432 : Int = 0;
+                        while _index_id_46432 < _len_id_46427 {
+                            let item : Qubit = _array_id_46423[_index_id_46432];
                             Controlled X(ctls, item);
-                            _index_id_46416 += 1;
+                            _index_id_46432 += 1;
                         }
 
                     }
@@ -2239,13 +2239,13 @@ fn apply_to_each_ca_callable_defunctionalizes() {
             operation ApplyToEachCA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46451 : Qubit[] = register;
+                        let _len_id_46455 : Int = Length(_array_id_46451);
+                        mutable _index_id_46460 : Int = 0;
+                        while _index_id_46460 < _len_id_46455 {
+                            let item : Qubit = _array_id_46451[_index_id_46460];
                             S(item);
-                            _index_id_46444 += 1;
+                            _index_id_46460 += 1;
                         }
 
                     }
@@ -2255,15 +2255,15 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46479 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46482 : Int = _range_id_46479::Start;
+                            let _step_id_46487 : Int = _range_id_46479::Step;
+                            let _end_id_46492 : Int = _range_id_46479::End;
+                            while _step_id_46487 > 0 and _index_id_46482 <= _end_id_46492 or _step_id_46487 < 0 and _index_id_46482 >= _end_id_46492 {
+                                let _index : Int = _index_id_46482;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46482 += _step_id_46487;
                             }
 
                         }
@@ -2273,13 +2273,13 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46522 : Qubit[] = register;
+                        let _len_id_46526 : Int = Length(_array_id_46522);
+                        mutable _index_id_46531 : Int = 0;
+                        while _index_id_46531 < _len_id_46526 {
+                            let item : Qubit = _array_id_46522[_index_id_46531];
                             Controlled S(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46531 += 1;
                         }
 
                     }
@@ -2289,15 +2289,15 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46550 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46553 : Int = _range_id_46550::Start;
+                            let _step_id_46558 : Int = _range_id_46550::Step;
+                            let _end_id_46563 : Int = _range_id_46550::End;
+                            while _step_id_46558 > 0 and _index_id_46553 <= _end_id_46563 or _step_id_46558 < 0 and _index_id_46553 >= _end_id_46563 {
+                                let _index : Int = _index_id_46553;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint S(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46553 += _step_id_46558;
                             }
 
                         }
@@ -2351,13 +2351,13 @@ fn cross_package_apply_to_each_closure_arg_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__Empty__closure_(register : Qubit[], __capture_0 : Double) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46296 : Qubit[] = register;
+                    let _len_id_46300 : Int = Length(_array_id_46296);
+                    mutable _index_id_46305 : Int = 0;
+                    while _index_id_46305 < _len_id_46300 {
+                        let item : Qubit = _array_id_46296[_index_id_46305];
                         _lambda_2(__capture_0, item);
-                        _index_id_46289 += 1;
+                        _index_id_46305 += 1;
                     }
 
                 }
@@ -2399,13 +2399,13 @@ fn cross_package_apply_to_each_adjoint_arg_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__AdjCtl__Adj_S_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46296 : Qubit[] = register;
+                    let _len_id_46300 : Int = Length(_array_id_46296);
+                    mutable _index_id_46305 : Int = 0;
+                    while _index_id_46305 < _len_id_46300 {
+                        let item : Qubit = _array_id_46296[_index_id_46305];
                         Adjoint S(item);
-                        _index_id_46289 += 1;
+                        _index_id_46305 += 1;
                     }
 
                 }
@@ -2448,13 +2448,13 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
             operation ApplyToEachCA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46451 : Qubit[] = register;
+                        let _len_id_46455 : Int = Length(_array_id_46451);
+                        mutable _index_id_46460 : Int = 0;
+                        while _index_id_46460 < _len_id_46455 {
+                            let item : Qubit = _array_id_46451[_index_id_46460];
                             S(item);
-                            _index_id_46444 += 1;
+                            _index_id_46460 += 1;
                         }
 
                     }
@@ -2464,15 +2464,15 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46479 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46482 : Int = _range_id_46479::Start;
+                            let _step_id_46487 : Int = _range_id_46479::Step;
+                            let _end_id_46492 : Int = _range_id_46479::End;
+                            while _step_id_46487 > 0 and _index_id_46482 <= _end_id_46492 or _step_id_46487 < 0 and _index_id_46482 >= _end_id_46492 {
+                                let _index : Int = _index_id_46482;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46482 += _step_id_46487;
                             }
 
                         }
@@ -2482,13 +2482,13 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46522 : Qubit[] = register;
+                        let _len_id_46526 : Int = Length(_array_id_46522);
+                        mutable _index_id_46531 : Int = 0;
+                        while _index_id_46531 < _len_id_46526 {
+                            let item : Qubit = _array_id_46522[_index_id_46531];
                             Controlled S(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46531 += 1;
                         }
 
                     }
@@ -2498,15 +2498,15 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46550 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46553 : Int = _range_id_46550::Start;
+                            let _step_id_46558 : Int = _range_id_46550::Step;
+                            let _end_id_46563 : Int = _range_id_46550::End;
+                            while _step_id_46558 > 0 and _index_id_46553 <= _end_id_46563 or _step_id_46558 < 0 and _index_id_46553 >= _end_id_46563 {
+                                let _index : Int = _index_id_46553;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint S(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46553 += _step_id_46558;
                             }
 
                         }
@@ -2624,13 +2624,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
             operation ApplyToEachCA_Qubit__AdjCtl__X_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46451 : Qubit[] = register;
+                        let _len_id_46455 : Int = Length(_array_id_46451);
+                        mutable _index_id_46460 : Int = 0;
+                        while _index_id_46460 < _len_id_46455 {
+                            let item : Qubit = _array_id_46451[_index_id_46460];
                             X(item);
-                            _index_id_46444 += 1;
+                            _index_id_46460 += 1;
                         }
 
                     }
@@ -2640,15 +2640,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46479 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46482 : Int = _range_id_46479::Start;
+                            let _step_id_46487 : Int = _range_id_46479::Step;
+                            let _end_id_46492 : Int = _range_id_46479::End;
+                            while _step_id_46487 > 0 and _index_id_46482 <= _end_id_46492 or _step_id_46487 < 0 and _index_id_46482 >= _end_id_46492 {
+                                let _index : Int = _index_id_46482;
                                 let item : Qubit = _array[_index];
                                 Adjoint X(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46482 += _step_id_46487;
                             }
 
                         }
@@ -2658,13 +2658,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46522 : Qubit[] = register;
+                        let _len_id_46526 : Int = Length(_array_id_46522);
+                        mutable _index_id_46531 : Int = 0;
+                        while _index_id_46531 < _len_id_46526 {
+                            let item : Qubit = _array_id_46522[_index_id_46531];
                             Controlled X(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46531 += 1;
                         }
 
                     }
@@ -2674,15 +2674,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46550 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46553 : Int = _range_id_46550::Start;
+                            let _step_id_46558 : Int = _range_id_46550::Step;
+                            let _end_id_46563 : Int = _range_id_46550::End;
+                            while _step_id_46558 > 0 and _index_id_46553 <= _end_id_46563 or _step_id_46558 < 0 and _index_id_46553 >= _end_id_46563 {
+                                let _index : Int = _index_id_46553;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint X(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46553 += _step_id_46558;
                             }
 
                         }
@@ -2694,13 +2694,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
             operation ApplyToEachCA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46451 : Qubit[] = register;
+                        let _len_id_46455 : Int = Length(_array_id_46451);
+                        mutable _index_id_46460 : Int = 0;
+                        while _index_id_46460 < _len_id_46455 {
+                            let item : Qubit = _array_id_46451[_index_id_46460];
                             H(item);
-                            _index_id_46444 += 1;
+                            _index_id_46460 += 1;
                         }
 
                     }
@@ -2710,15 +2710,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46479 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46482 : Int = _range_id_46479::Start;
+                            let _step_id_46487 : Int = _range_id_46479::Step;
+                            let _end_id_46492 : Int = _range_id_46479::End;
+                            while _step_id_46487 > 0 and _index_id_46482 <= _end_id_46492 or _step_id_46487 < 0 and _index_id_46482 >= _end_id_46492 {
+                                let _index : Int = _index_id_46482;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46482 += _step_id_46487;
                             }
 
                         }
@@ -2728,13 +2728,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46522 : Qubit[] = register;
+                        let _len_id_46526 : Int = Length(_array_id_46522);
+                        mutable _index_id_46531 : Int = 0;
+                        while _index_id_46531 < _len_id_46526 {
+                            let item : Qubit = _array_id_46522[_index_id_46531];
                             Controlled H(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46531 += 1;
                         }
 
                     }
@@ -2744,15 +2744,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46550 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46553 : Int = _range_id_46550::Start;
+                            let _step_id_46558 : Int = _range_id_46550::Step;
+                            let _end_id_46563 : Int = _range_id_46550::End;
+                            while _step_id_46558 > 0 and _index_id_46553 <= _end_id_46563 or _step_id_46558 < 0 and _index_id_46553 >= _end_id_46563 {
+                                let _index : Int = _index_id_46553;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint H(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46553 += _step_id_46558;
                             }
 
                         }
@@ -2804,13 +2804,13 @@ fn cross_package_mapped_defunctionalizes() {
             function Mapped_Int__Int__Double_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45810 : Int[] = array;
+                    let _len_id_45814 : Int = Length(_array_id_45810);
+                    mutable _index_id_45819 : Int = 0;
+                    while _index_id_45819 < _len_id_45814 {
+                        let element : Int = _array_id_45810[_index_id_45819];
                         mapped += [Double(element)];
-                        _index_id_45803 += 1;
+                        _index_id_45819 += 1;
                     }
 
                 }
@@ -2854,13 +2854,13 @@ fn cross_package_for_each_defunctionalizes() {
             operation ForEach_Qubit__Unit__AdjCtl__H_(array : Qubit[]) : Unit[] {
                 mutable output : Unit[] = [];
                 {
-                    let _array_id_45566 : Qubit[] = array;
-                    let _len_id_45570 : Int = Length(_array_id_45566);
-                    mutable _index_id_45575 : Int = 0;
-                    while _index_id_45575 < _len_id_45570 {
-                        let element : Qubit = _array_id_45566[_index_id_45575];
+                    let _array_id_45582 : Qubit[] = array;
+                    let _len_id_45586 : Int = Length(_array_id_45582);
+                    mutable _index_id_45591 : Int = 0;
+                    while _index_id_45591 < _len_id_45586 {
+                        let element : Qubit = _array_id_45582[_index_id_45591];
                         output += [H(element)];
-                        _index_id_45575 += 1;
+                        _index_id_45591 += 1;
                     }
 
                 }
@@ -2915,13 +2915,13 @@ fn stdlib_hof_specialized_with_concrete_callable() {
             function Mapped_Int__Int__closure_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45810 : Int[] = array;
+                    let _len_id_45814 : Int = Length(_array_id_45810);
+                    mutable _index_id_45819 : Int = 0;
+                    while _index_id_45819 < _len_id_45814 {
+                        let element : Int = _array_id_45810[_index_id_45819];
                         mapped += [_lambda_2(element, )];
-                        _index_id_45803 += 1;
+                        _index_id_45819 += 1;
                     }
 
                 }
@@ -2999,13 +2999,13 @@ fn lambda_expression_sample_shape_has_no_defunctionalization_errors() {
             function Fold_Int__Int__closure_(state : Int, array : Int[]) : Int {
                 mutable current : Int = state;
                 {
-                    let _array_id_45538 : Int[] = array;
-                    let _len_id_45542 : Int = Length(_array_id_45538);
-                    mutable _index_id_45547 : Int = 0;
-                    while _index_id_45547 < _len_id_45542 {
-                        let element : Int = _array_id_45538[_index_id_45547];
+                    let _array_id_45554 : Int[] = array;
+                    let _len_id_45558 : Int = Length(_array_id_45554);
+                    mutable _index_id_45563 : Int = 0;
+                    while _index_id_45563 < _len_id_45558 {
+                        let element : Int = _array_id_45554[_index_id_45563];
                         current = _lambda_2((current, element), );
-                        _index_id_45547 += 1;
+                        _index_id_45563 += 1;
                     }
 
                 }
@@ -3015,13 +3015,13 @@ fn lambda_expression_sample_shape_has_no_defunctionalization_errors() {
             function Mapped_Int__Int__closure_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45810 : Int[] = array;
+                    let _len_id_45814 : Int = Length(_array_id_45810);
+                    mutable _index_id_45819 : Int = 0;
+                    while _index_id_45819 < _len_id_45814 {
+                        let element : Int = _array_id_45810[_index_id_45819];
                         mapped += [_lambda_4(element, )];
-                        _index_id_45803 += 1;
+                        _index_id_45819 += 1;
                     }
 
                 }
@@ -3137,13 +3137,13 @@ fn partial_application_sample_shape_has_no_defunctionalization_errors() {
             function Mapped_Int__Int__closure_(array : Int[], __capture_0 : Int) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45810 : Int[] = array;
+                    let _len_id_45814 : Int = Length(_array_id_45810);
+                    mutable _index_id_45819 : Int = 0;
+                    while _index_id_45819 < _len_id_45814 {
+                        let element : Int = _array_id_45810[_index_id_45819];
                         mapped += [_lambda_8(__capture_0, element)];
-                        _index_id_45803 += 1;
+                        _index_id_45819 += 1;
                     }
 
                 }

--- a/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/grover.rs
+++ b/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/grover.rs
@@ -333,27 +333,27 @@ fn grover_sample_full_pipeline_reachable_items() {
         operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
             body ... {
                 {
-                    let _range_id_48949 : Range = 0..2..Length(ctls) - 2;
-                    mutable _index_id_48952 : Int = _range_id_48949::Start;
-                    let _step_id_48957 : Int = _range_id_48949::Step;
-                    let _end_id_48962 : Int = _range_id_48949::End;
-                    while _step_id_48957 > 0 and _index_id_48952 <= _end_id_48962 or _step_id_48957 < 0 and _index_id_48952 >= _end_id_48962 {
-                        let i : Int = _index_id_48952;
+                    let _range_id_48965 : Range = 0..2..Length(ctls) - 2;
+                    mutable _index_id_48968 : Int = _range_id_48965::Start;
+                    let _step_id_48973 : Int = _range_id_48965::Step;
+                    let _end_id_48978 : Int = _range_id_48965::End;
+                    while _step_id_48973 > 0 and _index_id_48968 <= _end_id_48978 or _step_id_48973 < 0 and _index_id_48968 >= _end_id_48978 {
+                        let i : Int = _index_id_48968;
                         CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                        _index_id_48952 += _step_id_48957;
+                        _index_id_48968 += _step_id_48973;
                     }
 
                 }
 
                 {
-                    let _range_id_48992 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
-                    mutable _index_id_48995 : Int = _range_id_48992::Start;
-                    let _step_id_49000 : Int = _range_id_48992::Step;
-                    let _end_id_49005 : Int = _range_id_48992::End;
-                    while _step_id_49000 > 0 and _index_id_48995 <= _end_id_49005 or _step_id_49000 < 0 and _index_id_48995 >= _end_id_49005 {
-                        let i : Int = _index_id_48995;
+                    let _range_id_49008 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
+                    mutable _index_id_49011 : Int = _range_id_49008::Start;
+                    let _step_id_49016 : Int = _range_id_49008::Step;
+                    let _end_id_49021 : Int = _range_id_49008::End;
+                    while _step_id_49016 > 0 and _index_id_49011 <= _end_id_49021 or _step_id_49016 < 0 and _index_id_49011 >= _end_id_49021 {
+                        let i : Int = _index_id_49011;
                         CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                        _index_id_48995 += _step_id_49000;
+                        _index_id_49011 += _step_id_49016;
                     }
 
                 }
@@ -363,14 +363,14 @@ fn grover_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(ctls) / 2 - 2 - adjustment;
                     {
-                        let _range_id_49035 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49038 : Int = _range_id_49035::Start;
-                        let _step_id_49043 : Int = _range_id_49035::Step;
-                        let _end_id_49048 : Int = _range_id_49035::End;
-                        while _step_id_49043 > 0 and _index_id_49038 <= _end_id_49048 or _step_id_49043 < 0 and _index_id_49038 >= _end_id_49048 {
-                            let i : Int = _index_id_49038;
+                        let _range_id_49051 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49054 : Int = _range_id_49051::Start;
+                        let _step_id_49059 : Int = _range_id_49051::Step;
+                        let _end_id_49064 : Int = _range_id_49051::End;
+                        while _step_id_49059 > 0 and _index_id_49054 <= _end_id_49064 or _step_id_49059 < 0 and _index_id_49054 >= _end_id_49064 {
+                            let i : Int = _index_id_49054;
                             Adjoint CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                            _index_id_49038 += _step_id_49043;
+                            _index_id_49054 += _step_id_49059;
                         }
 
                     }
@@ -380,14 +380,14 @@ fn grover_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..2..Length(ctls) - 2;
                     {
-                        let _range_id_49078 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49081 : Int = _range_id_49078::Start;
-                        let _step_id_49086 : Int = _range_id_49078::Step;
-                        let _end_id_49091 : Int = _range_id_49078::End;
-                        while _step_id_49086 > 0 and _index_id_49081 <= _end_id_49091 or _step_id_49086 < 0 and _index_id_49081 >= _end_id_49091 {
-                            let i : Int = _index_id_49081;
+                        let _range_id_49094 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49097 : Int = _range_id_49094::Start;
+                        let _step_id_49102 : Int = _range_id_49094::Step;
+                        let _end_id_49107 : Int = _range_id_49094::End;
+                        while _step_id_49102 > 0 and _index_id_49097 <= _end_id_49107 or _step_id_49102 < 0 and _index_id_49097 >= _end_id_49107 {
+                            let i : Int = _index_id_49097;
                             Adjoint CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                            _index_id_49081 += _step_id_49086;
+                            _index_id_49097 += _step_id_49102;
                         }
 
                     }
@@ -500,7 +500,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54052 : Unit = {
+                            let _generated_ident_54068 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -521,7 +521,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54052
+                            _generated_ident_54068
                         }
 
                     }
@@ -546,7 +546,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54066 : Unit = {
+                            let _generated_ident_54082 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -567,7 +567,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54066
+                            _generated_ident_54082
                         }
 
                     }
@@ -594,7 +594,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         CRz(ctls[0], theta, qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54122 : Unit = {
+                        let _generated_ident_54138 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -611,7 +611,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54122
+                        _generated_ident_54138
                     }
 
                 }
@@ -645,7 +645,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             Controlled CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54150 : Unit = {
+                            let _generated_ident_54166 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -666,7 +666,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54150
+                            _generated_ident_54166
                         }
 
                     }
@@ -691,7 +691,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             Controlled Adjoint CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54164 : Unit = {
+                            let _generated_ident_54180 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -712,7 +712,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54164
+                            _generated_ident_54180
                         }
 
                     }
@@ -739,7 +739,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54206 : Unit = {
+                        let _generated_ident_54222 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -756,7 +756,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54206
+                        _generated_ident_54222
                     }
 
                 }
@@ -773,7 +773,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         Adjoint CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54220 : Unit = {
+                        let _generated_ident_54236 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -790,7 +790,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54220
+                        _generated_ident_54236
                     }
 
                 }
@@ -821,7 +821,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54234 : Unit = {
+                            let _generated_ident_54250 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -842,7 +842,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54234
+                            _generated_ident_54250
                         }
 
                     }
@@ -867,7 +867,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54248 : Unit = {
+                            let _generated_ident_54264 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -888,7 +888,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54248
+                            _generated_ident_54264
                         }
 
                     }
@@ -921,7 +921,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCZ(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54290 : Unit = {
+                            let _generated_ident_54306 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -942,7 +942,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54290
+                            _generated_ident_54306
                         }
 
                     }
@@ -967,7 +967,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCZ(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54304 : Unit = {
+                            let _generated_ident_54320 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -988,7 +988,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54304
+                            _generated_ident_54320
                         }
 
                     }
@@ -1037,13 +1037,13 @@ fn grover_sample_full_pipeline_reachable_items() {
         operation MResetEachZ(register : Qubit[]) : Result[] {
             mutable results : Result[] = [];
             {
-                let _array_id_49717 : Qubit[] = register;
-                let _len_id_49721 : Int = Length(_array_id_49717);
-                mutable _index_id_49726 : Int = 0;
-                while _index_id_49726 < _len_id_49721 {
-                    let qubit : Qubit = _array_id_49717[_index_id_49726];
+                let _array_id_49733 : Qubit[] = register;
+                let _len_id_49737 : Int = Length(_array_id_49733);
+                mutable _index_id_49742 : Int = 0;
+                while _index_id_49742 < _len_id_49737 {
+                    let qubit : Qubit = _array_id_49733[_index_id_49742];
                     results += [MResetZ(qubit)];
-                    _index_id_49726 += 1;
+                    _index_id_49742 += 1;
                 }
 
             }

--- a/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
+++ b/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
@@ -148,17 +148,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47781 : Qubit[] = target;
-                    let _len_id_47785 : Int = Length(_array_id_47781);
-                    mutable _index_id_47790 : Int = 0;
-                    while _index_id_47790 < _len_id_47785 {
-                        let q : Qubit = _array_id_47781[_index_id_47790];
+                    let _array_id_47797 : Qubit[] = target;
+                    let _len_id_47801 : Int = Length(_array_id_47797);
+                    mutable _index_id_47806 : Int = 0;
+                    while _index_id_47806 < _len_id_47801 {
+                        let q : Qubit = _array_id_47797[_index_id_47806];
                         if runningValue &&& 1 != 0 {
                             X(q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47790 += 1;
+                        _index_id_47806 += 1;
                     }
 
                 }
@@ -169,17 +169,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47809 : Qubit[] = target;
-                    let _len_id_47813 : Int = Length(_array_id_47809);
-                    mutable _index_id_47818 : Int = 0;
-                    while _index_id_47818 < _len_id_47813 {
-                        let q : Qubit = _array_id_47809[_index_id_47818];
+                    let _array_id_47825 : Qubit[] = target;
+                    let _len_id_47829 : Int = Length(_array_id_47825);
+                    mutable _index_id_47834 : Int = 0;
+                    while _index_id_47834 < _len_id_47829 {
+                        let q : Qubit = _array_id_47825[_index_id_47834];
                         if runningValue &&& 1 != 0 {
                             X(q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47818 += 1;
+                        _index_id_47834 += 1;
                     }
 
                 }
@@ -190,17 +190,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47837 : Qubit[] = target;
-                    let _len_id_47841 : Int = Length(_array_id_47837);
-                    mutable _index_id_47846 : Int = 0;
-                    while _index_id_47846 < _len_id_47841 {
-                        let q : Qubit = _array_id_47837[_index_id_47846];
+                    let _array_id_47853 : Qubit[] = target;
+                    let _len_id_47857 : Int = Length(_array_id_47853);
+                    mutable _index_id_47862 : Int = 0;
+                    while _index_id_47862 < _len_id_47857 {
+                        let q : Qubit = _array_id_47853[_index_id_47862];
                         if runningValue &&& 1 != 0 {
                             Controlled X(ctls, q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47846 += 1;
+                        _index_id_47862 += 1;
                     }
 
                 }
@@ -211,17 +211,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47865 : Qubit[] = target;
-                    let _len_id_47869 : Int = Length(_array_id_47865);
-                    mutable _index_id_47874 : Int = 0;
-                    while _index_id_47874 < _len_id_47869 {
-                        let q : Qubit = _array_id_47865[_index_id_47874];
+                    let _array_id_47881 : Qubit[] = target;
+                    let _len_id_47885 : Int = Length(_array_id_47881);
+                    mutable _index_id_47890 : Int = 0;
+                    while _index_id_47890 < _len_id_47885 {
+                        let q : Qubit = _array_id_47881[_index_id_47890];
                         if runningValue &&& 1 != 0 {
                             Controlled X(ctls, q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47874 += 1;
+                        _index_id_47890 += 1;
                     }
 
                 }
@@ -430,27 +430,27 @@ fn shor_sample_full_pipeline_reachable_items() {
         operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
             body ... {
                 {
-                    let _range_id_48949 : Range = 0..2..Length(ctls) - 2;
-                    mutable _index_id_48952 : Int = _range_id_48949::Start;
-                    let _step_id_48957 : Int = _range_id_48949::Step;
-                    let _end_id_48962 : Int = _range_id_48949::End;
-                    while _step_id_48957 > 0 and _index_id_48952 <= _end_id_48962 or _step_id_48957 < 0 and _index_id_48952 >= _end_id_48962 {
-                        let i : Int = _index_id_48952;
+                    let _range_id_48965 : Range = 0..2..Length(ctls) - 2;
+                    mutable _index_id_48968 : Int = _range_id_48965::Start;
+                    let _step_id_48973 : Int = _range_id_48965::Step;
+                    let _end_id_48978 : Int = _range_id_48965::End;
+                    while _step_id_48973 > 0 and _index_id_48968 <= _end_id_48978 or _step_id_48973 < 0 and _index_id_48968 >= _end_id_48978 {
+                        let i : Int = _index_id_48968;
                         CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                        _index_id_48952 += _step_id_48957;
+                        _index_id_48968 += _step_id_48973;
                     }
 
                 }
 
                 {
-                    let _range_id_48992 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
-                    mutable _index_id_48995 : Int = _range_id_48992::Start;
-                    let _step_id_49000 : Int = _range_id_48992::Step;
-                    let _end_id_49005 : Int = _range_id_48992::End;
-                    while _step_id_49000 > 0 and _index_id_48995 <= _end_id_49005 or _step_id_49000 < 0 and _index_id_48995 >= _end_id_49005 {
-                        let i : Int = _index_id_48995;
+                    let _range_id_49008 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
+                    mutable _index_id_49011 : Int = _range_id_49008::Start;
+                    let _step_id_49016 : Int = _range_id_49008::Step;
+                    let _end_id_49021 : Int = _range_id_49008::End;
+                    while _step_id_49016 > 0 and _index_id_49011 <= _end_id_49021 or _step_id_49016 < 0 and _index_id_49011 >= _end_id_49021 {
+                        let i : Int = _index_id_49011;
                         CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                        _index_id_48995 += _step_id_49000;
+                        _index_id_49011 += _step_id_49016;
                     }
 
                 }
@@ -460,14 +460,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(ctls) / 2 - 2 - adjustment;
                     {
-                        let _range_id_49035 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49038 : Int = _range_id_49035::Start;
-                        let _step_id_49043 : Int = _range_id_49035::Step;
-                        let _end_id_49048 : Int = _range_id_49035::End;
-                        while _step_id_49043 > 0 and _index_id_49038 <= _end_id_49048 or _step_id_49043 < 0 and _index_id_49038 >= _end_id_49048 {
-                            let i : Int = _index_id_49038;
+                        let _range_id_49051 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49054 : Int = _range_id_49051::Start;
+                        let _step_id_49059 : Int = _range_id_49051::Step;
+                        let _end_id_49064 : Int = _range_id_49051::End;
+                        while _step_id_49059 > 0 and _index_id_49054 <= _end_id_49064 or _step_id_49059 < 0 and _index_id_49054 >= _end_id_49064 {
+                            let i : Int = _index_id_49054;
                             Adjoint CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                            _index_id_49038 += _step_id_49043;
+                            _index_id_49054 += _step_id_49059;
                         }
 
                     }
@@ -477,14 +477,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..2..Length(ctls) - 2;
                     {
-                        let _range_id_49078 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49081 : Int = _range_id_49078::Start;
-                        let _step_id_49086 : Int = _range_id_49078::Step;
-                        let _end_id_49091 : Int = _range_id_49078::End;
-                        while _step_id_49086 > 0 and _index_id_49081 <= _end_id_49091 or _step_id_49086 < 0 and _index_id_49081 >= _end_id_49091 {
-                            let i : Int = _index_id_49081;
+                        let _range_id_49094 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49097 : Int = _range_id_49094::Start;
+                        let _step_id_49102 : Int = _range_id_49094::Step;
+                        let _end_id_49107 : Int = _range_id_49094::End;
+                        while _step_id_49102 > 0 and _index_id_49097 <= _end_id_49107 or _step_id_49102 < 0 and _index_id_49097 >= _end_id_49107 {
+                            let i : Int = _index_id_49097;
                             Adjoint CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                            _index_id_49081 += _step_id_49086;
+                            _index_id_49097 += _step_id_49102;
                         }
 
                     }
@@ -597,7 +597,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54052 : Unit = {
+                            let _generated_ident_54068 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -618,7 +618,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54052
+                            _generated_ident_54068
                         }
 
                     }
@@ -643,7 +643,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54066 : Unit = {
+                            let _generated_ident_54082 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -664,7 +664,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54066
+                            _generated_ident_54082
                         }
 
                     }
@@ -749,13 +749,13 @@ fn shor_sample_full_pipeline_reachable_items() {
         }
         operation ResetAll(qubits : Qubit[]) : Unit {
             {
-                let _array_id_49450 : Qubit[] = qubits;
-                let _len_id_49454 : Int = Length(_array_id_49450);
-                mutable _index_id_49459 : Int = 0;
-                while _index_id_49459 < _len_id_49454 {
-                    let q : Qubit = _array_id_49450[_index_id_49459];
+                let _array_id_49466 : Qubit[] = qubits;
+                let _len_id_49470 : Int = Length(_array_id_49466);
+                mutable _index_id_49475 : Int = 0;
+                while _index_id_49475 < _len_id_49470 {
+                    let q : Qubit = _array_id_49466[_index_id_49475];
                     Reset(q);
-                    _index_id_49459 += 1;
+                    _index_id_49475 += 1;
                 }
 
             }
@@ -865,7 +865,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         CRz(ctls[0], theta, qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54122 : Unit = {
+                        let _generated_ident_54138 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -882,7 +882,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54122
+                        _generated_ident_54138
                     }
 
                 }
@@ -916,7 +916,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             Controlled CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54150 : Unit = {
+                            let _generated_ident_54166 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -937,7 +937,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54150
+                            _generated_ident_54166
                         }
 
                     }
@@ -962,7 +962,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             Controlled Adjoint CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54164 : Unit = {
+                            let _generated_ident_54180 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -983,7 +983,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54164
+                            _generated_ident_54180
                         }
 
                     }
@@ -1064,7 +1064,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54206 : Unit = {
+                        let _generated_ident_54222 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -1081,7 +1081,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54206
+                        _generated_ident_54222
                     }
 
                 }
@@ -1098,7 +1098,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         Adjoint CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54220 : Unit = {
+                        let _generated_ident_54236 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -1115,7 +1115,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54220
+                        _generated_ident_54236
                     }
 
                 }
@@ -1146,7 +1146,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54234 : Unit = {
+                            let _generated_ident_54250 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -1167,7 +1167,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54234
+                            _generated_ident_54250
                         }
 
                     }
@@ -1192,7 +1192,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54248 : Unit = {
+                            let _generated_ident_54264 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -1213,7 +1213,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54248
+                            _generated_ident_54264
                         }
 
                     }
@@ -1722,27 +1722,27 @@ fn shor_sample_full_pipeline_reachable_items() {
             body ... {
                 Fact(Length(xs) <= Length(ys), $"Input register ys must be at least as long as xs.");
                 {
-                    let _range_id_51250 : Range = 1..Length(xs) - 1;
-                    mutable _index_id_51253 : Int = _range_id_51250::Start;
-                    let _step_id_51258 : Int = _range_id_51250::Step;
-                    let _end_id_51263 : Int = _range_id_51250::End;
-                    while _step_id_51258 > 0 and _index_id_51253 <= _end_id_51263 or _step_id_51258 < 0 and _index_id_51253 >= _end_id_51263 {
-                        let i : Int = _index_id_51253;
+                    let _range_id_51266 : Range = 1..Length(xs) - 1;
+                    mutable _index_id_51269 : Int = _range_id_51266::Start;
+                    let _step_id_51274 : Int = _range_id_51266::Step;
+                    let _end_id_51279 : Int = _range_id_51266::End;
+                    while _step_id_51274 > 0 and _index_id_51269 <= _end_id_51279 or _step_id_51274 < 0 and _index_id_51269 >= _end_id_51279 {
+                        let i : Int = _index_id_51269;
                         CNOT(xs[i], ys[i]);
-                        _index_id_51253 += _step_id_51258;
+                        _index_id_51269 += _step_id_51274;
                     }
 
                 }
 
                 {
-                    let _range_id_51293 : Range = Length(xs) - 2..-1..1;
-                    mutable _index_id_51296 : Int = _range_id_51293::Start;
-                    let _step_id_51301 : Int = _range_id_51293::Step;
-                    let _end_id_51306 : Int = _range_id_51293::End;
-                    while _step_id_51301 > 0 and _index_id_51296 <= _end_id_51306 or _step_id_51301 < 0 and _index_id_51296 >= _end_id_51306 {
-                        let i : Int = _index_id_51296;
+                    let _range_id_51309 : Range = Length(xs) - 2..-1..1;
+                    mutable _index_id_51312 : Int = _range_id_51309::Start;
+                    let _step_id_51317 : Int = _range_id_51309::Step;
+                    let _end_id_51322 : Int = _range_id_51309::End;
+                    while _step_id_51317 > 0 and _index_id_51312 <= _end_id_51322 or _step_id_51317 < 0 and _index_id_51312 >= _end_id_51322 {
+                        let i : Int = _index_id_51312;
                         CNOT(xs[i], xs[i + 1]);
-                        _index_id_51296 += _step_id_51301;
+                        _index_id_51312 += _step_id_51317;
                     }
 
                 }
@@ -1753,14 +1753,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 2..-1..1;
                     {
-                        let _range_id_51336 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51339 : Int = _range_id_51336::Start;
-                        let _step_id_51344 : Int = _range_id_51336::Step;
-                        let _end_id_51349 : Int = _range_id_51336::End;
-                        while _step_id_51344 > 0 and _index_id_51339 <= _end_id_51349 or _step_id_51344 < 0 and _index_id_51339 >= _end_id_51349 {
-                            let i : Int = _index_id_51339;
+                        let _range_id_51352 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51355 : Int = _range_id_51352::Start;
+                        let _step_id_51360 : Int = _range_id_51352::Step;
+                        let _end_id_51365 : Int = _range_id_51352::End;
+                        while _step_id_51360 > 0 and _index_id_51355 <= _end_id_51365 or _step_id_51360 < 0 and _index_id_51355 >= _end_id_51365 {
+                            let i : Int = _index_id_51355;
                             Adjoint CNOT(xs[i], xs[i + 1]);
-                            _index_id_51339 += _step_id_51344;
+                            _index_id_51355 += _step_id_51360;
                         }
 
                     }
@@ -1770,14 +1770,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 1..Length(xs) - 1;
                     {
-                        let _range_id_51379 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51382 : Int = _range_id_51379::Start;
-                        let _step_id_51387 : Int = _range_id_51379::Step;
-                        let _end_id_51392 : Int = _range_id_51379::End;
-                        while _step_id_51387 > 0 and _index_id_51382 <= _end_id_51392 or _step_id_51387 < 0 and _index_id_51382 >= _end_id_51392 {
-                            let i : Int = _index_id_51382;
+                        let _range_id_51395 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51398 : Int = _range_id_51395::Start;
+                        let _step_id_51403 : Int = _range_id_51395::Step;
+                        let _end_id_51408 : Int = _range_id_51395::End;
+                        while _step_id_51403 > 0 and _index_id_51398 <= _end_id_51408 or _step_id_51403 < 0 and _index_id_51398 >= _end_id_51408 {
+                            let i : Int = _index_id_51398;
                             Adjoint CNOT(xs[i], ys[i]);
-                            _index_id_51382 += _step_id_51387;
+                            _index_id_51398 += _step_id_51403;
                         }
 
                     }
@@ -1788,27 +1788,27 @@ fn shor_sample_full_pipeline_reachable_items() {
             controlled (ctls, ...) {
                 Fact(Length(xs) <= Length(ys), $"Input register ys must be at least as long as xs.");
                 {
-                    let _range_id_51422 : Range = 1..Length(xs) - 1;
-                    mutable _index_id_51425 : Int = _range_id_51422::Start;
-                    let _step_id_51430 : Int = _range_id_51422::Step;
-                    let _end_id_51435 : Int = _range_id_51422::End;
-                    while _step_id_51430 > 0 and _index_id_51425 <= _end_id_51435 or _step_id_51430 < 0 and _index_id_51425 >= _end_id_51435 {
-                        let i : Int = _index_id_51425;
+                    let _range_id_51438 : Range = 1..Length(xs) - 1;
+                    mutable _index_id_51441 : Int = _range_id_51438::Start;
+                    let _step_id_51446 : Int = _range_id_51438::Step;
+                    let _end_id_51451 : Int = _range_id_51438::End;
+                    while _step_id_51446 > 0 and _index_id_51441 <= _end_id_51451 or _step_id_51446 < 0 and _index_id_51441 >= _end_id_51451 {
+                        let i : Int = _index_id_51441;
                         Controlled CNOT(ctls, (xs[i], ys[i]));
-                        _index_id_51425 += _step_id_51430;
+                        _index_id_51441 += _step_id_51446;
                     }
 
                 }
 
                 {
-                    let _range_id_51465 : Range = Length(xs) - 2..-1..1;
-                    mutable _index_id_51468 : Int = _range_id_51465::Start;
-                    let _step_id_51473 : Int = _range_id_51465::Step;
-                    let _end_id_51478 : Int = _range_id_51465::End;
-                    while _step_id_51473 > 0 and _index_id_51468 <= _end_id_51478 or _step_id_51473 < 0 and _index_id_51468 >= _end_id_51478 {
-                        let i : Int = _index_id_51468;
+                    let _range_id_51481 : Range = Length(xs) - 2..-1..1;
+                    mutable _index_id_51484 : Int = _range_id_51481::Start;
+                    let _step_id_51489 : Int = _range_id_51481::Step;
+                    let _end_id_51494 : Int = _range_id_51481::End;
+                    while _step_id_51489 > 0 and _index_id_51484 <= _end_id_51494 or _step_id_51489 < 0 and _index_id_51484 >= _end_id_51494 {
+                        let i : Int = _index_id_51484;
                         Controlled CNOT(ctls, (xs[i], xs[i + 1]));
-                        _index_id_51468 += _step_id_51473;
+                        _index_id_51484 += _step_id_51489;
                     }
 
                 }
@@ -1819,14 +1819,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 2..-1..1;
                     {
-                        let _range_id_51508 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51511 : Int = _range_id_51508::Start;
-                        let _step_id_51516 : Int = _range_id_51508::Step;
-                        let _end_id_51521 : Int = _range_id_51508::End;
-                        while _step_id_51516 > 0 and _index_id_51511 <= _end_id_51521 or _step_id_51516 < 0 and _index_id_51511 >= _end_id_51521 {
-                            let i : Int = _index_id_51511;
+                        let _range_id_51524 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51527 : Int = _range_id_51524::Start;
+                        let _step_id_51532 : Int = _range_id_51524::Step;
+                        let _end_id_51537 : Int = _range_id_51524::End;
+                        while _step_id_51532 > 0 and _index_id_51527 <= _end_id_51537 or _step_id_51532 < 0 and _index_id_51527 >= _end_id_51537 {
+                            let i : Int = _index_id_51527;
                             Controlled Adjoint CNOT(ctls, (xs[i], xs[i + 1]));
-                            _index_id_51511 += _step_id_51516;
+                            _index_id_51527 += _step_id_51532;
                         }
 
                     }
@@ -1836,14 +1836,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 1..Length(xs) - 1;
                     {
-                        let _range_id_51551 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51554 : Int = _range_id_51551::Start;
-                        let _step_id_51559 : Int = _range_id_51551::Step;
-                        let _end_id_51564 : Int = _range_id_51551::End;
-                        while _step_id_51559 > 0 and _index_id_51554 <= _end_id_51564 or _step_id_51559 < 0 and _index_id_51554 >= _end_id_51564 {
-                            let i : Int = _index_id_51554;
+                        let _range_id_51567 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51570 : Int = _range_id_51567::Start;
+                        let _step_id_51575 : Int = _range_id_51567::Step;
+                        let _end_id_51580 : Int = _range_id_51567::End;
+                        while _step_id_51575 > 0 and _index_id_51570 <= _end_id_51580 or _step_id_51575 < 0 and _index_id_51570 >= _end_id_51580 {
+                            let i : Int = _index_id_51570;
                             Controlled Adjoint CNOT(ctls, (xs[i], ys[i]));
-                            _index_id_51554 += _step_id_51559;
+                            _index_id_51570 += _step_id_51575;
                         }
 
                     }
@@ -1862,28 +1862,28 @@ fn shor_sample_full_pipeline_reachable_items() {
             controlled (controls, ...) {
                 Fact(Length(xs) == Length(ys), $"Input registers must have the same number of qubits.");
                 {
-                    let _range_id_51594 : Range = 0..Length(xs) - 2;
-                    mutable _index_id_51597 : Int = _range_id_51594::Start;
-                    let _step_id_51602 : Int = _range_id_51594::Step;
-                    let _end_id_51607 : Int = _range_id_51594::End;
-                    while _step_id_51602 > 0 and _index_id_51597 <= _end_id_51607 or _step_id_51602 < 0 and _index_id_51597 >= _end_id_51607 {
-                        let idx : Int = _index_id_51597;
+                    let _range_id_51610 : Range = 0..Length(xs) - 2;
+                    mutable _index_id_51613 : Int = _range_id_51610::Start;
+                    let _step_id_51618 : Int = _range_id_51610::Step;
+                    let _end_id_51623 : Int = _range_id_51610::End;
+                    while _step_id_51618 > 0 and _index_id_51613 <= _end_id_51623 or _step_id_51618 < 0 and _index_id_51613 >= _end_id_51623 {
+                        let idx : Int = _index_id_51613;
                         CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                        _index_id_51597 += _step_id_51602;
+                        _index_id_51613 += _step_id_51618;
                     }
 
                 }
 
                 {
-                    let _range_id_51637 : Range = Length(xs) - 1..-1..1;
-                    mutable _index_id_51640 : Int = _range_id_51637::Start;
-                    let _step_id_51645 : Int = _range_id_51637::Step;
-                    let _end_id_51650 : Int = _range_id_51637::End;
-                    while _step_id_51645 > 0 and _index_id_51640 <= _end_id_51650 or _step_id_51645 < 0 and _index_id_51640 >= _end_id_51650 {
-                        let idx : Int = _index_id_51640;
+                    let _range_id_51653 : Range = Length(xs) - 1..-1..1;
+                    mutable _index_id_51656 : Int = _range_id_51653::Start;
+                    let _step_id_51661 : Int = _range_id_51653::Step;
+                    let _end_id_51666 : Int = _range_id_51653::End;
+                    while _step_id_51661 > 0 and _index_id_51656 <= _end_id_51666 or _step_id_51661 < 0 and _index_id_51656 >= _end_id_51666 {
+                        let idx : Int = _index_id_51656;
                         Controlled CNOT(controls, (xs[idx], ys[idx]));
                         CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
-                        _index_id_51640 += _step_id_51645;
+                        _index_id_51656 += _step_id_51661;
                     }
 
                 }
@@ -1894,15 +1894,15 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 1..-1..1;
                     {
-                        let _range_id_51680 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51683 : Int = _range_id_51680::Start;
-                        let _step_id_51688 : Int = _range_id_51680::Step;
-                        let _end_id_51693 : Int = _range_id_51680::End;
-                        while _step_id_51688 > 0 and _index_id_51683 <= _end_id_51693 or _step_id_51688 < 0 and _index_id_51683 >= _end_id_51693 {
-                            let idx : Int = _index_id_51683;
+                        let _range_id_51696 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51699 : Int = _range_id_51696::Start;
+                        let _step_id_51704 : Int = _range_id_51696::Step;
+                        let _end_id_51709 : Int = _range_id_51696::End;
+                        while _step_id_51704 > 0 and _index_id_51699 <= _end_id_51709 or _step_id_51704 < 0 and _index_id_51699 >= _end_id_51709 {
+                            let idx : Int = _index_id_51699;
                             Adjoint CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
                             Adjoint Controlled CNOT(controls, (xs[idx], ys[idx]));
-                            _index_id_51683 += _step_id_51688;
+                            _index_id_51699 += _step_id_51704;
                         }
 
                     }
@@ -1912,14 +1912,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(xs) - 2;
                     {
-                        let _range_id_51723 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51726 : Int = _range_id_51723::Start;
-                        let _step_id_51731 : Int = _range_id_51723::Step;
-                        let _end_id_51736 : Int = _range_id_51723::End;
-                        while _step_id_51731 > 0 and _index_id_51726 <= _end_id_51736 or _step_id_51731 < 0 and _index_id_51726 >= _end_id_51736 {
-                            let idx : Int = _index_id_51726;
+                        let _range_id_51739 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51742 : Int = _range_id_51739::Start;
+                        let _step_id_51747 : Int = _range_id_51739::Step;
+                        let _end_id_51752 : Int = _range_id_51739::End;
+                        while _step_id_51747 > 0 and _index_id_51742 <= _end_id_51752 or _step_id_51747 < 0 and _index_id_51742 >= _end_id_51752 {
+                            let idx : Int = _index_id_51742;
                             Adjoint CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                            _index_id_51726 += _step_id_51731;
+                            _index_id_51742 += _step_id_51747;
                         }
 
                     }
@@ -1940,29 +1940,29 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(Length(xs) > 0, $"Array should not be empty.");
                 let nQubits : Int = Length(xs);
                 {
-                    let _range_id_51766 : Range = 0..nQubits - 2;
-                    mutable _index_id_51769 : Int = _range_id_51766::Start;
-                    let _step_id_51774 : Int = _range_id_51766::Step;
-                    let _end_id_51779 : Int = _range_id_51766::End;
-                    while _step_id_51774 > 0 and _index_id_51769 <= _end_id_51779 or _step_id_51774 < 0 and _index_id_51769 >= _end_id_51779 {
-                        let idx : Int = _index_id_51769;
+                    let _range_id_51782 : Range = 0..nQubits - 2;
+                    mutable _index_id_51785 : Int = _range_id_51782::Start;
+                    let _step_id_51790 : Int = _range_id_51782::Step;
+                    let _end_id_51795 : Int = _range_id_51782::End;
+                    while _step_id_51790 > 0 and _index_id_51785 <= _end_id_51795 or _step_id_51790 < 0 and _index_id_51785 >= _end_id_51795 {
+                        let idx : Int = _index_id_51785;
                         CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                        _index_id_51769 += _step_id_51774;
+                        _index_id_51785 += _step_id_51790;
                     }
 
                 }
 
                 Controlled CCNOT(controls, (xs[nQubits - 1], ys[nQubits - 1], ys[nQubits]));
                 {
-                    let _range_id_51809 : Range = nQubits - 1..-1..1;
-                    mutable _index_id_51812 : Int = _range_id_51809::Start;
-                    let _step_id_51817 : Int = _range_id_51809::Step;
-                    let _end_id_51822 : Int = _range_id_51809::End;
-                    while _step_id_51817 > 0 and _index_id_51812 <= _end_id_51822 or _step_id_51817 < 0 and _index_id_51812 >= _end_id_51822 {
-                        let idx : Int = _index_id_51812;
+                    let _range_id_51825 : Range = nQubits - 1..-1..1;
+                    mutable _index_id_51828 : Int = _range_id_51825::Start;
+                    let _step_id_51833 : Int = _range_id_51825::Step;
+                    let _end_id_51838 : Int = _range_id_51825::End;
+                    while _step_id_51833 > 0 and _index_id_51828 <= _end_id_51838 or _step_id_51833 < 0 and _index_id_51828 >= _end_id_51838 {
+                        let idx : Int = _index_id_51828;
                         Controlled CNOT(controls, (xs[idx], ys[idx]));
                         CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
-                        _index_id_51812 += _step_id_51817;
+                        _index_id_51828 += _step_id_51833;
                     }
 
                 }
@@ -1975,15 +1975,15 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = nQubits - 1..-1..1;
                     {
-                        let _range_id_51852 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51855 : Int = _range_id_51852::Start;
-                        let _step_id_51860 : Int = _range_id_51852::Step;
-                        let _end_id_51865 : Int = _range_id_51852::End;
-                        while _step_id_51860 > 0 and _index_id_51855 <= _end_id_51865 or _step_id_51860 < 0 and _index_id_51855 >= _end_id_51865 {
-                            let idx : Int = _index_id_51855;
+                        let _range_id_51868 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51871 : Int = _range_id_51868::Start;
+                        let _step_id_51876 : Int = _range_id_51868::Step;
+                        let _end_id_51881 : Int = _range_id_51868::End;
+                        while _step_id_51876 > 0 and _index_id_51871 <= _end_id_51881 or _step_id_51876 < 0 and _index_id_51871 >= _end_id_51881 {
+                            let idx : Int = _index_id_51871;
                             Adjoint CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
                             Adjoint Controlled CNOT(controls, (xs[idx], ys[idx]));
-                            _index_id_51855 += _step_id_51860;
+                            _index_id_51871 += _step_id_51876;
                         }
 
                     }
@@ -1994,14 +1994,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..nQubits - 2;
                     {
-                        let _range_id_51895 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51898 : Int = _range_id_51895::Start;
-                        let _step_id_51903 : Int = _range_id_51895::Step;
-                        let _end_id_51908 : Int = _range_id_51895::End;
-                        while _step_id_51903 > 0 and _index_id_51898 <= _end_id_51908 or _step_id_51903 < 0 and _index_id_51898 >= _end_id_51908 {
-                            let idx : Int = _index_id_51898;
+                        let _range_id_51911 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51914 : Int = _range_id_51911::Start;
+                        let _step_id_51919 : Int = _range_id_51911::Step;
+                        let _end_id_51924 : Int = _range_id_51911::End;
+                        while _step_id_51919 > 0 and _index_id_51914 <= _end_id_51924 or _step_id_51919 < 0 and _index_id_51914 >= _end_id_51924 {
+                            let idx : Int = _index_id_51914;
                             Adjoint CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                            _index_id_51898 += _step_id_51903;
+                            _index_id_51914 += _step_id_51919;
                         }
 
                     }
@@ -2079,7 +2079,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54492 : Unit = {
+                    let _generated_ident_54508 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2094,7 +2094,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54492
+                    _generated_ident_54508
                 }
 
             }
@@ -2106,7 +2106,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54506 : Unit = {
+                    let _generated_ident_54522 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2121,7 +2121,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54506
+                    _generated_ident_54522
                 }
 
             }
@@ -2133,7 +2133,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54520 : Unit = {
+                    let _generated_ident_54536 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2148,7 +2148,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54520
+                    _generated_ident_54536
                 }
 
             }
@@ -2160,7 +2160,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54534 : Unit = {
+                    let _generated_ident_54550 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2175,7 +2175,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54534
+                    _generated_ident_54550
                 }
 
             }
@@ -2707,21 +2707,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54663 : Unit = {
+                        let _generated_ident_54679 : Unit = {
                             {
                                 {
-                                    let _range_id_52611 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52614 : Int = _range_id_52611::Start;
-                                    let _step_id_52619 : Int = _range_id_52611::Step;
-                                    let _end_id_52624 : Int = _range_id_52611::End;
-                                    while _step_id_52619 > 0 and _index_id_52614 <= _end_id_52624 or _step_id_52619 < 0 and _index_id_52614 >= _end_id_52624 {
-                                        let i : Int = _index_id_52614;
+                                    let _range_id_52627 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52630 : Int = _range_id_52627::Start;
+                                    let _step_id_52635 : Int = _range_id_52627::Step;
+                                    let _end_id_52640 : Int = _range_id_52627::End;
+                                    while _step_id_52635 > 0 and _index_id_52630 <= _end_id_52640 or _step_id_52635 < 0 and _index_id_52630 >= _end_id_52640 {
+                                        let i : Int = _index_id_52630;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52614 += _step_id_52619;
+                                        _index_id_52630 += _step_id_52635;
                                     }
 
                                 }
@@ -2760,18 +2760,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52654 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52657 : Int = _range_id_52654::Start;
-                                        let _step_id_52662 : Int = _range_id_52654::Step;
-                                        let _end_id_52667 : Int = _range_id_52654::End;
-                                        while _step_id_52662 > 0 and _index_id_52657 <= _end_id_52667 or _step_id_52662 < 0 and _index_id_52657 >= _end_id_52667 {
-                                            let i : Int = _index_id_52657;
+                                        let _range_id_52670 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52673 : Int = _range_id_52670::Start;
+                                        let _step_id_52678 : Int = _range_id_52670::Step;
+                                        let _end_id_52683 : Int = _range_id_52670::End;
+                                        while _step_id_52678 > 0 and _index_id_52673 <= _end_id_52683 or _step_id_52678 < 0 and _index_id_52673 >= _end_id_52683 {
+                                            let i : Int = _index_id_52673;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52657 += _step_id_52662;
+                                            _index_id_52673 += _step_id_52678;
                                         }
 
                                     }
@@ -2783,7 +2783,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54663
+                        _generated_ident_54679
                     }
 
                 }
@@ -2816,21 +2816,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54677 : Unit = {
+                        let _generated_ident_54693 : Unit = {
                             {
                                 {
-                                    let _range_id_52697 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52700 : Int = _range_id_52697::Start;
-                                    let _step_id_52705 : Int = _range_id_52697::Step;
-                                    let _end_id_52710 : Int = _range_id_52697::End;
-                                    while _step_id_52705 > 0 and _index_id_52700 <= _end_id_52710 or _step_id_52705 < 0 and _index_id_52700 >= _end_id_52710 {
-                                        let i : Int = _index_id_52700;
+                                    let _range_id_52713 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52716 : Int = _range_id_52713::Start;
+                                    let _step_id_52721 : Int = _range_id_52713::Step;
+                                    let _end_id_52726 : Int = _range_id_52713::End;
+                                    while _step_id_52721 > 0 and _index_id_52716 <= _end_id_52726 or _step_id_52721 < 0 and _index_id_52716 >= _end_id_52726 {
+                                        let i : Int = _index_id_52716;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52700 += _step_id_52705;
+                                        _index_id_52716 += _step_id_52721;
                                     }
 
                                 }
@@ -2869,18 +2869,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52740 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52743 : Int = _range_id_52740::Start;
-                                        let _step_id_52748 : Int = _range_id_52740::Step;
-                                        let _end_id_52753 : Int = _range_id_52740::End;
-                                        while _step_id_52748 > 0 and _index_id_52743 <= _end_id_52753 or _step_id_52748 < 0 and _index_id_52743 >= _end_id_52753 {
-                                            let i : Int = _index_id_52743;
+                                        let _range_id_52756 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52759 : Int = _range_id_52756::Start;
+                                        let _step_id_52764 : Int = _range_id_52756::Step;
+                                        let _end_id_52769 : Int = _range_id_52756::End;
+                                        while _step_id_52764 > 0 and _index_id_52759 <= _end_id_52769 or _step_id_52764 < 0 and _index_id_52759 >= _end_id_52769 {
+                                            let i : Int = _index_id_52759;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52743 += _step_id_52748;
+                                            _index_id_52759 += _step_id_52764;
                                         }
 
                                     }
@@ -2892,7 +2892,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54677
+                        _generated_ident_54693
                     }
 
                 }
@@ -2925,21 +2925,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54691 : Unit = {
+                        let _generated_ident_54707 : Unit = {
                             {
                                 {
-                                    let _range_id_52783 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52786 : Int = _range_id_52783::Start;
-                                    let _step_id_52791 : Int = _range_id_52783::Step;
-                                    let _end_id_52796 : Int = _range_id_52783::End;
-                                    while _step_id_52791 > 0 and _index_id_52786 <= _end_id_52796 or _step_id_52791 < 0 and _index_id_52786 >= _end_id_52796 {
-                                        let i : Int = _index_id_52786;
+                                    let _range_id_52799 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52802 : Int = _range_id_52799::Start;
+                                    let _step_id_52807 : Int = _range_id_52799::Step;
+                                    let _end_id_52812 : Int = _range_id_52799::End;
+                                    while _step_id_52807 > 0 and _index_id_52802 <= _end_id_52812 or _step_id_52807 < 0 and _index_id_52802 >= _end_id_52812 {
+                                        let i : Int = _index_id_52802;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52786 += _step_id_52791;
+                                        _index_id_52802 += _step_id_52807;
                                     }
 
                                 }
@@ -2978,18 +2978,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52826 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52829 : Int = _range_id_52826::Start;
-                                        let _step_id_52834 : Int = _range_id_52826::Step;
-                                        let _end_id_52839 : Int = _range_id_52826::End;
-                                        while _step_id_52834 > 0 and _index_id_52829 <= _end_id_52839 or _step_id_52834 < 0 and _index_id_52829 >= _end_id_52839 {
-                                            let i : Int = _index_id_52829;
+                                        let _range_id_52842 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52845 : Int = _range_id_52842::Start;
+                                        let _step_id_52850 : Int = _range_id_52842::Step;
+                                        let _end_id_52855 : Int = _range_id_52842::End;
+                                        while _step_id_52850 > 0 and _index_id_52845 <= _end_id_52855 or _step_id_52850 < 0 and _index_id_52845 >= _end_id_52855 {
+                                            let i : Int = _index_id_52845;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52829 += _step_id_52834;
+                                            _index_id_52845 += _step_id_52850;
                                         }
 
                                     }
@@ -3001,7 +3001,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54691
+                        _generated_ident_54707
                     }
 
                 }
@@ -3034,21 +3034,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54705 : Unit = {
+                        let _generated_ident_54721 : Unit = {
                             {
                                 {
-                                    let _range_id_52869 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52872 : Int = _range_id_52869::Start;
-                                    let _step_id_52877 : Int = _range_id_52869::Step;
-                                    let _end_id_52882 : Int = _range_id_52869::End;
-                                    while _step_id_52877 > 0 and _index_id_52872 <= _end_id_52882 or _step_id_52877 < 0 and _index_id_52872 >= _end_id_52882 {
-                                        let i : Int = _index_id_52872;
+                                    let _range_id_52885 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52888 : Int = _range_id_52885::Start;
+                                    let _step_id_52893 : Int = _range_id_52885::Step;
+                                    let _end_id_52898 : Int = _range_id_52885::End;
+                                    while _step_id_52893 > 0 and _index_id_52888 <= _end_id_52898 or _step_id_52893 < 0 and _index_id_52888 >= _end_id_52898 {
+                                        let i : Int = _index_id_52888;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52872 += _step_id_52877;
+                                        _index_id_52888 += _step_id_52893;
                                     }
 
                                 }
@@ -3087,18 +3087,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52912 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52915 : Int = _range_id_52912::Start;
-                                        let _step_id_52920 : Int = _range_id_52912::Step;
-                                        let _end_id_52925 : Int = _range_id_52912::End;
-                                        while _step_id_52920 > 0 and _index_id_52915 <= _end_id_52925 or _step_id_52920 < 0 and _index_id_52915 >= _end_id_52925 {
-                                            let i : Int = _index_id_52915;
+                                        let _range_id_52928 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52931 : Int = _range_id_52928::Start;
+                                        let _step_id_52936 : Int = _range_id_52928::Step;
+                                        let _end_id_52941 : Int = _range_id_52928::End;
+                                        while _step_id_52936 > 0 and _index_id_52931 <= _end_id_52941 or _step_id_52936 < 0 and _index_id_52931 >= _end_id_52941 {
+                                            let i : Int = _index_id_52931;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52915 += _step_id_52920;
+                                            _index_id_52931 += _step_id_52936;
                                         }
 
                                     }
@@ -3110,7 +3110,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54705
+                        _generated_ident_54721
                     }
 
                 }

--- a/source/compiler/qsc_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_openqasm_parser/src/semantic/lowerer.rs
@@ -252,6 +252,7 @@ impl Lowerer {
                         continue;
                     } else if include.filename.to_lowercase() == "qdk.inc" {
                         self.define_mresetzchecked();
+                        self.define_postselectz();
                         continue;
                     }
 
@@ -431,6 +432,23 @@ impl Lowerer {
             name,
             Span::default(),
             Type::Function(vec![Type::Qubit].into(), Type::Int(None, false).into()),
+            Span::default(),
+            Default::default(),
+        );
+        if self.symbols.insert_symbol(symbol).is_err() {
+            self.push_redefined_symbol_error(name, Span::default());
+        }
+    }
+
+    fn define_postselectz(&mut self) {
+        let name = "postselectz";
+        let symbol = Symbol::new(
+            name,
+            Span::default(),
+            Type::Function(
+                vec![Type::Bit(false), Type::Qubit].into(),
+                Type::Void.into(),
+            ),
             Span::default(),
             Default::default(),
         );

--- a/source/paulimer/src/outcome_specific_simulation.rs
+++ b/source/paulimer/src/outcome_specific_simulation.rs
@@ -133,6 +133,9 @@ pub fn measure_pauli_with_hint<HintBits: PauliBits, HintPhase: PhaseExponent>(
         pauli *= Phase::from_exponent(3u8.wrapping_sub(preimage.xz_phase_exponent().raw_value()));
         PauliExponent::new(pauli) * &mut simulation.clifford;
         if let Some(forced) = forced_bit {
+            // Since we have a forced bit, use that as ther result instead of a random one.
+            // To keep the internal state consistent, we also mark this as a random outcome,
+            // incrementing the count as well.
             simulation.outcome_vector.push(forced);
             simulation.random_outcome_indicator.push(true);
             simulation.num_random_bits += 1;

--- a/source/paulimer/src/outcome_specific_simulation.rs
+++ b/source/paulimer/src/outcome_specific_simulation.rs
@@ -61,6 +61,10 @@ impl OutcomeSpecificSimulation {
     pub fn outcome_vector(&self) -> &Vec<bool> {
         &self.outcome_vector
     }
+
+    pub fn post_select_z(&mut self, value: bool, index: usize) -> Result<(), String> {
+        measure_pauli_forced(self, &SparsePauli::from([quantum_core::z(index)]), value)
+    }
 }
 
 pub fn apply_hadamard(simulation: &mut OutcomeSpecificSimulation, qubit_index: usize) {
@@ -113,6 +117,7 @@ pub fn measure_pauli_with_hint<HintBits: PauliBits, HintPhase: PhaseExponent>(
     simulation: &mut OutcomeSpecificSimulation,
     observable: &SparsePauli,
     hint: &PauliUnitary<HintBits, HintPhase>,
+    forced_bit: Option<bool>,
 ) {
     assert!(
         anti_commutes_with(observable, hint),
@@ -127,7 +132,13 @@ pub fn measure_pauli_with_hint<HintBits: PauliBits, HintPhase: PhaseExponent>(
         let mut pauli = observable.clone() * hint;
         pauli *= Phase::from_exponent(3u8.wrapping_sub(preimage.xz_phase_exponent().raw_value()));
         PauliExponent::new(pauli) * &mut simulation.clifford;
-        allocate_random_bit(simulation);
+        if let Some(forced) = forced_bit {
+            simulation.outcome_vector.push(forced);
+            simulation.random_outcome_indicator.push(true);
+            simulation.num_random_bits += 1;
+        } else {
+            allocate_random_bit(simulation);
+        }
         apply_conditional_pauli(
             simulation,
             hint,
@@ -153,12 +164,34 @@ pub fn measure_pauli(simulation: &mut OutcomeSpecificSimulation, observable: &Sp
     match non_zero_pos {
         Some(pos) => {
             let hint = simulation.clifford.image_z(pos);
-            measure_pauli_with_hint(simulation, observable, &hint);
+            measure_pauli_with_hint(simulation, observable, &hint, None);
         }
         None => {
             measure_deterministic(simulation, &preimage);
         }
     }
+}
+
+pub fn measure_pauli_forced(
+    simulation: &mut OutcomeSpecificSimulation,
+    observable: &SparsePauli,
+    forced_bit: bool,
+) -> Result<(), String> {
+    let preimage = simulation.clifford.preimage(observable);
+    let non_zero_pos = preimage.x_bits().support().next();
+    match non_zero_pos {
+        Some(pos) => {
+            let hint = simulation.clifford.image_z(pos);
+            measure_pauli_with_hint(simulation, observable, &hint, Some(forced_bit));
+        }
+        None => {
+            measure_deterministic(simulation, &preimage);
+            if simulation.outcome_vector().last() != Some(&forced_bit) {
+                return Err("post-selection condition has zero probability".into());
+            }
+        }
+    }
+    Ok(())
 }
 
 fn measure_deterministic<Bits: PauliBits, Phase: PhaseExponent>(
@@ -252,7 +285,7 @@ impl Simulation for OutcomeSpecificSimulation {
     ) -> usize {
         let pauli = SparsePauli::from(observable);
         let hint = SparsePauli::from(hint);
-        measure_pauli_with_hint(self, &pauli, &hint);
+        measure_pauli_with_hint(self, &pauli, &hint, None);
         self.outcome_vector().len() - 1
     }
 

--- a/source/qdk_package/tests/test_qasm.py
+++ b/source/qdk_package/tests/test_qasm.py
@@ -133,6 +133,56 @@ def test_mresetzchecked_not_present_without_qdk_inc() -> None:
     assert "undefined symbol: mresetz_checked" in str(excinfo.value)
 
 
+def test_postselectz_one() -> None:
+    result = run(
+        """
+        include "stdgates.inc";
+        include "qdk.inc";
+        qubit q1;
+        bit r;
+        h q1;
+        postselectz(1, q1);
+        r = measure q1;
+        """,
+        shots=100,
+        seed=0,
+    )
+    assert all(r == Result.One for r in result)
+
+
+def test_postselectz_zero() -> None:
+    result = run(
+        """
+        include "stdgates.inc";
+        include "qdk.inc";
+        qubit q1;
+        bit r;
+        h q1;
+        postselectz(0, q1);
+        r = measure q1;
+        """,
+        shots=100,
+        seed=0,
+    )
+    assert all(r == Result.Zero for r in result)
+
+
+def test_postselectz_not_present_without_qdk_inc() -> None:
+    with pytest.raises(QasmError) as excinfo:
+        run(
+            """
+            include "stdgates.inc";
+            qubit q1;
+            bit r;
+            postselectz(0, q1);
+            r = measure q1;
+            """,
+            shots=100,
+            seed=0,
+        )
+    assert "undefined symbol: postselectz" in str(excinfo.value)
+
+
 def test_run_with_result(capsys) -> None:
     results = run("output bit c;", 3)
     assert results == [Result.Zero, Result.Zero, Result.Zero]
@@ -310,21 +360,16 @@ def test_compile_qir_str() -> None:
 def test_compile_qir_str_with_single_arg_raises_error() -> None:
     init(target_profile=TargetProfile.Base)
     with pytest.raises(QSharpError) as excinfo:
-        compile(
-            """
+        compile("""
             include "stdgates.inc";
             input float f;
             qubit q;
             rx(f) q;
             output bit c;
             c = measure q;
-            """
-        )
-    assert (
-        str(excinfo.value)
-        == """Circuit has unbound input parameters
+            """)
+    assert str(excinfo.value) == """Circuit has unbound input parameters
   help: Parameters: f: Double"""
-    )
 
 
 # Import + Compile
@@ -630,12 +675,10 @@ def test_circuit_from_program() -> None:
         x q1;
         """,
     )
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── X ──
         q_1    ───────
-        """
-    )
+        """)
 
 
 def test_circuit_from_program_static() -> None:
@@ -653,12 +696,10 @@ def test_circuit_from_program_static() -> None:
         """,
         generation_method=CircuitGenerationMethod.Static,
     )
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── H ──── M ──── if: c_0 = |1〉 ──
                          ╘═══════════ ● ════════
-        """
-    )
+        """)
 
 
 def test_circuit_from_callable() -> None:
@@ -674,12 +715,10 @@ def test_circuit_from_callable() -> None:
         name="Foo",
     )
     c = qsharp_circuit("{ use (q1, q2) = (Qubit(), Qubit()); Foo(q1, q2); }")
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── X ──
         q_1    ───────
-        """
-    )
+        """)
 
 
 def test_circuit_from_callable_with_multiple_qubit_registers() -> None:
@@ -696,14 +735,12 @@ def test_circuit_from_callable_with_multiple_qubit_registers() -> None:
         name="Foo",
     )
     c = qsharp_circuit("{ use (qs1, qs2) = (Qubit[2], Qubit[2]); Foo(qs1, qs2); }")
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── X ──
         q_1    ───────
         q_2    ───────
         q_3    ── X ──
-        """
-    )
+        """)
 
 
 def test_circuit_from_callable_with_single_qubit_and_qubit_registers() -> None:
@@ -724,15 +761,13 @@ def test_circuit_from_callable_with_single_qubit_and_qubit_registers() -> None:
     c = qsharp_circuit(
         "{ use (qs1, a, qs2) = (Qubit[2], Qubit(), Qubit[2]); Foo(qs1, a, qs2); }"
     )
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── X ──
         q_1    ───────
         q_2    ── X ──
         q_3    ───────
         q_4    ── X ──
-        """
-    )
+        """)
 
 
 def test_circuit_from_callable_with_args() -> None:
@@ -749,12 +784,10 @@ def test_circuit_from_callable_with_args() -> None:
         name="Foo",
     )
     c = qsharp_circuit("{ use qs = Qubit[2]; Foo(2, qs); }")
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── X ──
         q_1    ── X ──
-        """
-    )
+        """)
 
 
 def test_circuit_with_measure_from_callable() -> None:
@@ -764,12 +797,10 @@ def test_circuit_with_measure_from_callable() -> None:
         name="Foo",
     )
     c = qsharp_circuit("{ use q = Qubit(); Foo(q); }")
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── H ──── M ──
                          ╘═══
-        """
-    )
+        """)
 
 
 def test_circuit_from_callable_static() -> None:
@@ -791,20 +822,17 @@ def test_circuit_from_callable_static() -> None:
         code.qasm_import.Foo,
         generation_method=CircuitGenerationMethod.Static,
     )
-    assert str(c) == dedent(
-        """\
+    assert str(c) == dedent("""\
         q_0    ── H ──── M ──── if: c_0 = |1〉 ──
                          ╘═══════════ ● ════════
-        """
-    )
+        """)
 
 
 # Estimate
 
 
 def test_qasm_estimation() -> None:
-    res = estimate(
-        """
+    res = estimate("""
         include "stdgates.inc";
         const int SIZE = 10;
         qubit[SIZE] q;
@@ -812,8 +840,7 @@ def test_qasm_estimation() -> None:
             t q[i];
             measure q[i];
         }
-        """
-    )
+        """)
     assert res["status"] == "success"
     assert res["physicalCounts"] is not None
     assert res.logical_counts == LogicalCounts(

--- a/source/simulators/src/stabilizer_simulator.rs
+++ b/source/simulators/src/stabilizer_simulator.rs
@@ -137,6 +137,11 @@ impl StabilizerSimulator {
         }
     }
 
+    /// Forces the state of a qubit to collapse to a specific value.
+    pub fn post_select_z(&mut self, result: bool, target: QubitID) -> Result<(), String> {
+        self.state.post_select_z(result, target)
+    }
+
     fn apply_gate_in_place(&mut self, gate: &Operation) {
         match *gate {
             Operation::I { .. } => (),


### PR DESCRIPTION
This change adds support for simulation time post-selection in the Z basis when using the Clifford simulator. It also adds `postselectz` to `qdk.inc` so OpenQASM code can call it as well.