### PR TITLE
Track dynamic constants across call boundaries in RCA

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -843,21 +843,21 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
         block_1:
           br label %block_2
         block_2:
-          %var_151 = phi i1 [true, %block_0], [false, %block_1]
+          %var_199 = phi i1 [true, %block_0], [false, %block_1]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
           %var_11 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 1 to %Result*))
           br i1 %var_11, label %block_3, label %block_4
         block_3:
           br label %block_4
         block_4:
-          %var_152 = phi i1 [%var_151, %block_2], [false, %block_3]
+          %var_200 = phi i1 [%var_199, %block_2], [false, %block_3]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
           %var_13 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 2 to %Result*))
           br i1 %var_13, label %block_5, label %block_6
         block_5:
           br label %block_6
         block_6:
-          %var_153 = phi i1 [%var_152, %block_4], [false, %block_5]
+          %var_201 = phi i1 [%var_200, %block_4], [false, %block_5]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -874,21 +874,21 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
         block_7:
           br label %block_8
         block_8:
-          %var_154 = phi i1 [true, %block_6], [false, %block_7]
+          %var_202 = phi i1 [true, %block_6], [false, %block_7]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
           %var_27 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 4 to %Result*))
           br i1 %var_27, label %block_9, label %block_10
         block_9:
           br label %block_10
         block_10:
-          %var_155 = phi i1 [%var_154, %block_8], [false, %block_9]
+          %var_203 = phi i1 [%var_202, %block_8], [false, %block_9]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
           %var_29 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 5 to %Result*))
           br i1 %var_29, label %block_11, label %block_12
         block_11:
           br label %block_12
         block_12:
-          %var_156 = phi i1 [%var_155, %block_10], [false, %block_11]
+          %var_204 = phi i1 [%var_203, %block_10], [false, %block_11]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -947,26 +947,26 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
-          %var_98 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 6 to %Result*))
-          br i1 %var_98, label %block_13, label %block_14
+          %var_130 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 6 to %Result*))
+          br i1 %var_130, label %block_13, label %block_14
         block_13:
           br label %block_14
         block_14:
-          %var_157 = phi i1 [true, %block_12], [false, %block_13]
+          %var_205 = phi i1 [true, %block_12], [false, %block_13]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
-          %var_100 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 7 to %Result*))
-          br i1 %var_100, label %block_15, label %block_16
+          %var_132 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 7 to %Result*))
+          br i1 %var_132, label %block_15, label %block_16
         block_15:
           br label %block_16
         block_16:
-          %var_158 = phi i1 [%var_157, %block_14], [false, %block_15]
+          %var_206 = phi i1 [%var_205, %block_14], [false, %block_15]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 8 to %Result*))
-          %var_102 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 8 to %Result*))
-          br i1 %var_102, label %block_17, label %block_18
+          %var_134 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 8 to %Result*))
+          br i1 %var_134, label %block_17, label %block_18
         block_17:
           br label %block_18
         block_18:
-          %var_159 = phi i1 [%var_158, %block_16], [false, %block_17]
+          %var_207 = phi i1 [%var_206, %block_16], [false, %block_17]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -1005,32 +1005,32 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 9 to %Result*))
-          %var_143 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 9 to %Result*))
-          br i1 %var_143, label %block_19, label %block_20
+          %var_191 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 9 to %Result*))
+          br i1 %var_191, label %block_19, label %block_20
         block_19:
           br label %block_20
         block_20:
-          %var_160 = phi i1 [true, %block_18], [false, %block_19]
+          %var_208 = phi i1 [true, %block_18], [false, %block_19]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 10 to %Result*))
-          %var_145 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 10 to %Result*))
-          br i1 %var_145, label %block_21, label %block_22
+          %var_193 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 10 to %Result*))
+          br i1 %var_193, label %block_21, label %block_22
         block_21:
           br label %block_22
         block_22:
-          %var_161 = phi i1 [%var_160, %block_20], [false, %block_21]
+          %var_209 = phi i1 [%var_208, %block_20], [false, %block_21]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 11 to %Result*))
-          %var_147 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 11 to %Result*))
-          br i1 %var_147, label %block_23, label %block_24
+          %var_195 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 11 to %Result*))
+          br i1 %var_195, label %block_23, label %block_24
         block_23:
           br label %block_24
         block_24:
-          %var_162 = phi i1 [%var_161, %block_22], [false, %block_23]
+          %var_210 = phi i1 [%var_209, %block_22], [false, %block_23]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__rt__array_record_output(i64 4, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_153, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_156, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_159, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_162, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_201, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_204, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_207, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_210, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
           ret i64 0
         }
 

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -604,9 +604,9 @@ impl<'a> PartialEvaluator<'a> {
                 rhs_expr_id,
                 bin_op_expr_span,
             ),
-            Value::Result(lhs_result) => self.eval_bin_op_with_lhs_result_operand(
+            Value::Result(_) => self.eval_bin_op_with_lhs_result_operand(
                 bin_op,
-                lhs_result,
+                &lhs_value,
                 rhs_expr_id,
                 bin_op_expr_span,
             ),
@@ -645,6 +645,33 @@ impl<'a> PartialEvaluator<'a> {
                     ));
                 };
                 Ok(EvalControlFlow::Continue(rhs_value))
