### PR TITLE
Remove hard dependency on cirq in qdk.qre

### DIFF
--- a/source/qdk_package/pyproject.toml
+++ b/source/qdk_package/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 jupyter = ["qsharp-widgets==0.0.0", "qsharp-jupyterlab==0.0.0"]
 azure = ["azure-quantum>=3.8.0"]
 qiskit = ["qiskit>=1.2.2,<3.0.0"]
-cirq = ["cirq-core>=1.6.1,<1.7", "cirq-ionq>=1.6.1,<1.7"]
-qre = ["cirq-core==1.6.1,<1.7", "pandas>=2.1", "ply>=3.11"]
+cirq = ["cirq-core>=1.6.1,<1.7", "cirq-ionq>=1.6.1,<1.7", "ply>=3.11"]
+qre = ["pandas>=2.1"]
 applications = ["cirq-core==1.6.1,<1.7"]
 all = [
   "qsharp-widgets==0.0.0",

--- a/source/qdk_package/qdk/qre/application/__init__.py
+++ b/source/qdk_package/qdk/qre/application/__init__.py
@@ -1,15 +1,30 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from ._cirq import CirqApplication, CirqApplicationParams
 from ._qir import QIRApplication
 from ._qsharp import QSharpApplication
 from ._openqasm import OpenQASMApplication
 
+try:
+    from ._cirq import CirqApplication, CirqApplicationParams
+except ImportError:
+
+    class _CirqNotInstalled:
+        """Placeholder that raises a helpful error when cirq is not installed."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "CirqApplication requires the 'cirq' extra. "
+                "Install it with: pip install qdk[qre,cirq]"
+            )
+
+    CirqApplication = _CirqNotInstalled
+    CirqApplicationParams = _CirqNotInstalled
+
 __all__ = [
     "CirqApplication",
     "CirqApplicationParams",
+    "OpenQASMApplication",
     "QIRApplication",
     "QSharpApplication",
-    "OpenQASMApplication",
 ]

--- a/source/qdk_package/qdk/qre/application/_cirq.py
+++ b/source/qdk_package/qdk/qre/application/_cirq.py
@@ -26,6 +26,7 @@ class CirqApplicationParams:
             they are decompsed into SWAP and RESET instructions.  Defaults to
             True.
     """
+
     track_memory_qubits: bool = field(default=True, metadata={"domain": [True]})
 
 
@@ -67,7 +68,9 @@ class CirqApplication(Application[CirqApplicationParams]):
         else:
             self._circuit = self.circuit_or_qasm
 
-    def get_trace(self, parameters: CirqApplicationParams = CirqApplicationParams()) -> Trace:
+    def get_trace(
+        self, parameters: CirqApplicationParams = CirqApplicationParams()
+    ) -> Trace:
         """Return the resource estimation trace for the Cirq circuit.
 
         Args:

--- a/source/qdk_package/qdk/qre/interop/__init__.py
+++ b/source/qdk_package/qdk/qre/interop/__init__.py
@@ -4,12 +4,6 @@
 from ._qir import trace_from_qir
 from ._qsharp import trace_from_entry_expr, trace_from_entry_expr_cached
 
-__all__ = [
-    "trace_from_entry_expr",
-    "trace_from_entry_expr_cached",
-    "trace_from_qir",
-]
-
 try:
     from ._cirq import (
         PeakUsageGreedyQubitManager,
@@ -24,19 +18,47 @@ try:
         trace_from_cirq,
         write_to_memory,
     )
-
-    __all__ += [
-        "trace_from_cirq",
-        "PushBlock",
-        "PopBlock",
-        "QubitType",
-        "TypedQubit",
-        "PeakUsageGreedyQubitManager",
-        "ReadFromMemoryGate",
-        "WriteToMemoryGate",
-        "write_to_memory",
-        "read_from_memory",
-        "assert_qubits_type",
-    ]
 except ImportError:
-    pass
+    _CIRQ_INSTALL_MSG = (
+        "This function requires the 'cirq' extra. "
+        "Install it with: pip install qdk[qre,cirq]"
+    )
+
+    class _CirqNotInstalled:
+        """Placeholder that raises a helpful error when cirq is not installed."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(_CIRQ_INSTALL_MSG)
+
+    def _cirq_not_installed_func(*args, **kwargs):
+        """Placeholder that raises a helpful error when cirq is not installed."""
+        raise ImportError(_CIRQ_INSTALL_MSG)
+
+    PeakUsageGreedyQubitManager = _CirqNotInstalled
+    PopBlock = _CirqNotInstalled
+    PushBlock = _CirqNotInstalled
+    QubitType = _CirqNotInstalled
+    ReadFromMemoryGate = _CirqNotInstalled
+    TypedQubit = _CirqNotInstalled
+    WriteToMemoryGate = _CirqNotInstalled
+    assert_qubits_type = _cirq_not_installed_func
+    read_from_memory = _cirq_not_installed_func
+    trace_from_cirq = _cirq_not_installed_func
+    write_to_memory = _cirq_not_installed_func
+
+__all__ = [
+    "PeakUsageGreedyQubitManager",
+    "PopBlock",
+    "PushBlock",
+    "QubitType",
+    "ReadFromMemoryGate",
+    "TypedQubit",
+    "WriteToMemoryGate",
+    "assert_qubits_type",
+    "read_from_memory",
+    "trace_from_cirq",
+    "trace_from_entry_expr",
+    "trace_from_entry_expr_cached",
+    "trace_from_qir",
+    "write_to_memory",
+]

--- a/source/qdk_package/qdk/qre/interop/__init__.py
+++ b/source/qdk_package/qdk/qre/interop/__init__.py
@@ -1,35 +1,42 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from ._cirq import (
-    PeakUsageGreedyQubitManager,
-    PopBlock,
-    PushBlock,
-    QubitType,
-    ReadFromMemoryGate,
-    TypedQubit,
-    WriteToMemoryGate,
-    assert_qubits_type,
-    read_from_memory,
-    trace_from_cirq,
-    write_to_memory,
-)
 from ._qir import trace_from_qir
 from ._qsharp import trace_from_entry_expr, trace_from_entry_expr_cached
 
 __all__ = [
-    "trace_from_cirq",
     "trace_from_entry_expr",
     "trace_from_entry_expr_cached",
     "trace_from_qir",
-    "PushBlock",
-    "PopBlock",
-    "QubitType",
-    "TypedQubit",
-    "PeakUsageGreedyQubitManager",
-    "ReadFromMemoryGate",
-    "WriteToMemoryGate",
-    "write_to_memory",
-    "read_from_memory",
-    "assert_qubits_type",
 ]
+
+try:
+    from ._cirq import (
+        PeakUsageGreedyQubitManager,
+        PopBlock,
+        PushBlock,
+        QubitType,
+        ReadFromMemoryGate,
+        TypedQubit,
+        WriteToMemoryGate,
+        assert_qubits_type,
+        read_from_memory,
+        trace_from_cirq,
+        write_to_memory,
+    )
+
+    __all__ += [
+        "trace_from_cirq",
+        "PushBlock",
+        "PopBlock",
+        "QubitType",
+        "TypedQubit",
+        "PeakUsageGreedyQubitManager",
+        "ReadFromMemoryGate",
+        "WriteToMemoryGate",
+        "write_to_memory",
+        "read_from_memory",
+        "assert_qubits_type",
+    ]
+except ImportError:
+    pass

--- a/source/qdk_package/tests/qre/test_application.py
+++ b/source/qdk_package/tests/qre/test_application.py
@@ -1,11 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# flake8: noqa E402
-
-import pytest
-
-cirq = pytest.importorskip("cirq")
 
 from dataclasses import dataclass, field
 

--- a/source/qdk_package/tests/qre/test_cirq_interop.py
+++ b/source/qdk_package/tests/qre/test_cirq_interop.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# flake8: noqa E402
+
+
 import pytest
 
 cirq = pytest.importorskip("cirq")

--- a/source/qdk_package/tests/qre/test_estimation.py
+++ b/source/qdk_package/tests/qre/test_estimation.py
@@ -5,7 +5,6 @@ import os
 
 import pytest
 
-cirq = pytest.importorskip("cirq")
 
 from qdk.estimator import LogicalCounts
 from qdk.qre import (

--- a/source/qdk_package/tests/qre/test_estimation_table.py
+++ b/source/qdk_package/tests/qre/test_estimation_table.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-cirq = pytest.importorskip("cirq")
 
 import pandas as pd
 

--- a/source/qdk_package/tests/qre/test_interop.py
+++ b/source/qdk_package/tests/qre/test_interop.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-cirq = pytest.importorskip("cirq")
 
 from qdk import qsharp
 import qdk.code


### PR DESCRIPTION
This removes the hard dependency on `cirq` in QRE. It's possible now to import, e.g., `QSharpApplication` if `cirq-core` is note installed.

If the user wants to import `CirqApplication`, one needs to install `pip install qdk[qre,cirq]`. This message is also printed if the user tries to instantiate `CirqApplication` when `cirq-core` is not installed.

The `pyproject.toml` is updated accordingly.

All tests that require `cirq` are in one file and guarded by `pytest.importskip`, but `cirq` is available in tests.