### PR TITLE
FIR Transform capture-value resolution across the function boundaries should work

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -6137,4 +6137,66 @@ mod adaptive_profile {
         "#]]
             .assert_eq(&qir);
     }
+
+    /// Regression test for a defunctionalization capture-resolution bug where a
+    /// partial-application closure returned across a function boundary threaded
+    /// the wrong captured value into the specialized callable. This mirrors the
+    /// Bernstein-Vazirani sample shape: `MakeParity` returns
+    /// `ApplyParity(secret, _, _)` (capturing `secret`), which is then invoked
+    /// through the `Apply` higher-order operation. The captured `secret` (5 =
+    /// 0b101) must drive which `CNOT`s fire — controls on query qubits 0 and 2,
+    /// each targeting the shared ancilla. Before the fix, the capture was
+    /// resolved to a caller-scope qubit, corrupting the CNOT operands.
+    #[test]
+    fn cross_function_partial_application_capture_threads_correct_value() {
+        let source = "namespace Test {
+            import Std.Intrinsic.*;
+            operation ApplyParity(secret : Int, query : Qubit[], target : Qubit) : Unit {
+                if (secret &&& 1) != 0 {
+                    CNOT(query[0], target);
+                }
+                if (secret &&& 2) != 0 {
+                    CNOT(query[1], target);
+                }
+                if (secret &&& 4) != 0 {
+                    CNOT(query[2], target);
+                }
+            }
+            function MakeParity(secret : Int) : ((Qubit[], Qubit) => Unit) {
+                return ApplyParity(secret, _, _);
+            }
+            operation Apply(f : ((Qubit[], Qubit) => Unit), query : Qubit[], target : Qubit) : Unit {
+                f(query, target);
+            }
+            @EntryPoint()
+            operation Main() : Unit {
+                use query = Qubit[3];
+                use target = Qubit();
+                let parity = MakeParity(5);
+                Apply(parity, query, target);
+            }
+        }";
+        let qir = compile_source_to_qir(source, *CAPABILITIES);
+        // secret = 5 (0b101) folds at compile time -> CNOT(query[0], target) and
+        // CNOT(query[2], target). query qubits are 0,1,2 and target is qubit 3, so
+        // both CNOTs use constant operands and share target qubit 3. Before the fix
+        // the captured `secret` resolved to a caller-scope qubit, corrupting the
+        // operands (and the bit selection).
+        assert!(
+            qir.contains(
+                "call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 3 to ptr))"
+            ),
+            "expected CNOT(query[0]=0, target=3), got:\n{qir}"
+        );
+        assert!(
+            qir.contains(
+                "call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))"
+            ),
+            "expected CNOT(query[2]=2, target=3), got:\n{qir}"
+        );
+        assert!(
+            !qir.contains("call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr),"),
+            "secret 0b101 must not fire CNOT on query[1], got:\n{qir}"
+        );
+    }
 }

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/analysis.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/analysis.rs
@@ -1264,6 +1264,13 @@ fn resolve_same_package_callable_return(
         args_expr_id,
         package_id,
     );
+    // Snapshot the parameter -> caller-argument expression map immediately
+    // after seeding and before the body is analyzed. The body's own local
+    // bindings can collide with caller-scope `LocalVarId`s, which would make
+    // a transitive walk over the merged `state.exprs` ambiguous. This clean 
+    // snapshot lets capture resolution stop at a producing-function parameter
+    // and substitute the caller-scope argument bound to it.
+    let param_substitutions: FxHashMap<LocalVarId, ExprId> = state.exprs.clone();
     analyze_block_flow(pkg, store, body_block_id, &mut state, package_id, None);
 
     let block = pkg.get_block(body_block_id);
