### PR TITLE
Iterating a QRE trace gate by gate

### DIFF
--- a/source/qdk_package/qdk/qre/_qre.pyi
+++ b/source/qdk_package/qdk/qre/_qre.pyi
@@ -1487,6 +1487,76 @@ class Trace:
         """
         ...
 
+    def flatten(self) -> Iterator[Gate]:
+        """
+        Iterate over gates as if executing the circuit.
+
+        Yield each gate in execution order. Gates inside repeated blocks
+        are yielded once per repetition.
+
+        Returns:
+            Iterator[Gate]: An iterator over the gates in the trace.
+        """
+        ...
+
+class Gate:
+    """
+    Represent a single gate operation in a trace.
+
+    Attributes:
+        id (int): The instruction ID of the gate.
+        qubits (list[int]): The qubits the gate acts on.
+        params (list[float]): The parameters of the gate.
+    """
+
+    @property
+    def id(self) -> int:
+        """
+        The instruction ID of the gate.
+
+        Returns:
+            int: The instruction ID.
+        """
+        ...
+
+    @property
+    def qubits(self) -> list[int]:
+        """
+        The qubits the gate acts on.
+
+        Returns:
+            list[int]: The qubit indices.
+        """
+        ...
+
+    @property
+    def params(self) -> list[float]:
+        """
+        The parameters of the gate.
+
+        Returns:
+            list[float]: The gate parameters.
+        """
+        ...
+
+    def __str__(self) -> str:
+        """
+        Return a string representation of the gate.
+
+        Returns:
+            str: A string representation of the gate.
+        """
+        ...
+
+    def __repr__(self) -> str:
+        """
+        Return a detailed string representation of the gate.
+
+        Returns:
+            str: A detailed string representation of the gate.
+        """
+        ...
+
 class Block:
     """
     Represents a block of operations in a trace.