+            }
+            Value::Pauli(p) => {
+                let rhs_control_flow = self.try_eval_expr(rhs_expr_id)?;
+                let EvalControlFlow::Continue(rhs_value) = rhs_control_flow else {
+                    return Err(Error::Unexpected(
+                        "embedded return in RHS expression".to_string(),
+                        self.get_expr_package_span(rhs_expr_id),
+                    ));
+                };
+                match bin_op {
+                    BinOp::Eq => {
+                        let Value::Pauli(rhs_pauli) = rhs_value else {
+                            panic!("expected pauli value from RHS expression");
+                        };
+                        Ok(EvalControlFlow::Continue(Value::Bool(p == rhs_pauli)))
+                    }
+                    BinOp::Neq => {
+                        let Value::Pauli(rhs_pauli) = rhs_value else {
+                            panic!("expected pauli value from RHS expression");
+                        };
+                        Ok(EvalControlFlow::Continue(Value::Bool(p != rhs_pauli)))
+                    }
+                    _ => Err(Error::Unimplemented(
+                        "pauli binary operation".to_string(),
+                        bin_op_expr_span,
+                    )),
+                }
             }
             _ => Err(Error::Unexpected(
                 format!("unsupported LHS value: {lhs_value}"),
@@ -696,7 +723,7 @@ impl<'a> PartialEvaluator<'a> {
     fn eval_bin_op_with_lhs_result_operand(
         &mut self,
         bin_op: BinOp,
-        lhs_result: val::Result,
+        lhs_value: &Value,
         rhs_expr_id: ExprId,
         bin_op_expr_span: PackageSpan, // For diagnostic purposes only.
     ) -> Result<EvalControlFlow, Error> {
@@ -707,9 +734,6 @@ impl<'a> PartialEvaluator<'a> {
                 self.get_expr_package_span(rhs_expr_id),
             ));
         };
-        let Value::Result(rhs_result) = rhs_value else {
-            panic!("expected result value from RHS expression");
-        };
 
         // Even though to get to this path, an expression would have to be categorized as hybrid by RCA, it is
         // possible that the expression is in fact purely classical.
@@ -717,8 +741,10 @@ impl<'a> PartialEvaluator<'a> {
         // dynamic values. In such instances, RCA identifies all the contents of the data structure as dynamic even if
         // some values are static.
         // Here we handle this case and if both operands are purely classical we evaluate them.
-        if let (val::Result::Val(lhs_result_value), val::Result::Val(rhs_result_value)) =
-            (lhs_result, rhs_result)
+        if let (
+            Value::Result(val::Result::Val(lhs_result_value)),
+            Value::Result(val::Result::Val(rhs_result_value)),
+        ) = (lhs_value, &rhs_value)
         {
             let bool_value = match bin_op {
                 BinOp::Eq => lhs_result_value == rhs_result_value,
@@ -734,8 +760,8 @@ impl<'a> PartialEvaluator<'a> {
         }
 
         // Get the operands to use when generating the binary operation instruction.
-        let lhs_operand = self.eval_result_as_bool_operand(lhs_result);
-        let rhs_operand = self.eval_result_as_bool_operand(rhs_result);
+        let lhs_operand = self.eval_result_as_bool_operand(lhs_value);
+        let rhs_operand = self.eval_result_as_bool_operand(&rhs_value);
 
         // Create a variable to store the result of the expression.
         let variable_id = self.resource_manager.next_var();
@@ -1831,30 +1857,7 @@ impl<'a> PartialEvaluator<'a> {
                     Err(_) => Err(EvalError::ArrayTooLarge(args_span).into()),
                 }
             }
-            "IntAsDouble" => match args_value {
-                #[allow(clippy::cast_precision_loss)]
-                Value::Int(i) => Ok(Value::Double(i as f64)),
-                Value::Var(_) => {
-                    let variable_id = self.resource_manager.next_var();
-                    self.convert_value(&args_value, rir::Variable::new_double(variable_id))
-                }
-                _ => panic!(
-                    "Unexpected value type for IntAsDouble: {}",
-                    args_value.type_name()
-                ),
-            },
-            "Truncate" => match args_value {
-                #[allow(clippy::cast_possible_truncation)]
-                Value::Double(d) => Ok(Value::Int(d as i64)),
-                Value::Var(_) => {
-                    let variable_id = self.resource_manager.next_var();
-                    self.convert_value(&args_value, rir::Variable::new_integer(variable_id))
-                }
-                _ => panic!(
-                    "Unexpected value type for Truncate: {}",
-                    args_value.type_name()
-                ),
-            },
+            "IntAsDouble" | "Truncate" => self.convert_value(&args_value, args_span),
             _ => self.eval_expr_call_to_intrinsic_qis(
                 store_item_id,
                 callable_decl,
@@ -2271,14 +2274,6 @@ impl<'a> PartialEvaluator<'a> {
             ));
         };
 
-        // Get the variable type corresponding to the value the unary operator acts upon.
-        let Some(eval_variable_type) = try_get_eval_var_type(&value) else {
-            return Err(Error::Unexpected(
-                format!("invalid type for unary operation value: {value}"),
-                value_expr_package_span,
-            ));
-        };
-
         // The leading positive operator is a no-op.
         if matches!(un_op, UnOp::Pos) {
             let control_flow = EvalControlFlow::Continue(value);
@@ -2294,6 +2289,15 @@ impl<'a> PartialEvaluator<'a> {
         // For all the other supported unary operations we have to generate an instruction, so create a variable to
         // store the result.
         let variable_id = self.resource_manager.next_var();
+
+        // Get the variable type corresponding to the value the unary operator acts upon.
+        let Some(eval_variable_type) = try_get_eval_var_type(&value) else {
+            return Err(Error::Unexpected(
+                format!("invalid type for unary operation value: {value}"),
+                value_expr_package_span,
+            ));
+        };
+
         let rir_variable_type = map_eval_var_type_to_rir_type(eval_variable_type);
         let rir_variable = rir::Variable {
             variable_id,
@@ -2563,36 +2567,40 @@ impl<'a> PartialEvaluator<'a> {
         Ok(EvalControlFlow::Continue(Value::unit()))
     }
 
-    fn eval_result_as_bool_operand(&mut self, result: val::Result) -> Operand {
-        match result {
-            val::Result::Id(id) => {
-                // If this is a result ID, generate the instruction to read it.
-                let result_operand = Operand::Literal(Literal::Result(
-                    id.try_into().expect("could not convert result ID to u32"),
-                ));
-                let read_result_callable_id =
-                    self.get_or_insert_callable(builder::read_result_decl());
-                let variable_id = self.resource_manager.next_var();
-                let variable_ty = rir::Ty::Prim(rir::Prim::Boolean);
-                let variable = rir::Variable {
-                    variable_id,
-                    ty: variable_ty,
-                };
-                // Current debug location should be set to the call expression currently being evaluated.
-                let metadata = self.metadata_from_current_dbg_location();
-                let current_block = self.get_current_rir_block_mut();
-                let instruction = Instruction::Call(
-                    read_result_callable_id,
-                    vec![result_operand],
-                    Some(variable),
-                    metadata,
-                );
-                current_block.0.push(instruction);
-                Operand::Variable(variable)
+    fn eval_result_as_bool_operand(&mut self, result: &Value) -> Operand {
+        let result_operand = match result {
+            Value::Result(val::Result::Id(id)) => Operand::Literal(Literal::Result(
+                (*id)
+                    .try_into()
+                    .expect("could not convert result ID to u32"),
+            )),
+            Value::Result(val::Result::Val(bool)) => return Operand::Literal(Literal::Bool(*bool)),
+            Value::Result(val::Result::Loss) => {
+                panic!("loss result should not occur in partial evaluation")
             }
-            val::Result::Val(bool) => Operand::Literal(Literal::Bool(bool)),
-            val::Result::Loss => panic!("loss result should not occur in partial evaluation"),
-        }
+            _ => unreachable!(
+                "result eval value should be result id or result variable, found: {result:?}"
+            ),
+        };
+        // Generate the instruction to read the result.
+        let read_result_callable_id = self.get_or_insert_callable(builder::read_result_decl());
+        let variable_id = self.resource_manager.next_var();
+        let variable_ty = rir::Ty::Prim(rir::Prim::Boolean);
+        let variable = rir::Variable {
+            variable_id,
+            ty: variable_ty,
+        };
+        // Current debug location should be set to the call expression currently being evaluated.
+        let metadata = self.metadata_from_current_dbg_location();
+        let current_block = self.get_current_rir_block_mut();
+        let instruction = Instruction::Call(
+            read_result_callable_id,
+            vec![result_operand],
+            Some(variable),
+            metadata,
+        );
+        current_block.0.push(instruction);
+        Operand::Variable(variable)
     }
 
     fn generate_instructions_for_binary_operation_with_double_operands(
@@ -3352,15 +3360,38 @@ impl<'a> PartialEvaluator<'a> {
     fn convert_value(
         &mut self,
         args_value: &Value,
-        variable: rir::Variable,
+        args_span: PackageSpan,
     ) -> Result<Value, Error> {
-        let instruction =
-            Instruction::Convert(self.map_eval_value_to_rir_operand(args_value), variable);
-        let current_block = self.get_current_rir_block_mut();
-        current_block.0.push(instruction);
-        Ok(Value::Var(
-            map_rir_var_to_eval_var(variable).expect("variable should convert"),
-        ))
+        match args_value {
+            Value::Var(var) => {
+                let variable_id = self.resource_manager.next_var();
+                let variable = match var.ty {
+                    VarTy::Double => rir::Variable::new_integer(variable_id),
+                    VarTy::Integer => rir::Variable::new_double(variable_id),
+                    _ => {
+                        return Err(Error::Unimplemented(
+                            format!("unsupported variable type in conversion {:?}", var.ty),
+                            args_span,
+                        ));
+                    }
+                };
+                let instruction =
+                    Instruction::Convert(self.map_eval_value_to_rir_operand(args_value), variable);
+                let current_block = self.get_current_rir_block_mut();
+                current_block.0.push(instruction);
+                Ok(Value::Var(
+                    map_rir_var_to_eval_var(variable).expect("variable should convert"),
+                ))
+            }
+            #[allow(clippy::cast_precision_loss)]
+            Value::Int(i) => Ok(Value::Double(*i as f64)),
+            #[allow(clippy::cast_possible_truncation)]
+            Value::Double(d) => Ok(Value::Int(*d as i64)),
+            _ => Err(Error::Unimplemented(
+                format!("unsupported value type in conversion {args_value:?}"),
+                args_span,
+            )),
+        }
     }
 
     fn update_bindings(&mut self, lhs_expr_id: ExprId, rhs_value: Value) -> Result<(), Error> {
@@ -4214,13 +4245,6 @@ fn eval_bin_op_with_double_literals(
     rhs_literal: Literal,
     bin_op_expr_span: PackageSpan, // For diagnostic purposes only
 ) -> Result<Value, Error> {
-    fn eval_double_div(lhs: f64, rhs: f64, span: PackageSpan) -> Result<Value, Error> {
-        match (lhs, rhs) {
-            (_, 0.0) => Err(EvalError::DivZero(span).into()),
-            (lhs, rhs) => Ok(Value::Double(lhs / rhs)),
-        }
-    }
-
     // Validate that both literals are doubles.
     let (Literal::Double(lhs), Literal::Double(rhs)) = (lhs_literal, rhs_literal) else {
         panic!("at least one literal is not an double: {lhs_literal}, {rhs_literal}");
@@ -4244,7 +4268,15 @@ fn eval_bin_op_with_double_literals(
         BinOp::Add => Ok(Value::Double(lhs + rhs)),
         BinOp::Sub => Ok(Value::Double(lhs - rhs)),
         BinOp::Mul => Ok(Value::Double(lhs * rhs)),
-        BinOp::Div => eval_double_div(lhs, rhs, bin_op_expr_span),
+        BinOp::Div => match (lhs, rhs) {
+            (_, 0.0) => Err(EvalError::DivZero(bin_op_expr_span).into()),
+            (lhs, rhs) => Ok(Value::Double(lhs / rhs)),
+        },
+        BinOp::Mod => match (lhs, rhs) {
+            (_, 0.0) => Err(EvalError::DivZero(bin_op_expr_span).into()),
+            (lhs, rhs) => Ok(Value::Double(lhs % rhs)),
+        },
+        BinOp::Exp => Ok(Value::Double(lhs.powf(rhs))),
         _ => panic!("invalid double operator: {bin_op:?}"),
     }
 }

--- a/source/compiler/qsc_partial_eval/src/tests/debug_metadata.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/debug_metadata.rs
@@ -86,7 +86,7 @@ fn one_measurement() {
             Block 0:Block:
                 Call id(1), args( Pointer, )
                 Call id(2), args( Qubit(0), ) !dbg dbg_location=2
-                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=6
+                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=9
                 Call id(4), args( Integer(1), Tag(0, 3), )
                 Call id(5), args( Result(0), Tag(1, 5), )
                 Return
@@ -101,7 +101,7 @@ fn one_measurement() {
                 [2]: scope=1 location=(1-111297) inlined_at=1
                 [3]: scope=0 location=(2-126)
                 [4]: scope=2 location=(1-112976) inlined_at=3
-                [6]: scope=3 location=(1-114163) inlined_at=4"#]],
+                [9]: scope=3 location=(1-114163) inlined_at=4"#]],
     );
 }
 
@@ -373,17 +373,17 @@ fn result_comparison_to_literal() {
             Block 0:Block:
                 Call id(1), args( Pointer, )
                 Call id(2), args( Qubit(0), ) !dbg dbg_location=2
-                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=6
+                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=9
                 Variable(0, Boolean) = Call id(4), args( Result(0), ) !dbg dbg_location=3
                 Variable(1, Boolean) = Store Variable(0, Boolean)
-                Branch Variable(1, Boolean), 2, 1 !dbg dbg_location=10
+                Branch Variable(1, Boolean), 2, 1 !dbg dbg_location=13
             Block 1:Block:
-                Call id(6), args( Qubit(0), ) !dbg dbg_location=12
+                Call id(6), args( Qubit(0), ) !dbg dbg_location=15
                 Call id(7), args( Integer(1), Tag(0, 3), )
                 Call id(8), args( Result(0), Tag(1, 5), )
                 Return
             Block 2:Block:
-                Call id(5), args( Qubit(0), ) !dbg dbg_location=9
+                Call id(5), args( Qubit(0), ) !dbg dbg_location=12
                 Jump(1)
 
             dbg_scopes:
@@ -398,12 +398,12 @@ fn result_comparison_to_literal() {
                 [2]: scope=1 location=(1-111297) inlined_at=1
                 [3]: scope=0 location=(2-110)
                 [4]: scope=2 location=(1-112976) inlined_at=3
-                [6]: scope=3 location=(1-114163) inlined_at=4
-                [8]: scope=0 location=(2-154)
-                [9]: scope=4 location=(1-134095) inlined_at=8
-                [10]: scope=0 location=(2-125)
-                [11]: scope=0 location=(2-179)
-                [12]: scope=5 location=(1-117367) inlined_at=11"#]],
+                [9]: scope=3 location=(1-114163) inlined_at=4
+                [11]: scope=0 location=(2-154)
+                [12]: scope=4 location=(1-134095) inlined_at=11
+                [13]: scope=0 location=(2-125)
+                [14]: scope=0 location=(2-179)
+                [15]: scope=5 location=(1-117367) inlined_at=14"#]],
     );
 }
 
@@ -434,21 +434,21 @@ fn if_else() {
             Block 0:Block:
                 Call id(1), args( Pointer, )
                 Call id(2), args( Qubit(0), ) !dbg dbg_location=3
-                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=7
+                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=10
                 Variable(0, Boolean) = Call id(4), args( Result(0), ) !dbg dbg_location=4
                 Variable(1, Boolean) = Store Variable(0, Boolean)
-                Branch Variable(1, Boolean), 2, 3 !dbg dbg_location=13
+                Branch Variable(1, Boolean), 2, 3 !dbg dbg_location=16
             Block 1:Block:
-                Call id(3), args( Qubit(1), Result(1), ) !dbg dbg_location=17
+                Call id(3), args( Qubit(1), Result(1), ) !dbg dbg_location=23
                 Call id(7), args( Integer(2), Tag(0, 3), )
                 Call id(8), args( Result(0), Tag(1, 5), )
                 Call id(8), args( Result(1), Tag(2, 5), )
                 Return
             Block 2:Block:
-                Call id(5), args( Qubit(1), ) !dbg dbg_location=10
+                Call id(5), args( Qubit(1), ) !dbg dbg_location=13
                 Jump(1)
             Block 3:Block:
-                Call id(6), args( Qubit(1), ) !dbg dbg_location=12
+                Call id(6), args( Qubit(1), ) !dbg dbg_location=15
                 Jump(1)
 
             dbg_scopes:
@@ -463,15 +463,15 @@ fn if_else() {
                 [3]: scope=1 location=(1-111297) inlined_at=2
                 [4]: scope=0 location=(2-135)
                 [5]: scope=2 location=(1-112976) inlined_at=4
-                [7]: scope=3 location=(1-114163) inlined_at=5
-                [9]: scope=0 location=(2-176)
-                [10]: scope=4 location=(1-134095) inlined_at=9
-                [11]: scope=0 location=(2-212)
-                [12]: scope=5 location=(1-135317) inlined_at=11
-                [13]: scope=0 location=(2-150)
-                [14]: scope=0 location=(2-246)
-                [15]: scope=2 location=(1-112976) inlined_at=14
-                [17]: scope=3 location=(1-114163) inlined_at=15"#]],
+                [10]: scope=3 location=(1-114163) inlined_at=5
+                [12]: scope=0 location=(2-176)
+                [13]: scope=4 location=(1-134095) inlined_at=12
+                [14]: scope=0 location=(2-212)
+                [15]: scope=5 location=(1-135317) inlined_at=14
+                [16]: scope=0 location=(2-150)
+                [17]: scope=0 location=(2-246)
+                [18]: scope=2 location=(1-112976) inlined_at=17
+                [23]: scope=3 location=(1-114163) inlined_at=18"#]],
     );
 }
 
@@ -495,18 +495,18 @@ fn branch_due_to_binop_short_circuit() {
                 Call id(1), args( Pointer, )
                 Call id(2), args( Qubit(0), ) !dbg dbg_location=3
                 Call id(2), args( Qubit(1), ) !dbg dbg_location=5
-                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=9
+                Call id(3), args( Qubit(0), Result(0), ) !dbg dbg_location=12
                 Variable(0, Boolean) = Call id(4), args( Result(0), ) !dbg dbg_location=6
                 Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
                 Variable(2, Boolean) = Store Bool(false)
-                Branch Variable(1, Boolean), 2, 1 !dbg dbg_location=16
+                Branch Variable(1, Boolean), 2, 1 !dbg dbg_location=22
             Block 1:Block:
                 Variable(5, Boolean) = Store Variable(2, Boolean)
                 Call id(5), args( Integer(0), Tag(0, 3), )
                 Return
             Block 2:Block:
-                Call id(3), args( Qubit(1), Result(1), ) !dbg dbg_location=14
-                Variable(3, Boolean) = Call id(4), args( Result(1), ) !dbg dbg_location=11
+                Call id(3), args( Qubit(1), Result(1), ) !dbg dbg_location=20
+                Variable(3, Boolean) = Call id(4), args( Result(1), ) !dbg dbg_location=14
                 Variable(4, Boolean) = Icmp Eq, Variable(3, Boolean), Bool(false)
                 Variable(2, Boolean) = Store Variable(4, Boolean)
                 Jump(1)
@@ -523,10 +523,10 @@ fn branch_due_to_binop_short_circuit() {
                 [5]: scope=1 location=(1-111297) inlined_at=4
                 [6]: scope=0 location=(2-107)
                 [7]: scope=2 location=(1-112976) inlined_at=6
-                [9]: scope=3 location=(1-114163) inlined_at=7
-                [11]: scope=0 location=(2-129)
-                [12]: scope=2 location=(1-112976) inlined_at=11
-                [14]: scope=3 location=(1-114163) inlined_at=12
-                [16]: scope=0 location=(2-127)"#]],
+                [12]: scope=3 location=(1-114163) inlined_at=7
+                [14]: scope=0 location=(2-129)
+                [15]: scope=2 location=(1-112976) inlined_at=14
+                [20]: scope=3 location=(1-114163) inlined_at=15
+                [22]: scope=0 location=(2-127)"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/applications.rs
+++ b/source/compiler/qsc_rca/src/applications.rs
@@ -47,9 +47,22 @@ impl GeneratorSetsBuilder {
         for input_param in input_params {
             let input_param_variants = match input_param.ty {
                 Ty::Array(_) => {
-                    // For parameters of type array, two dynamic variants exist:
+                    // For parameters of type array, three dynamic variants exist:
+                    // - An array with static content and static size.
                     // - An array with dynamic content and static size.
                     // - An array with dynamic content and dynamic size.
+                    let static_content_static_size = ApplicationInstance::new(
+                        input_params,
+                        controls,
+                        return_type,
+                        Some((
+                            input_param.index,
+                            ComputeKind::Dynamic {
+                                runtime_features: RuntimeFeatureFlags::empty(),
+                                value_kind: ValueKind::Constant,
+                            },
+                        )),
+                    );
                     let dynamic_content_static_size = ApplicationInstance::new(
                         input_params,
                         controls,
@@ -74,22 +87,40 @@ impl GeneratorSetsBuilder {
                             },
                         )),
                     );
-                    vec![dynamic_content_static_size, dynamic_content_dynamic_size]
+                    vec![
+                        static_content_static_size,
+                        dynamic_content_static_size,
+                        dynamic_content_dynamic_size,
+                    ]
                 }
                 _ => {
-                    // For non-array params, only one dynamic variant exists.
-                    vec![ApplicationInstance::new(
-                        input_params,
-                        controls,
-                        return_type,
-                        Some((
-                            input_param.index,
-                            ComputeKind::Dynamic {
-                                runtime_features: RuntimeFeatureFlags::empty(),
-                                value_kind: ValueKind::Variable,
-                            },
-                        )),
-                    )]
+                    // For non-array params, we check against both dynamic constant and dynamic variable variants.
+                    vec![
+                        ApplicationInstance::new(
+                            input_params,
+                            controls,
+                            return_type,
+                            Some((
+                                input_param.index,
+                                ComputeKind::Dynamic {
+                                    runtime_features: RuntimeFeatureFlags::empty(),
+                                    value_kind: ValueKind::Constant,
+                                },
+                            )),
+                        ),
+                        ApplicationInstance::new(
+                            input_params,
+                            controls,
+                            return_type,
+                            Some((
+                                input_param.index,
+                                ComputeKind::Dynamic {
+                                    runtime_features: RuntimeFeatureFlags::empty(),
+                                    value_kind: ValueKind::Variable,
+                                },
+                            )),
+                        ),
+                    ]
                 }
             };
             application_instances.push(input_param_variants);
@@ -201,6 +232,15 @@ impl GeneratorSetsBuilder {
                     panic!("expected an array param application");
                 };
                 array_compute_properties
+                    .constant_content
+                    .value_kind
+                    .iter()
+                    .for_each(|value_kind| {
+                        array_param_application
+                            .constant_content
+                            .aggregate_value_kind(*value_kind);
+                    });
+                array_compute_properties
                     .static_size
                     .value_kind
                     .iter()
@@ -226,10 +266,22 @@ impl GeneratorSetsBuilder {
                     panic!("expected an element param application");
                 };
                 element_compute_properties
+                    .constant
                     .value_kind
                     .iter()
                     .for_each(|value_kind| {
-                        element_param_application.aggregate_value_kind(*value_kind);
+                        element_param_application
+                            .constant
+                            .aggregate_value_kind(*value_kind);
+                    });
+                element_compute_properties
+                    .variable
+                    .value_kind
+                    .iter()
+                    .for_each(|value_kind| {
+                        element_param_application
+                            .variable
+                            .aggregate_value_kind(*value_kind);
                     });
             }
         }
@@ -245,8 +297,8 @@ impl GeneratorSetsBuilder {
     }
 
     fn close_param(&mut self, param_index: InputParamIndex) -> ParamApplicationComputeProperties {
-        const DYNAMIC_ELEMENTS_PARAM_VARIANTS: usize = 1;
-        const DYNAMIC_ARRAY_PARAM_VARIANTS: usize = 2;
+        const DYNAMIC_ELEMENTS_PARAM_VARIANTS: usize = 2;
+        const DYNAMIC_ARRAY_PARAM_VARIANTS: usize = 3;
 
         // We need to offset the index since the first top-level vector in application instances is reserved for the
         // inherent variant.
@@ -257,11 +309,20 @@ impl GeneratorSetsBuilder {
 
         // The kind of parameter application we create depends on the number of variants that the parameter has.
         if variants.len() == DYNAMIC_ELEMENTS_PARAM_VARIANTS {
-            let application_instance = variants
+            let variable_compute_properties = variants
                 .pop()
-                .expect("element parameter application instance could not be popped");
-            let compute_properties = application_instance.close();
-            ParamApplicationComputeProperties::Element(compute_properties)
+                .expect("element parameter application instance could not be popped")
+                .close();
+            let constant_compute_properties = variants
+                .pop()
+                .expect("element parameter application instance could not be popped")
+                .close();
+            ParamApplicationComputeProperties::Element(Box::new(
+                ElementParamApplicationComputeProperties {
+                    constant: constant_compute_properties,
+                    variable: variable_compute_properties,
+                },
+            ))
         } else if variants.len() == DYNAMIC_ARRAY_PARAM_VARIANTS {
             // IMPORTANT: the position of each application instance in the variants vector has a specific meaning, so
             // we need the order of pops to remain consistent.
@@ -271,8 +332,12 @@ impl GeneratorSetsBuilder {
             let static_size_application_instance = variants
                 .pop()
                 .expect("array parameter application instance could not be popped");
+            let constant_content_application_instance = variants
+                .pop()
+                .expect("array parameter application instance could not be popped");
             ParamApplicationComputeProperties::Array(Box::new(
                 ArrayParamApplicationComputeProperties {
+                    constant_content: constant_content_application_instance.close(),
                     static_size: static_size_application_instance.close(),
                     dynamic_size: dynamic_size_application_instance.close(),
                 },
@@ -662,7 +727,7 @@ impl ApplicationInstanceComputeProperties {
 }
 
 enum ParamApplicationComputeProperties {
-    Element(ApplicationInstanceComputeProperties),
+    Element(Box<ElementParamApplicationComputeProperties>),
     Array(Box<ArrayParamApplicationComputeProperties>),
 }
 
@@ -670,23 +735,35 @@ impl ParamApplicationComputeProperties {
     fn remove_item(&mut self, item: ApplicationInstanceItem) -> crate::ParamApplication {
         match self {
             Self::Element(compute_properties) => {
-                let compute_kind = compute_properties.remove(item);
-                crate::ParamApplication::Element(compute_kind)
+                let constant_compute_kind = compute_properties.constant.remove(item);
+                let variable_compute_kind = compute_properties.variable.remove(item);
+                crate::ParamApplication::Element(crate::ElementParamApplication {
+                    constant: constant_compute_kind,
+                    variable: variable_compute_kind,
+                })
             }
             Self::Array(array_param) => {
-                let dynamic_content_static_size = array_param.static_size.remove(item);
-                let dynamic_content_dynamic_size = array_param.dynamic_size.remove(item);
+                let constant_content = array_param.constant_content.remove(item);
+                let static_size = array_param.static_size.remove(item);
+                let dynamic_size = array_param.dynamic_size.remove(item);
                 crate::ParamApplication::Array(crate::ArrayParamApplication {
-                    static_size: dynamic_content_static_size,
-                    dynamic_size: dynamic_content_dynamic_size,
+                    constant_content,
+                    static_size,
+                    dynamic_size,
                 })
             }
         }
     }
 }
 
+struct ElementParamApplicationComputeProperties {
+    constant: ApplicationInstanceComputeProperties,
+    variable: ApplicationInstanceComputeProperties,
+}
+
 #[allow(clippy::struct_field_names)]
 struct ArrayParamApplicationComputeProperties {
+    constant_content: ApplicationInstanceComputeProperties,
     static_size: ApplicationInstanceComputeProperties,
     dynamic_size: ApplicationInstanceComputeProperties,
 }

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::{
     ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, ComputePropertiesLookup,
-    ParamApplication, RuntimeFeatureFlags, ValueKind,
+    ElementParamApplication, ParamApplication, RuntimeFeatureFlags, ValueKind,
     applications::{ApplicationInstance, GeneratorSetsBuilder, LocalComputeKind},
     common::{
         AssignmentStmtCounter, Callee, FunctorAppExt, GlobalSpecId, Local, LocalKind,
@@ -2242,13 +2242,17 @@ fn default_application_generator_set_for_callable(
     for param in &callable_context.input_params {
         let param_application = match &param.ty {
             Ty::Array(_) => ParamApplication::Array(ArrayParamApplication {
+                constant_content: ComputeKind::Static,
                 static_size: ComputeKind::Static,
                 dynamic_size: ComputeKind::Dynamic {
                     runtime_features: RuntimeFeatureFlags::UseOfDynamicallySizedArray,
                     value_kind: ValueKind::Variable,
                 },
             }),
-            _ => ParamApplication::Element(ComputeKind::Static),
+            _ => ParamApplication::Element(ElementParamApplication {
+                constant: ComputeKind::Static,
+                variable: ComputeKind::Static,
+            }),
         };
         dynamic_param_applications.push(param_application);
     }
@@ -2268,6 +2272,7 @@ fn derive_intrinsic_function_application_generator_set(
         return ApplicationGeneratorSet {
             inherent: ComputeKind::Static,
             dynamic_param_applications: vec![ParamApplication::Array(ArrayParamApplication {
+                constant_content: ComputeKind::Static,
                 static_size: ComputeKind::Static,
                 dynamic_size: ComputeKind::Dynamic {
                     runtime_features: RuntimeFeatureFlags::UseOfDynamicallySizedArray,
@@ -2300,7 +2305,13 @@ fn derive_intrinsic_function_application_generator_set(
             Ty::Array(_) => {
                 array_param_application_from_runtime_features(runtime_features, value_kind)
             }
-            _ => ParamApplication::Element(param_compute_kind),
+            _ => ParamApplication::Element(ElementParamApplication {
+                constant: ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::empty(),
+                    value_kind: ValueKind::Constant,
+                },
+                variable: param_compute_kind,
+            }),
         };
         dynamic_param_applications.push(param_application);
     }
@@ -2317,6 +2328,7 @@ fn array_param_application_from_runtime_features(
     value_kind: ValueKind,
 ) -> ParamApplication {
     ParamApplication::Array(ArrayParamApplication {
+        constant_content: ComputeKind::Static,
         static_size: ComputeKind::Dynamic {
             runtime_features,
             value_kind,
@@ -2379,7 +2391,13 @@ fn derive_instrinsic_operation_application_generator_set(
             Ty::Array(_) => {
                 array_param_application_from_runtime_features(runtime_features, value_kind)
             }
-            _ => ParamApplication::Element(param_compute_kind),
+            _ => ParamApplication::Element(ElementParamApplication {
+                constant: ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::empty(),
+                    value_kind: ValueKind::Constant,
+                },
+                variable: param_compute_kind,
+            }),
         };
         dynamic_param_applications.push(param_application);
     }

--- a/source/compiler/qsc_rca/src/cyclic_callables.rs
+++ b/source/compiler/qsc_rca/src/cyclic_callables.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 use crate::{
-    ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, ParamApplication,
-    RuntimeFeatureFlags, ValueKind, common::LocalSpecId, cycle_detection::CycleDetector,
-    scaffolding::InternalPackageStoreComputeProperties,
+    ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, ElementParamApplication,
+    ParamApplication, RuntimeFeatureFlags, ValueKind, common::LocalSpecId,
+    cycle_detection::CycleDetector, scaffolding::InternalPackageStoreComputeProperties,
 };
 use qsc_fir::{
     extensions::InputParam,
@@ -155,10 +155,14 @@ impl<'a> Analyzer<'a> {
             // Create a parameter application depending on the parameter type.
             let param_application = match &param.ty {
                 Ty::Array(_) => ParamApplication::Array(ArrayParamApplication {
+                    constant_content: param_compute_kind,
                     static_size: param_compute_kind,
                     dynamic_size: param_compute_kind,
                 }),
-                _ => ParamApplication::Element(param_compute_kind),
+                _ => ParamApplication::Element(ElementParamApplication {
+                    constant: param_compute_kind,
+                    variable: param_compute_kind,
+                }),
             };
             dynamic_param_applications.push(param_application);
         }
@@ -289,10 +293,14 @@ fn create_operation_specialization_application_generator_set(
         // Create a parameter application depending on the parameter type.
         let param_application = match &param.ty {
             Ty::Array(_) => ParamApplication::Array(ArrayParamApplication {
+                constant_content: inherent_compute_kind,
                 static_size: inherent_compute_kind,
                 dynamic_size: inherent_compute_kind,
             }),
-            _ => ParamApplication::Element(inherent_compute_kind),
+            _ => ParamApplication::Element(ElementParamApplication {
+                constant: inherent_compute_kind,
+                variable: inherent_compute_kind,
+            }),
         };
         dynamic_param_applications.push(param_application);
     }

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -458,6 +458,7 @@ impl Display for ArrayParamApplication {
         let mut indent = set_indentation(indented(f), 0);
         write!(indent, "ArrayParamApplication:")?;
         indent = set_indentation(indent, 1);
+        write!(indent, "\nconstant_content: {}", self.constant_content)?;
         write!(indent, "\nstatic_size: {}", self.static_size)?;
         write!(indent, "\ndynamic_size: {}", self.dynamic_size)?;
         Ok(())

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -369,8 +369,15 @@ impl ApplicationGeneratorSet {
         {
             match param_application {
                 ParamApplication::Element(param_compute_kind) => {
-                    if arg_compute_kind.is_variable_value_kind() {
-                        compute_kind = compute_kind.aggregate(*param_compute_kind);
+                    if let ComputeKind::Dynamic { value_kind, .. } = arg_compute_kind {
+                        match value_kind {
+                            ValueKind::Variable => {
+                                compute_kind = compute_kind.aggregate(param_compute_kind.variable);
+                            }
+                            ValueKind::Constant => {
+                                compute_kind = compute_kind.aggregate(param_compute_kind.constant);
+                            }
+                        }
                     }
                 }
                 ParamApplication::Array(array_param_application) => {
@@ -392,7 +399,8 @@ impl ApplicationGeneratorSet {
                                     compute_kind.aggregate(array_param_application.static_size);
                             }
                             ValueKind::Constant => {
-                                // No aggregation needed for static arrays.
+                                compute_kind = compute_kind
+                                    .aggregate(array_param_application.constant_content);
                             }
                         }
                     }
@@ -405,7 +413,7 @@ impl ApplicationGeneratorSet {
 
 #[derive(Clone, Debug)]
 pub enum ParamApplication {
-    Element(ComputeKind),
+    Element(ElementParamApplication),
     Array(ArrayParamApplication),
 }
 
@@ -422,7 +430,25 @@ impl Display for ParamApplication {
 }
 
 #[derive(Clone, Debug)]
+pub struct ElementParamApplication {
+    pub constant: ComputeKind,
+    pub variable: ComputeKind,
+}
+
+impl Display for ElementParamApplication {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut indent = set_indentation(indented(f), 0);
+        write!(indent, "ElementParamApplication:")?;
+        indent = set_indentation(indent, 1);
+        write!(indent, "\nconstant: {}", self.constant)?;
+        write!(indent, "\nvariable: {}", self.variable)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct ArrayParamApplication {
+    pub constant_content: ComputeKind,
     pub static_size: ComputeKind,
     pub dynamic_size: ComputeKind,
 }

--- a/source/compiler/qsc_rca/src/tests.rs
+++ b/source/compiler/qsc_rca/src/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::too_many_lines)]
-
 mod arrays;
 mod assigns;
 mod bindings;

--- a/source/compiler/qsc_rca/src/tests.rs
+++ b/source/compiler/qsc_rca/src/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::too_many_lines)]
+
 mod arrays;
 mod assigns;
 mod bindings;

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// Test snapshots can grow large, so allow long functions here.
+#![allow(clippy::too_many_lines)]
+
 use super::{
     CompilationContext, check_callable_compute_properties, check_last_statement_compute_properties,
 };

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -19,12 +19,20 @@ fn check_rca_for_function_in_core_package() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicallySizedArray | LoopWithDynamicCondition)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicallySizedArray | LoopWithDynamicCondition)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -248,33 +256,49 @@ fn check_rca_for_unrestricted_h() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -292,33 +316,49 @@ fn check_rca_for_base_h() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -336,45 +376,77 @@ fn check_rca_for_unrestricted_r1() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -392,45 +464,77 @@ fn check_rca_for_base_r1() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -448,45 +552,77 @@ fn check_rca_for_unrestricted_rx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -504,45 +640,77 @@ fn check_rca_for_base_rx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -560,57 +728,105 @@ fn check_rca_for_unrestricted_rxx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -628,57 +844,105 @@ fn check_rca_for_base_rxx() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -696,45 +960,77 @@ fn check_rca_for_unrestricted_ry() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -752,45 +1048,77 @@ fn check_rca_for_base_ry() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -808,57 +1136,105 @@ fn check_rca_for_unrestricted_ryy() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -876,57 +1252,105 @@ fn check_rca_for_base_ryy() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -944,45 +1368,77 @@ fn check_rca_for_unrestricted_rz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1000,45 +1456,77 @@ fn check_rca_for_base_rz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1056,57 +1544,105 @@ fn check_rca_for_unrestricted_rzz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1124,57 +1660,105 @@ fn check_rca_for_base_rzz() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1192,33 +1776,49 @@ fn check_rca_for_unrestricted_s() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1236,33 +1836,49 @@ fn check_rca_for_base_s() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1280,33 +1896,49 @@ fn check_rca_for_unrestricted_t() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1324,33 +1956,49 @@ fn check_rca_for_base_t() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1368,33 +2016,49 @@ fn check_rca_for_unrestricted_x() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1412,33 +2076,49 @@ fn check_rca_for_base_x() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1456,33 +2136,49 @@ fn check_rca_for_unrestricted_y() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1500,33 +2196,49 @@ fn check_rca_for_base_y() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1544,33 +2256,49 @@ fn check_rca_for_unrestricted_z() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }
 
@@ -1588,32 +2316,48 @@ fn check_rca_for_base_z() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant"#]],
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/cycles.rs
+++ b/source/compiler/qsc_rca/src/tests/cycles.rs
@@ -447,6 +447,9 @@ fn check_rca_for_function_cycle_within_call_input() {
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
                                 value_kind: Variable
                         [1]: [Parameter Type Array] ArrayParamApplication:
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
                                 value_kind: Variable
@@ -701,6 +704,9 @@ fn check_rca_for_multi_param_recursive_unit_function() {
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
                                 value_kind: Constant
                         [1]: [Parameter Type Array] ArrayParamApplication:
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
                                 value_kind: Constant

--- a/source/compiler/qsc_rca/src/tests/cycles.rs
+++ b/source/compiler/qsc_rca/src/tests/cycles.rs
@@ -23,9 +23,13 @@ fn check_rca_for_one_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -54,9 +58,13 @@ fn check_rca_for_two_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -71,9 +79,13 @@ fn check_rca_for_two_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -104,9 +116,13 @@ fn check_rca_for_three_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -120,9 +136,13 @@ fn check_rca_for_three_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -136,9 +156,13 @@ fn check_rca_for_three_functions_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -164,9 +188,13 @@ fn check_rca_for_indirect_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -194,9 +222,13 @@ fn check_rca_for_indirect_chain_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -222,9 +254,13 @@ fn check_rca_for_indirect_tuple_function_cycle() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -250,9 +286,13 @@ fn check_rca_for_function_cycle_within_binding() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -279,9 +319,13 @@ fn check_rca_for_function_cycle_within_assignment() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -306,9 +350,13 @@ fn check_rca_for_function_cycle_within_return() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -334,9 +382,13 @@ fn check_rca_for_function_cycle_within_tuple() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -387,9 +439,13 @@ fn check_rca_for_function_cycle_within_call_input() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                         [1]: [Parameter Type Array] ArrayParamApplication:
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
@@ -425,9 +481,13 @@ fn check_rca_for_function_cycle_within_if_block() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -456,9 +516,13 @@ fn check_rca_for_function_cycle_within_if_condition() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -486,9 +550,13 @@ fn check_rca_for_function_cycle_within_for_block() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -516,9 +584,13 @@ fn check_rca_for_function_cycle_within_while_block() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -545,9 +617,13 @@ fn check_rca_for_function_cycle_within_while_condition() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -572,15 +648,27 @@ fn check_rca_for_multi_param_recursive_bool_function() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -605,9 +693,13 @@ fn check_rca_for_multi_param_recursive_unit_function() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
                         [1]: [Parameter Type Array] ArrayParamApplication:
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
@@ -615,9 +707,13 @@ fn check_rca_for_multi_param_recursive_unit_function() {
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
                                 value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -644,9 +740,13 @@ fn check_rca_for_result_recursive_operation() {
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -673,18 +773,34 @@ fn check_rca_for_multi_param_result_recursive_operation() {
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
-                        [3]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                        [3]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -711,9 +827,13 @@ fn check_rca_for_operation_body_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -745,17 +865,25 @@ fn check_rca_for_operation_body_adj_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 ctl: <none>
                 ctl-adj: <none>"#]],
     );
@@ -786,18 +914,26 @@ fn check_rca_for_operation_body_ctl_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 ctl-adj: <none>"#]],
     );
 }
@@ -827,18 +963,26 @@ fn check_rca_for_operation_multi_controlled_functor_recursion() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 ctl-adj: <none>"#]],
     );
 }
@@ -863,9 +1007,13 @@ fn check_rca_for_operation_body_recursion_non_unit_return() {
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -895,9 +1043,13 @@ fn check_rca_for_operation_body_recursion_preserves_inherent_capabilities() {
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -933,9 +1085,13 @@ fn check_rca_for_two_operation_cycle() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -952,9 +1108,13 @@ fn check_rca_for_two_operation_cycle() {
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],

--- a/source/compiler/qsc_rca/src/tests/intrinsics.rs
+++ b/source/compiler/qsc_rca/src/tests/intrinsics.rs
@@ -91,6 +91,7 @@ fn check_rca_for_length() {
                     inherent: Static
                     dynamic_param_applications:
                         [0]: [Parameter Type Array] ArrayParamApplication:
+                            constant_content: Static
                             static_size: Static
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
@@ -1317,6 +1318,7 @@ fn check_rca_for_account_for_estimates_internal() {
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Array] ArrayParamApplication:
+                            constant_content: Static
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
                                 value_kind: Constant
@@ -1331,6 +1333,7 @@ fn check_rca_for_account_for_estimates_internal() {
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
                                 value_kind: Constant
                         [2]: [Parameter Type Array] ArrayParamApplication:
+                            constant_content: Static
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant

--- a/source/compiler/qsc_rca/src/tests/intrinsics.rs
+++ b/source/compiler/qsc_rca/src/tests/intrinsics.rs
@@ -38,9 +38,13 @@ fn check_rca_for_quantum_rt_qubit_release() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -61,9 +65,13 @@ fn check_rca_for_quantum_qis_m_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -107,9 +115,13 @@ fn check_rca_for_quantum_qis_mresetz_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -128,9 +140,13 @@ fn check_rca_for_int_as_double() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -149,9 +165,13 @@ fn check_rca_for_int_as_big_int() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -190,9 +210,13 @@ fn check_rca_for_check_zero() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -211,9 +235,13 @@ fn check_rca_for_message() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -232,9 +260,13 @@ fn check_rca_for_arc_cos() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -253,9 +285,13 @@ fn check_rca_for_arc_sin() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -274,9 +310,13 @@ fn check_rca_for_arc_tan() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -295,12 +335,20 @@ fn check_rca_for_arc_tan_2() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -319,9 +367,13 @@ fn check_rca_for_cos() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -340,9 +392,13 @@ fn check_rca_for_cosh() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -361,9 +417,13 @@ fn check_rca_for_sin() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -382,9 +442,13 @@ fn check_rca_for_sinh() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -403,9 +467,13 @@ fn check_rca_for_tan() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -424,9 +492,13 @@ fn check_rca_for_tanh() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -445,9 +517,13 @@ fn check_rca_for_sqrt() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -466,9 +542,13 @@ fn check_rca_for_log() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -487,9 +567,13 @@ fn check_rca_for_truncate() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -510,15 +594,27 @@ fn check_rca_for_quantum_qis_ccx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -539,12 +635,20 @@ fn check_rca_for_quantum_qis_cx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -565,12 +669,20 @@ fn check_rca_for_quantum_qis_cy_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -591,12 +703,20 @@ fn check_rca_for_quantum_qis_cz_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -617,12 +737,20 @@ fn check_rca_for_quantum_qis_rx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -643,15 +771,27 @@ fn check_rca_for_quantum_qis_rxx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -672,12 +812,20 @@ fn check_rca_for_quantum_qis_ry_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -698,15 +846,27 @@ fn check_rca_for_quantum_qis_ryy_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -727,12 +887,20 @@ fn check_rca_for_quantum_qis_rz_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -753,15 +921,27 @@ fn check_rca_for_quantum_qis_rzz_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [2]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -782,9 +962,13 @@ fn check_rca_for_quantum_qis_h_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -805,9 +989,13 @@ fn check_rca_for_quantum_qis_s_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -828,9 +1016,13 @@ fn check_rca_for_quantum_qis_s_adj() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -851,9 +1043,13 @@ fn check_rca_for_quantum_qis_sx_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -874,9 +1070,13 @@ fn check_rca_for_quantum_qis_t_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -897,9 +1097,13 @@ fn check_rca_for_quantum_qis_t_adj() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -920,9 +1124,13 @@ fn check_rca_for_quantum_qis_x_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -943,9 +1151,13 @@ fn check_rca_for_quantum_qis_y_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -966,9 +1178,13 @@ fn check_rca_for_quantum_qis_z_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -989,12 +1205,20 @@ fn check_rca_for_quantum_qis_swap_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1015,9 +1239,13 @@ fn check_rca_for_quantum_qis_reset_body() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1036,12 +1264,20 @@ fn check_rca_for_begin_estimate_caching() {
                 body: ApplicationsGeneratorSet:
                     inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Variable
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Variable
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Variable
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1087,9 +1323,13 @@ fn check_rca_for_account_for_estimates_internal() {
                             dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
                                 value_kind: Constant
-                        [1]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Constant
+                        [1]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Constant
                         [2]: [Parameter Type Array] ArrayParamApplication:
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
@@ -1117,9 +1357,13 @@ fn check_rca_for_begin_repeat_estimates_internal() {
                         runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Dynamic:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Constant
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(0x0)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],

--- a/source/compiler/qsc_rca/src/tests/return_unify_interactions.rs
+++ b/source/compiler/qsc_rca/src/tests/return_unify_interactions.rs
@@ -60,6 +60,9 @@ fn flag_fallback_value_kind_after_dynamic_scope_return() {
                         value_kind: Variable
                     dynamic_param_applications:
                         [0]: [Parameter Type Array] ArrayParamApplication:
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicQubit | UseOfDynamicallySizedArray | MeasurementWithinDynamicScope | UseOfDynamicIndex | LoopWithDynamicCondition | UseOfDynamicResult)
+                                value_kind: Variable
                             static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicQubit | UseOfDynamicArray | UseOfDynamicallySizedArray | MeasurementWithinDynamicScope | UseOfDynamicIndex | LoopWithDynamicCondition | UseOfDynamicResult)
                                 value_kind: Variable

--- a/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
@@ -9,21 +9,21 @@
 define i64 @ENTRYPOINT__main() #0 {
 block_0:
   %var_2 = alloca i64
-  %var_8 = alloca i64
+  %var_9 = alloca i64
   call void @__quantum__rt__initialize(ptr null)
   call void @__quantum__qis__x__body(ptr inttoptr (i64 5 to ptr))
   store i64 0, ptr %var_2
   br label %block_1
 block_1:
-  %var_14 = load i64, ptr %var_2
-  %var_3 = icmp slt i64 %var_14, 5
+  %var_15 = load i64, ptr %var_2
+  %var_3 = icmp slt i64 %var_15, 5
   br i1 %var_3, label %block_2, label %block_3
 block_2:
-  %var_20 = load i64, ptr %var_2
-  %var_4 = getelementptr ptr, ptr @array0, i64 %var_20
-  %var_21 = load ptr, ptr %var_4
-  call void @__quantum__qis__h__body(ptr %var_21)
-  %var_6 = add i64 %var_20, 1
+  %var_21 = load i64, ptr %var_2
+  %var_4 = getelementptr ptr, ptr @array0, i64 %var_21
+  %var_22 = load ptr, ptr %var_4
+  call void @__quantum__qis__h__body(ptr %var_22)
+  %var_6 = add i64 %var_21, 1
   store i64 %var_6, ptr %var_2
   br label %block_1
 block_3:
@@ -31,19 +31,19 @@ block_3:
   call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 5 to ptr))
   call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 5 to ptr))
   call void @__quantum__qis__cx__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 5 to ptr))
-  store i64 4, ptr %var_8
+  store i64 4, ptr %var_9
   br label %block_4
 block_4:
-  %var_16 = load i64, ptr %var_8
-  %var_9 = icmp sge i64 %var_16, 0
-  br i1 %var_9, label %block_5, label %block_6
+  %var_17 = load i64, ptr %var_9
+  %var_10 = icmp sge i64 %var_17, 0
+  br i1 %var_10, label %block_5, label %block_6
 block_5:
-  %var_17 = load i64, ptr %var_8
-  %var_10 = getelementptr ptr, ptr @array0, i64 %var_17
-  %var_18 = load ptr, ptr %var_10
-  call void @__quantum__qis__h__body(ptr %var_18)
-  %var_12 = add i64 %var_17, -1
-  store i64 %var_12, ptr %var_8
+  %var_18 = load i64, ptr %var_9
+  %var_11 = getelementptr ptr, ptr @array0, i64 %var_18
+  %var_19 = load ptr, ptr %var_11
+  call void @__quantum__qis__h__body(ptr %var_19)
+  %var_13 = add i64 %var_18, -1
+  store i64 %var_13, ptr %var_9
   br label %block_4
 block_6:
   call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -9,7 +9,7 @@ use expect_test::{Expect, expect};
 pub const BERNSTEINVAZIRANI_EXPECT: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 29822"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR: Expect = expect!["generated QIR of length 20283"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR: Expect = expect!["generated QIR of length 20291"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =


### PR DESCRIPTION
This change updates how RCA handles dynamic constants across call boundaries. Previously, a dynamic constant would effectively be considered a static value when passed to a call. This worked fine for some cases, but as we enhance RCA to differentiate between static values and dynamic constant values (such as upcoming work on `Result` arrays), we need that difference to propagate properly at analysis time. This fixes #3283.