@@ -1285,6 +1292,7 @@ fn resolve_same_package_callable_return(
     materialize_capture_exprs_from_state(
         pkg,
         &state,
+        &param_substitutions,
         resolve_callee_projection(
             pkg,
             store,
@@ -1359,23 +1367,31 @@ fn remap_condition_expr(pkg: &Package, locals: &LocalState, expr_id: ExprId) -> 
 }
 
 /// Materializes `CapturedVar::expr` fields for each capture appearing in a
-/// `CalleeLattice` by looking up the capture's defining expression in the
-/// current `LocalState` so rewrite can re-emit the captures as arguments.
+/// `CalleeLattice` by resolving the capture's defining expression in the
+/// callee's analyzed `LocalState`, substituting producing-function parameters
+/// with the caller-scope argument expressions in `param_substitutions`, so
+/// rewrite can re-emit the captures as caller-scope arguments.
 fn materialize_capture_exprs_from_state(
     pkg: &Package,
     state: &LocalState,
+    param_substitutions: &FxHashMap<LocalVarId, ExprId>,
     resolved: CalleeLattice,
 ) -> CalleeLattice {
     match resolved {
-        CalleeLattice::Single(concrete) => {
-            CalleeLattice::Single(materialize_capture_exprs_in_callable(pkg, state, concrete))
-        }
+        CalleeLattice::Single(concrete) => CalleeLattice::Single(
+            materialize_capture_exprs_in_callable(pkg, state, param_substitutions, concrete),
+        ),
         CalleeLattice::Multi(entries) => CalleeLattice::Multi(
             entries
                 .into_iter()
                 .map(|(concrete, condition)| {
                     (
-                        materialize_capture_exprs_in_callable(pkg, state, concrete),
+                        materialize_capture_exprs_in_callable(
+                            pkg,
+                            state,
+                            param_substitutions,
+                            concrete,
+                        ),
                         condition,
                     )
                 })
@@ -1385,12 +1401,15 @@ fn materialize_capture_exprs_from_state(
     }
 }
 
-/// Walks every reaching lattice entry recorded for the callables in a
-/// reachable item set and calls [`materialize_capture_exprs_from_state`]
-/// for each one so the final `LatticeStates` exposes capture expressions.
+/// Resolves each closure capture to a caller-scope expression. For a
+/// partial-application closure returned across a function boundary, the
+/// capture references a producing-function parameter; this walks the callee
+/// `state` from the capture var, stops at the first producing-function
+/// parameter, and substitutes the caller-scope argument bound to it.
 fn materialize_capture_exprs_in_callable(
     pkg: &Package,
     state: &LocalState,
+    param_substitutions: &FxHashMap<LocalVarId, ExprId>,
     concrete: ConcreteCallable,
 ) -> ConcreteCallable {
     match concrete {
@@ -1400,8 +1419,10 @@ fn materialize_capture_exprs_in_callable(
             functor,
         } => {
             for capture in &mut captures {
-                if capture.expr.is_none() {
-                    capture.expr = resolve_capture_expr_from_state(pkg, state, capture.var);
+                if let Some(expr) =
+                    resolve_capture_to_caller(pkg, state, param_substitutions, capture.var)
+                {
+                    capture.expr = Some(expr);
                 }
             }
 
@@ -1415,29 +1436,37 @@ fn materialize_capture_exprs_in_callable(
     }
 }
 
-/// Resolves the defining expression for a captured local by consulting the
-/// flow-sensitive `LocalState::exprs` map populated during analysis.
-fn resolve_capture_expr_from_state(
+/// Resolves a closure capture variable to a caller-scope expression.
+///
+/// Walks `Var(Local)` indirection through the callee's analyzed `state`
+/// starting from `var`. When the walk reaches a producing-function parameter
+/// it returns the caller-scope argument expression bound to that parameter at
+/// the call site. Checking `param_substitutions` first is essential: the 
+/// callee body's local bindings can collide with caller-scope `LocalVarId`s,
+/// so following the merged `state.exprs` past a parameter would misinterpret
+/// a caller-scope id as a callee-scope one. Returns the terminal expression
+/// when the walk ends at a non-variable, or `None` when nothing is resolvable.
+fn resolve_capture_to_caller(
     pkg: &Package,
     state: &LocalState,
+    param_substitutions: &FxHashMap<LocalVarId, ExprId>,
     var: LocalVarId,
 ) -> Option<ExprId> {
     let mut current = var;
-
     for _ in 0..MAX_RESOLVE_DEPTH {
+        if let Some(&arg_expr_id) = param_substitutions.get(&current) {
+            return Some(arg_expr_id);
+        }
         let &expr_id = state.exprs.get(&current)?;
         let expr = pkg.get_expr(expr_id);
-        if let ExprKind::Var(Res::Local(next_var), _) = &expr.kind
-            && *next_var != current
-            && state.exprs.contains_key(next_var)
+        if let ExprKind::Var(Res::Local(next), _) = &expr.kind
+            && *next != current
         {
-            current = *next_var;
+            current = *next;
             continue;
         }
-
         return Some(expr_id);
     }
-
     None
 }
 

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/analysis.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/analysis.rs
@@ -1267,7 +1267,7 @@ fn resolve_same_package_callable_return(
     // Snapshot the parameter -> caller-argument expression map immediately
     // after seeding and before the body is analyzed. The body's own local
     // bindings can collide with caller-scope `LocalVarId`s, which would make
-    // a transitive walk over the merged `state.exprs` ambiguous. This clean 
+    // a transitive walk over the merged `state.exprs` ambiguous. This clean
     // snapshot lets capture resolution stop at a producing-function parameter
     // and substitute the caller-scope argument bound to it.
     let param_substitutions: FxHashMap<LocalVarId, ExprId> = state.exprs.clone();
@@ -1441,7 +1441,7 @@ fn materialize_capture_exprs_in_callable(
 /// Walks `Var(Local)` indirection through the callee's analyzed `state`
 /// starting from `var`. When the walk reaches a producing-function parameter
 /// it returns the caller-scope argument expression bound to that parameter at
-/// the call site. Checking `param_substitutions` first is essential: the 
+/// the call site. Checking `param_substitutions` first is essential: the
 /// callee body's local bindings can collide with caller-scope `LocalVarId`s,
 /// so following the merged `state.exprs` past a parameter would misinterpret
 /// a caller-scope id as a callee-scope one. Returns the terminal expression

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/analysis.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/analysis.rs
@@ -2508,82 +2508,82 @@ fn callable_returning_partial_application_resolves_statically() {
     check_rewrite(
         source,
         &expect![[r#"
-        BEFORE:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
-            if bits[0] {
-                CNOT(register[0], target);
+            BEFORE:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
             }
+            operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
+                if bits[0] {
+                    CNOT(register[0], target);
+                }
 
-        }
-        operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Bool[] = bits;
-                / * closure item = 5 captures = [arg] * / _lambda_
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            let op : ((Qubit[], Qubit) => Unit) = MakeParity([true]);
-            ApplyOp_Empty_(op, register, target);
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-        }
-        operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        // entry
-        Main()
-
-        AFTER:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
-            if bits[0] {
-                CNOT(register[0], target);
             }
+            operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Bool[] = bits;
+                    / * closure item = 5 captures = [arg] * / _lambda_
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                let op : ((Qubit[], Qubit) => Unit) = MakeParity([true]);
+                ApplyOp_Empty_(op, register, target);
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+            }
+            operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            // entry
+            Main()
 
-        }
-        operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Bool[] = bits;
-                ()
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            ApplyOp_Empty__closure_(register, target, register);
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-        }
-        operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Bool[]) : Unit {
-            _lambda_(__capture_0, (register, target));
-        }
-        // entry
-        Main()
-    "#]],
+            AFTER:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
+                if bits[0] {
+                    CNOT(register[0], target);
+                }
+
+            }
+            operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Bool[] = bits;
+                    ()
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                ApplyOp_Empty__closure_(register, target, [true]);
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+            }
+            operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Bool[]) : Unit {
+                _lambda_(__capture_0, (register, target));
+            }
+            // entry
+            Main()
+        "#]],
     );
 }
 
@@ -2620,82 +2620,82 @@ fn analysis_callable_returning_partial_application_with_explicit_return() {
     check_rewrite(
         source,
         &expect![[r#"
-        BEFORE:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
-            if bits[0] {
-                CNOT(register[0], target);
+            BEFORE:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
             }
+            operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
+                if bits[0] {
+                    CNOT(register[0], target);
+                }
 
-        }
-        operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Bool[] = bits;
-                / * closure item = 5 captures = [arg] * / _lambda_
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            let op : ((Qubit[], Qubit) => Unit) = MakeParity([true]);
-            ApplyOp_Empty_(op, register, target);
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-        }
-        operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        // entry
-        Main()
-
-        AFTER:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
-            if bits[0] {
-                CNOT(register[0], target);
             }
+            operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Bool[] = bits;
+                    / * closure item = 5 captures = [arg] * / _lambda_
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                let op : ((Qubit[], Qubit) => Unit) = MakeParity([true]);
+                ApplyOp_Empty_(op, register, target);
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+            }
+            operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            // entry
+            Main()
 
-        }
-        operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Bool[] = bits;
-                ()
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            ApplyOp_Empty__closure_(register, target, register);
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-        }
-        operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Bool[]) : Unit {
-            _lambda_(__capture_0, (register, target));
-        }
-        // entry
-        Main()
-    "#]],
+            AFTER:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyParityOperation(bits : Bool[], register : Qubit[], target : Qubit) : Unit {
+                if bits[0] {
+                    CNOT(register[0], target);
+                }
+
+            }
+            operation MakeParity(bits : Bool[]) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Bool[] = bits;
+                    ()
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                ApplyOp_Empty__closure_(register, target, [true]);
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+            }
+            operation _lambda_(arg : Bool[], (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Bool[]) : Unit {
+                _lambda_(__capture_0, (register, target));
+            }
+            // entry
+            Main()
+        "#]],
     );
 }
 