--- a/source/qdk_package/src/qre.rs
+++ b/source/qdk_package/src/qre.rs
@@ -1282,8 +1282,7 @@ impl Trace {
         // `Trace` (and its blocks/operations) will not be dropped while this
         // `TraceWalkIterator` exists.  The struct is marked `unsendable` so it
         // stays on the thread that created it.
-        let walk_iter: qre::WalkIterator<'static> =
-            unsafe { std::mem::transmute(walk_iter) };
+        let walk_iter: qre::WalkIterator<'static> = unsafe { std::mem::transmute(walk_iter) };
         Py::new(
             slf.py(),
             TraceWalkIterator {

--- a/source/qdk_package/src/qre.rs
+++ b/source/qdk_package/src/qre.rs
@@ -25,6 +25,7 @@ pub(crate) fn register_qre_submodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ConstraintBound>()?;
     m.add_class::<ProvenanceGraph>()?;
     m.add_class::<Trace>()?;
+    m.add_class::<Gate>()?;
     m.add_class::<Block>()?;
     m.add_class::<PSSPC>()?;
     m.add_class::<LatticeSurgery>()?;
@@ -1272,9 +1273,75 @@ impl Trace {
         format!("{}", self.0)
     }
 
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn flatten(slf: PyRef<'_, Self>) -> PyResult<Py<TraceWalkIterator>> {
+        let walk_iter = slf.0.walk_iter();
+        // SAFETY: The `WalkIterator` borrows from the `Trace` stored inside
+        // the `Py<Trace>` we keep alive in `parent`.  Because `Py<Trace>` is
+        // reference-counted and stored alongside the iterator, the underlying
+        // `Trace` (and its blocks/operations) will not be dropped while this
+        // `TraceWalkIterator` exists.  The struct is marked `unsendable` so it
+        // stays on the thread that created it.
+        let walk_iter: qre::WalkIterator<'static> =
+            unsafe { std::mem::transmute(walk_iter) };
+        Py::new(
+            slf.py(),
+            TraceWalkIterator {
+                iter: walk_iter,
+                parent: slf.into(),
+            },
+        )
+    }
+
     #[getter]
     pub fn required_isa(&self) -> ISARequirements {
         ISARequirements(self.0.required_instruction_ids(None))
+    }
+}
+
+#[pyclass]
+pub struct Gate {
+    #[pyo3(get)]
+    id: u64,
+    #[pyo3(get)]
+    qubits: Vec<u64>,
+    #[pyo3(get)]
+    params: Vec<f64>,
+}
+
+#[pymethods]
+impl Gate {
+    fn __str__(&self) -> String {
+        format!(
+            "Gate(id={}, qubits={:?}, params={:?})",
+            self.id, self.qubits, self.params
+        )
+    }
+
+    fn __repr__(&self) -> String {
+        self.__str__()
+    }
+}
+
+#[pyclass(unsendable)]
+pub struct TraceWalkIterator {
+    iter: qre::WalkIterator<'static>,
+    #[allow(dead_code)]
+    parent: Py<Trace>,
+}
+
+#[pymethods]
+impl TraceWalkIterator {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<Gate> {
+        slf.iter.next().map(|g| Gate {
+            id: g.id(),
+            qubits: g.qubits().to_vec(),
+            params: g.params().to_vec(),
+        })
     }
 }
 

--- a/source/qdk_package/tests/qre/test_application.py
+++ b/source/qdk_package/tests/qre/test_application.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# flake8: noqa E402
+
 import pytest
 
 cirq = pytest.importorskip("cirq")
@@ -225,3 +227,51 @@ def test_rotation_error_psspc():
         assert (
             transformed.base_error < 1.0
         ), f"Base error too high: {transformed.base_error} for {psspc.num_ts_per_rotation} T states per rotation"
+
+
+def test_trace_iter_simple():
+    """Test that iterating over a trace yields gates in execution order."""
+    trace = Trace(2)
+    trace.add_operation(1, [0])
+    trace.add_operation(2, [1])
+
+    gate_ids = [g.id for g in trace.flatten()]
+    assert gate_ids == [1, 2]
+
+
+def test_trace_iter_with_repeated_block():
+    """Test that iterating over a trace repeats gates for repeated blocks."""
+    trace = Trace(2)
+    trace.add_operation(1, [0])
+    block = trace.add_block(3)
+    block.add_operation(2, [1])
+    trace.add_operation(3, [0])
+
+    gate_ids = [g.id for g in trace.flatten()]
+    assert gate_ids == [1, 2, 2, 2, 3]
+
+
+def test_trace_iter_nested_blocks():
+    """Test that iterating over nested repeated blocks works correctly."""
+    trace = Trace(3)
+    trace.add_operation(1, [0])
+    block = trace.add_block(2)
+    block.add_operation(2, [1])
+    inner = block.add_block(3)
+    inner.add_operation(3, [2])
+    trace.add_operation(4, [0])
+
+    gate_ids = [g.id for g in trace.flatten()]
+    assert gate_ids == [1, 2, 3, 3, 3, 2, 3, 3, 3, 4]
+
+
+def test_trace_iter_gate_attributes():
+    """Test that gate attributes are correctly exposed."""
+    trace = Trace(1)
+    trace.add_operation(42, [0, 1], [3.14])
+
+    gates = list(trace.flatten())
+    assert len(gates) == 1
+    assert gates[0].id == 42
+    assert gates[0].qubits == [0, 1]
+    assert gates[0].params == [3.14]

--- a/source/qre/src/lib.rs
+++ b/source/qre/src/lib.rs
@@ -22,7 +22,8 @@ pub use trace::instruction_ids;
 pub use trace::instruction_ids::instruction_name;
 pub use trace::{
     Block, ComputeCapacity, DynamicMemoryCompute, EvictionStrategy, LatticeSurgery, PSSPC,
-    Property, Trace, TraceTransform, Unmemory, estimate_parallel, estimate_with_graph,
+    Property, Trace, TraceTransform, Unmemory, WalkIterator, estimate_parallel,
+    estimate_with_graph,
 };
 mod utils;
 pub use utils::{binom_ppf, float_from_bits, float_to_bits};

--- a/source/qre/src/trace.rs
+++ b/source/qre/src/trace.rs
@@ -162,6 +162,11 @@ impl Trace {
         TraceIterator::new(&self.block)
     }
 
+    #[must_use]
+    pub fn walk_iter(&self) -> WalkIterator<'_> {
+        WalkIterator::new(&self.block)
+    }
+
     /// Returns the set of instruction IDs required by this trace, along with
     /// their arity constraints if available.  We take the actual arity from the
     /// instruction, and if we see instructions with the same ID but different
@@ -453,6 +458,23 @@ pub struct Gate {
     params: Vec<f64>,
 }
 
+impl Gate {
+    #[must_use]
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    #[must_use]
+    pub fn qubits(&self) -> &[u64] {
+        &self.qubits
+    }
+
+    #[must_use]
+    pub fn params(&self) -> &[f64] {
+        &self.params
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Block {
     operations: Vec<Operation>,
@@ -635,6 +657,46 @@ impl<'a> Iterator for TraceIterator<'a> {
                     }
                 },
                 _ => {
+                    self.stack.pop();
+                }
+            }
+        }
+    }
+}
+
+pub struct WalkIterator<'a> {
+    // Each frame: (operations slice, current index, remaining repetitions)
+    stack: Vec<(&'a [Operation], usize, u64)>,
+}
+
+impl<'a> WalkIterator<'a> {
+    fn new(block: &'a Block) -> Self {
+        Self {
+            stack: vec![(&block.operations, 0, block.repetitions)],
+        }
+    }
+}
+
+impl<'a> Iterator for WalkIterator<'a> {
+    type Item = &'a Gate;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (ops, idx, remaining) = self.stack.last_mut()?;
+            if *idx < ops.len() {
+                let op = &ops[*idx];
+                *idx += 1;
+                match op {
+                    Operation::GateOperation(g) => return Some(g),
+                    Operation::BlockOperation(block) => {
+                        self.stack.push((&block.operations, 0, block.repetitions));
+                    }
+                }
+            } else {
+                *remaining -= 1;
+                if *remaining > 0 {
+                    *idx = 0;
+                } else {
                     self.stack.pop();
                 }
             }

--- a/source/qre/src/trace/tests.rs
+++ b/source/qre/src/trace/tests.rs
@@ -29,6 +29,59 @@ fn test_nested_blocks() {
 }
 
 #[test]
+fn test_walk_iter_simple() {
+    let mut trace = Trace::new(2);
+    trace.add_operation(1, vec![0], vec![]);
+    trace.add_operation(2, vec![1], vec![]);
+
+    let ids: Vec<u64> = trace.walk_iter().map(|g| g.id).collect();
+    assert_eq!(ids, vec![1, 2]);
+}
+
+#[test]
+fn test_walk_iter_with_block() {
+    let mut trace = Trace::new(2);
+    trace.add_operation(1, vec![0], vec![]);
+    let block = trace.add_block(3);
+    block.add_operation(2, vec![1], vec![]);
+    trace.add_operation(3, vec![0], vec![]);
+
+    let ids: Vec<u64> = trace.walk_iter().map(|g| g.id).collect();
+    assert_eq!(ids, vec![1, 2, 2, 2, 3]);
+}
+
+#[test]
+fn test_walk_iter_nested_blocks() {
+    let mut trace = Trace::new(3);
+    trace.add_operation(1, vec![0], vec![]);
+    let block = trace.add_block(2);
+    block.add_operation(2, vec![1], vec![]);
+    let inner = block.add_block(3);
+    inner.add_operation(3, vec![2], vec![]);
+    trace.add_operation(4, vec![0], vec![]);
+
+    // Expected: gate 1, then 2x(gate 2, 3x(gate 3)), then gate 4
+    // = 1, [2, 3, 3, 3, 2, 3, 3, 3], 4
+    let ids: Vec<u64> = trace.walk_iter().map(|g| g.id).collect();
+    assert_eq!(ids, vec![1, 2, 3, 3, 3, 2, 3, 3, 3, 4]);
+}
+
+#[test]
+fn test_walk_iter_count_matches_deep_iter() {
+    let mut trace = Trace::new(3);
+    trace.add_operation(1, vec![0], vec![]);
+    let block = trace.add_block(2);
+    block.add_operation(2, vec![1], vec![]);
+    let inner = block.add_block(3);
+    inner.add_operation(3, vec![2], vec![]);
+    trace.add_operation(4, vec![0], vec![]);
+
+    let walk_count = trace.walk_iter().count();
+    let deep_count: u64 = trace.deep_iter().map(|(_, m)| m).sum();
+    assert_eq!(walk_count as u64, deep_count);
+}
+
+#[test]
 fn test_depth_simple() {
     let mut trace = Trace::new(2);
     trace.add_operation(1, vec![0], vec![]);


### PR DESCRIPTION
This adds a method `Trace.flatten` that returns an iterator to iterate through the gates of a trace in the order as if the trace is executed, i.e., it enters and unrolls all blocks. The underlying functionality is implemented in the Rust type as `Rust::walk_iter`.