@@ -2930,84 +2930,84 @@ fn callable_returning_partial_application_from_function_resolves_statically() {
     check_rewrite(
         source,
         &expect![[r#"
-        BEFORE:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
-            if value == 1 {
-                CNOT(register[0], target);
+            BEFORE:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
             }
+            operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
+                if value == 1 {
+                    CNOT(register[0], target);
+                }
 
-        }
-        function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Int = value;
-                / * closure item = 5 captures = [arg] * / _lambda_
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            let value : Int = 1;
-            let oracle : ((Qubit[], Qubit) => Unit) = Encode(value);
-            ApplyOp_Empty_(oracle, register, target);
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-        }
-        operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        // entry
-        Main()
-
-        AFTER:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
-            if value == 1 {
-                CNOT(register[0], target);
             }
+            function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Int = value;
+                    / * closure item = 5 captures = [arg] * / _lambda_
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                let value : Int = 1;
+                let oracle : ((Qubit[], Qubit) => Unit) = Encode(value);
+                ApplyOp_Empty_(oracle, register, target);
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+            }
+            operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            // entry
+            Main()
 
-        }
-        function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Int = value;
-                ()
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            let value : Int = 1;
-            ApplyOp_Empty__closure_(register, target, register);
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-        }
-        operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Int) : Unit {
-            _lambda_(__capture_0, (register, target));
-        }
-        // entry
-        Main()
-    "#]],
+            AFTER:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
+                if value == 1 {
+                    CNOT(register[0], target);
+                }
+
+            }
+            function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Int = value;
+                    ()
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                let value : Int = 1;
+                ApplyOp_Empty__closure_(register, target, value);
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+            }
+            operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Int) : Unit {
+                _lambda_(__capture_0, (register, target));
+            }
+            // entry
+            Main()
+        "#]],
     );
 }
 
@@ -3150,110 +3150,110 @@ fn analysis_callable_returning_partial_application_from_function_in_loop() {
     check_rewrite(
         source,
         &expect![[r#"
-        BEFORE:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
-            if value == 1 {
-                CNOT(register[0], target);
+            BEFORE:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
             }
-
-        }
-        function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Int = value;
-                / * closure item = 5 captures = [arg] * / _lambda_
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            let _generated_ident_156 : Unit = {
-                let _array_id_118 : Int[] = [1, 2];
-                let _len_id_122 : Int = Length(_array_id_118);
-                mutable _index_id_127 : Int = 0;
-                while _index_id_127 < _len_id_122 {
-                    let value : Int = _array_id_118[_index_id_127];
-                    let oracle : ((Qubit[], Qubit) => Unit) = Encode(value);
-                    ApplyOp_Empty_(oracle, register, target);
-                    _index_id_127 += 1;
+            operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
+                if value == 1 {
+                    CNOT(register[0], target);
                 }
 
-            };
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-            _generated_ident_156
-        }
-        operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        function Length(a : Int[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        // entry
-        Main()
-
-        AFTER:
-        // namespace test
-        operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
-            if value == 1 {
-                CNOT(register[0], target);
             }
+            function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Int = value;
+                    / * closure item = 5 captures = [arg] * / _lambda_
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                let _generated_ident_156 : Unit = {
+                    let _array_id_118 : Int[] = [1, 2];
+                    let _len_id_122 : Int = Length(_array_id_118);
+                    mutable _index_id_127 : Int = 0;
+                    while _index_id_127 < _len_id_122 {
+                        let value : Int = _array_id_118[_index_id_127];
+                        let oracle : ((Qubit[], Qubit) => Unit) = Encode(value);
+                        ApplyOp_Empty_(oracle, register, target);
+                        _index_id_127 += 1;
+                    }
 
-        }
-        function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
-            return {
-                let arg : Int = value;
-                ()
-            };
-        }
-        operation Main() : Unit {
-            let register : Qubit[] = AllocateQubitArray(1);
-            let target : Qubit = __quantum__rt__qubit_allocate();
-            let _generated_ident_156 : Unit = {
-                let _array_id_118 : Int[] = [1, 2];
-                let _len_id_122 : Int = Length(_array_id_118);
-                mutable _index_id_127 : Int = 0;
-                while _index_id_127 < _len_id_122 {
-                    let value : Int = _array_id_118[_index_id_127];
-                    ApplyOp_Empty__closure_(register, target, register);
-                    _index_id_127 += 1;
+                };
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+                _generated_ident_156
+            }
+            operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            function Length(a : Int[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            // entry
+            Main()
+
+            AFTER:
+            // namespace test
+            operation ApplyOp(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyParityOperation(value : Int, register : Qubit[], target : Qubit) : Unit {
+                if value == 1 {
+                    CNOT(register[0], target);
                 }
 
-            };
-            __quantum__rt__qubit_release(target);
-            ReleaseQubitArray(register);
-            _generated_ident_156
-        }
-        operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
-            ApplyParityOperation(arg, hole, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        function Length(a : Int[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
-            op(register, target);
-        }
-        operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Int) : Unit {
-            _lambda_(__capture_0, (register, target));
-        }
-        // entry
-        Main()
-    "#]],
+            }
+            function Encode(value : Int) : ((Qubit[], Qubit) => Unit) {
+                return {
+                    let arg : Int = value;
+                    ()
+                };
+            }
+            operation Main() : Unit {
+                let register : Qubit[] = AllocateQubitArray(1);
+                let target : Qubit = __quantum__rt__qubit_allocate();
+                let _generated_ident_156 : Unit = {
+                    let _array_id_118 : Int[] = [1, 2];
+                    let _len_id_122 : Int = Length(_array_id_118);
+                    mutable _index_id_127 : Int = 0;
+                    while _index_id_127 < _len_id_122 {
+                        let value : Int = _array_id_118[_index_id_127];
+                        ApplyOp_Empty__closure_(register, target, value);
+                        _index_id_127 += 1;
+                    }
+
+                };
+                __quantum__rt__qubit_release(target);
+                ReleaseQubitArray(register);
+                _generated_ident_156
+            }
+            operation _lambda_(arg : Int, (hole : Qubit[], hole : Qubit)) : Unit {
+                ApplyParityOperation(arg, hole, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            function Length(a : Int[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : ((Qubit[], Qubit) => Unit), register : Qubit[], target : Qubit) : Unit {
+                op(register, target);
+            }
+            operation ApplyOp_Empty__closure_(register : Qubit[], target : Qubit, __capture_0 : Int) : Unit {
+                _lambda_(__capture_0, (register, target));
+            }
+            // entry
+            Main()
+        "#]],
     );
 }
 

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
@@ -671,7 +671,7 @@ fn analysis_bernstein_vazirani_sample_shape() {
                     mutable _index_id_216 : Int = 0;
                     while _index_id_216 < _len_id_211 {
                         let integer : Int = _array_id_207[_index_id_216];
-                        let _ : Result[] = BernsteinVazirani_Empty__closure_(nQubits, nQubits);
+                        let _ : Result[] = BernsteinVazirani_Empty__closure_(nQubits, integer);
                         _index_id_216 += 1;
                     }
 

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/fixpoint.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/fixpoint.rs
@@ -1189,72 +1189,72 @@ fn producer_body_closure_cleanup_converges() {
     check_rewrite(
         source,
         &expect![[r#"
-        BEFORE:
-        // namespace test
-        operation ApplyOp(op : (Qubit => Unit), q : Qubit) : Unit {
-            op(q);
-        }
-        operation InnerOp(extra : Bool, q : Qubit) : Unit {
-            H(q);
-        }
-        function MakeOp(extra : Bool) : (Qubit => Unit) {
-            return {
-                let arg : Bool = extra;
-                / * closure item = 5 captures = [arg] * / _lambda_
-            };
-        }
-        operation Main() : Unit {
-            let q : Qubit = __quantum__rt__qubit_allocate();
-            let op : (Qubit => Unit) = MakeOp(true);
-            ApplyOp_Empty_(op, q);
-            __quantum__rt__qubit_release(q);
-        }
-        operation _lambda_(arg : Bool, hole : Qubit) : Unit {
-            InnerOp(arg, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : (Qubit => Unit), q : Qubit) : Unit {
-            op(q);
-        }
-        // entry
-        Main()
+            BEFORE:
+            // namespace test
+            operation ApplyOp(op : (Qubit => Unit), q : Qubit) : Unit {
+                op(q);
+            }
+            operation InnerOp(extra : Bool, q : Qubit) : Unit {
+                H(q);
+            }
+            function MakeOp(extra : Bool) : (Qubit => Unit) {
+                return {
+                    let arg : Bool = extra;
+                    / * closure item = 5 captures = [arg] * / _lambda_
+                };
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                let op : (Qubit => Unit) = MakeOp(true);
+                ApplyOp_Empty_(op, q);
+                __quantum__rt__qubit_release(q);
+            }
+            operation _lambda_(arg : Bool, hole : Qubit) : Unit {
+                InnerOp(arg, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : (Qubit => Unit), q : Qubit) : Unit {
+                op(q);
+            }
+            // entry
+            Main()
 
-        AFTER:
-        // namespace test
-        operation ApplyOp(op : (Qubit => Unit), q : Qubit) : Unit {
-            op(q);
-        }
-        operation InnerOp(extra : Bool, q : Qubit) : Unit {
-            H(q);
-        }
-        function MakeOp(extra : Bool) : (Qubit => Unit) {
-            return {
-                let arg : Bool = extra;
-                ()
-            };
-        }
-        operation Main() : Unit {
-            let q : Qubit = __quantum__rt__qubit_allocate();
-            ApplyOp_Empty__closure_(q, q);
-            __quantum__rt__qubit_release(q);
-        }
-        operation _lambda_(arg : Bool, hole : Qubit) : Unit {
-            InnerOp(arg, hole)
-        }
-        function Length(a : Qubit[]) : Int {
-            body intrinsic;
-        }
-        operation ApplyOp_Empty_(op : (Qubit => Unit), q : Qubit) : Unit {
-            op(q);
-        }
-        operation ApplyOp_Empty__closure_(q : Qubit, __capture_0 : Bool) : Unit {
-            _lambda_(__capture_0, q);
-        }
-        // entry
-        Main()
-    "#]],
+            AFTER:
+            // namespace test
+            operation ApplyOp(op : (Qubit => Unit), q : Qubit) : Unit {
+                op(q);
+            }
+            operation InnerOp(extra : Bool, q : Qubit) : Unit {
+                H(q);
+            }
+            function MakeOp(extra : Bool) : (Qubit => Unit) {
+                return {
+                    let arg : Bool = extra;
+                    ()
+                };
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                ApplyOp_Empty__closure_(q, true);
+                __quantum__rt__qubit_release(q);
+            }
+            operation _lambda_(arg : Bool, hole : Qubit) : Unit {
+                InnerOp(arg, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation ApplyOp_Empty_(op : (Qubit => Unit), q : Qubit) : Unit {
+                op(q);
+            }
+            operation ApplyOp_Empty__closure_(q : Qubit, __capture_0 : Bool) : Unit {
+                _lambda_(__capture_0, q);
+            }
+            // entry
+            Main()
+        "#]],
     );
 }
 

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/specialization.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/specialization.rs
@@ -3488,3 +3488,177 @@ fn direct_call_preserves_lambda_body_span() {
         "surviving direct call should carry the lambda body span, got {slice:?}"
     );
 }
+
+/// A closure is created by a separate function, `MakeAdder`, that returns it,
+/// then bound to a local, `adder`, and passed to a higher-order function,
+/// `Apply`. Because the closure's capture, `base`, is defined across the
+/// function-return boundary, the HOF call-site rewrite cannot resolve the
+/// capture's value from the enclosing block and threads the wrong local.
+#[test]
+fn cross_function_closure_capture_threads_correct_value() {
+    let source = r#"
+        import Std.Convert.*;
+        operation Apply(f : (Qubit => Unit), q : Qubit) : Unit {
+            f(q);
+        }
+
+        operation ApplyRotation(base : Int, q : Qubit) : Unit {
+            Rx(IntAsDouble(base), q);
+        }
+
+        function MakeRotation(base : Int) : (Qubit => Unit) {
+            return ApplyRotation(base, _);
+        }
+
+        operation Main() : Unit {
+            use q = Qubit();
+            let amount = 5;
+            let rotation = MakeRotation(amount);
+            Apply(rotation, q);
+        }
+        "#;
+    check_rewrite_with_capabilities(
+        source,
+        adaptive_qirgen_capabilities(),
+        &expect![[r#"
+            BEFORE:
+            // namespace test
+            operation Apply(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            operation ApplyRotation(base : Int, q : Qubit) : Unit {
+                Rx(IntAsDouble(base), q);
+            }
+            function MakeRotation(base : Int) : (Qubit => Unit) {
+                return {
+                    let arg : Int = base;
+                    / * closure item = 5 captures = [arg] * / _lambda_
+                };
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                let amount : Int = 5;
+                let rotation : (Qubit => Unit) = MakeRotation(amount);
+                Apply_Empty_(rotation, q);
+                __quantum__rt__qubit_release(q);
+            }
+            operation _lambda_(arg : Int, hole : Qubit) : Unit {
+                ApplyRotation(arg, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation Apply_Empty_(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            // entry
+            Main()
+
+            AFTER:
+            // namespace test
+            operation Apply(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            operation ApplyRotation(base : Int, q : Qubit) : Unit {
+                Rx(IntAsDouble(base), q);
+            }
+            function MakeRotation(base : Int) : (Qubit => Unit) {
+                return {
+                    let arg : Int = base;
+                    ()
+                };
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                let amount : Int = 5;
+                Apply_Empty__closure_(q, amount);
+                __quantum__rt__qubit_release(q);
+            }
+            operation _lambda_(arg : Int, hole : Qubit) : Unit {
+                ApplyRotation(arg, hole)
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation Apply_Empty_(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            operation Apply_Empty__closure_(q : Qubit, __capture_0 : Int) : Unit {
+                _lambda_(__capture_0, q);
+            }
+            // entry
+            Main()
+        "#]],
+    );
+}
+
+/// The closure is created inline in the same block as the HOF call.
+#[test]
+fn inline_closure_capture_threads_correct_value() {
+    let source = r#"
+        import Std.Convert.*;
+        operation Apply(f : (Qubit => Unit), q : Qubit) : Unit {
+            f(q);
+        }
+
+        operation Main() : Unit {
+            use q = Qubit();
+            let amount = 5;
+            Apply(qubit => Rx(IntAsDouble(amount), qubit), q);
+        }
+        "#;
+    check_rewrite_with_capabilities(
+        source,
+        adaptive_qirgen_capabilities(),
+        &expect![[r#"
+            BEFORE:
+            // namespace test
+            operation Apply(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                let amount : Int = 5;
+                Apply_Empty_(/ * closure item = 3 captures = [amount] * / _lambda_, q);
+                __quantum__rt__qubit_release(q);
+            }
+            operation _lambda_(amount : Int, qubit : Qubit) : Unit {
+                Rx(IntAsDouble(amount), qubit)
+            }
+            operation Apply_Empty_(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            // entry
+            Main()
+
+            AFTER:
+            // namespace test
+            operation Apply(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                let amount : Int = 5;
+                Apply_Empty__closure_(q, amount);
+                __quantum__rt__qubit_release(q);
+            }
+            operation _lambda_(amount : Int, qubit : Qubit) : Unit {
+                Rx(IntAsDouble(amount), qubit)
+            }
+            operation Apply_Empty_(f : (Qubit => Unit), q : Qubit) : Unit {
+                f(q);
+            }
+            function Length(a : Qubit[]) : Int {
+                body intrinsic;
+            }
+            operation Apply_Empty__closure_(q : Qubit, __capture_0 : Int) : Unit {
+                _lambda_(__capture_0, q);
+            }
+            // entry
+            Main()
+        "#]],
+    );
+}

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -8,8 +8,8 @@ use expect_test::{Expect, expect};
 // fail to compile until the new expect strings are added.
 pub const BERNSTEINVAZIRANI_EXPECT: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[127, 238, 512]"];
-pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 27618"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR: Expect = expect!["generated QIR of length 19379"];
+pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 29822"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR: Expect = expect!["generated QIR of length 20283"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =


### PR DESCRIPTION
## Example

```qsharp
operation ApplyRotation(amount : Double, q : Qubit) : Unit {
    Rx(amount, q);
}

// Produces a partial-application closure that captures `amount`.
function MakeRotation(amount : Double) : (Qubit => Unit) {
    return ApplyRotation(amount, _);   // closure captures `amount`
}

operation Apply(f : (Qubit => Unit), q : Qubit) : Unit {
    f(q);
}

operation Main() : Unit {
    use q = Qubit();
    let amount = 3.14;
    let rotation = MakeRotation(amount);   // closure crosses a function boundary
    Apply(rotation, q);                    // expected: rotate q by ~pi
}
```

## The issue

When the closure produced by `MakeRotation(amount)` was returned out of that function and handed to `Apply`, defunctionalization resolved the closure's captured value incorrectly. To resolve what `Apply(rotation, q)` should pass, the analysis built a single `state.exprs` map that merged `Main`'s locals with `MakeRotation`'s locals — but FIR reuses `LocalVarId`s across callables, so `Main`'s `amount` (id 2) collided with the closure's internal capture local `arg` (the `let arg = amount` introduced when lowering the partial application, also id 2). Seeding `MakeRotation`'s parameter produced `exprs[amount-param=1] = Var(2)` while the body added `exprs[arg=2] = Var(1)`, a cyclic `1<->2` mapping the resolver couldn't disambiguate. It therefore threaded a callee-scope reference (`MakeRotation`'s parameter) into `Main`, where id 1 resolved to the unrelated qubit `q`, so the specialized call became `Apply__closure_(q, q)` instead of `Apply__closure_(q, amount)` — and in Bernstein-Vazirani this surfaced as `BernsteinVazirani_Empty__closure_(nQubits, nQubits)` instead of `(nQubits, integer)`, corrupting the CNOT operands.

## The fix

We snapshot a clean `param_substitutions` map (`MakeRotation`'s parameter -> the caller's argument expression `amount`) immediately after seeding the call arguments and before analyzing `MakeRotation`'s body pollutes the shared map with the colliding `arg` id. The new `resolve_capture_to_caller` helper then walks the capture chain for `rotation` but consults `param_substitutions` first at each hop, so it stops at `MakeRotation`'s parameter and substitutes `Main`'s actual `amount` expression instead of following the collided id back into the wrong scope. The capture now resolves to its true caller-side value, yielding `Apply__closure_(q, amount)` (and `BernsteinVazirani_Empty__closure_(nQubits, integer)`).