### PR TITLE
Use internal npm registry in azdo pipeline

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -453,8 +453,10 @@ extends:
                     displayName: Set version
 
                   # Windows arm64
+                  # Skip checking because that would force npm install, which won't work properly until UseNode supports arm64
+                  # https://github.com/microsoft/azure-pipelines-tasks/issues/21743
                   - script: |
-                      python build.py --qdk --no-check-prereqs --no-integration-tests --no-optional-dependencies
+                      python build.py --qdk --no-check --no-check-prereqs --no-integration-tests --no-optional-dependencies
                     displayName: Build Platform-Dependent Py Packages (Windows ARM64)
                     condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -20,6 +20,14 @@ schedules:
 variables:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN_VERSION: "1.95"
+  # CFS requires that we have a .npmrc next to each package.json.  If we set this variable, it will
+  # synthesize everything it requires during the pipeline run, leaving our external contributors
+  # free to continue using the default npmjs.org registry.
+  # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/central-feed-services-cfs/central-feed-services-cfs
+  #
+  # Caveat: the synthesized .npmrc file doesn't seem to contain the necessary token, so we'll have to
+  # use the npmAuthenticate task explicitly.
+  AZURE_ARTIFACTS_FEED: https://pkgs.dev.azure.com/ms-azurequantum/AzureQuantum/_packaging/azure-quantum/npm/registry/
 
 resources:
   repositories:
@@ -125,6 +133,11 @@ extends:
                 inputs:
                   version: "22.x"
 
+              # See the note on AZURE_ARTIFACTS_FEED
+              - task: npmAuthenticate@0
+                inputs:
+                  workingFile: .npmrc
+
               - script: |
                   python ./prereqs.py --install && python ./version.py
                 displayName: Install Prereqs and set version
@@ -177,6 +190,11 @@ extends:
               - task: UseNode@1
                 inputs:
                   version: "22.x"
+
+              # See the note on AZURE_ARTIFACTS_FEED
+              - task: npmAuthenticate@0
+                inputs:
+                  workingFile: .npmrc
 
               - script: |
                   python ./prereqs.py --install && python ./version.py

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -455,13 +455,13 @@ extends:
                   # Windows arm64
                   - script: |
                       python build.py --qdk --no-check-prereqs --no-integration-tests --no-optional-dependencies
-                    displayName: Build Platform-Dependent Py Packages
+                    displayName: Build Platform-Dependent Py Packages (Windows ARM64)
                     condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
 
                   # every other platform
                   - script: |
                       python build.py --qdk --no-check-prereqs --integration-tests
-                    displayName: Build Platform-Dependent Py Packages
+                    displayName: Build Platform-Dependent Py Packages (Other)
                     condition: not(and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64')))
 
                   - script: |

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -322,6 +322,16 @@ extends:
                 inputs:
                   workingFile: .npmrc
 
+              # See the note on AZURE_ARTIFACTS_FEED
+              - task: npmAuthenticate@0
+                inputs:
+                  workingFile: source/jupyterlab/.npmrc
+
+              # See the note on AZURE_ARTIFACTS_FEED
+              - task: npmAuthenticate@0
+                inputs:
+                  workingFile: source/widgets/.npmrc
+
               - script: |
                   python ./prereqs.py --skip-wasm && python ./version.py
                 displayName: Install Prereqs and set version

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -23,7 +23,7 @@ variables:
   # CFS requires that we have a .npmrc next to each package.json.  If we set this variable, it will
   # synthesize everything it requires during the pipeline run, leaving our external contributors
   # free to continue using the default npmjs.org registry.
-  # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/central-feed-services-cfs/central-feed-services-cfs
+  # (To learn more, search eng.ms for AZURE_ARTIFACTS_FEED.)
   #
   # Caveat: the synthesized .npmrc file doesn't seem to contain the necessary token, so we'll have to
   # use the npmAuthenticate task explicitly.

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -317,6 +317,11 @@ extends:
                 inputs:
                   version: "22.x"
 
+              # See the note on AZURE_ARTIFACTS_FEED
+              - task: npmAuthenticate@0
+                inputs:
+                  workingFile: .npmrc
+
               - script: |
                   python ./prereqs.py --skip-wasm && python ./version.py
                 displayName: Install Prereqs and set version
@@ -406,6 +411,11 @@ extends:
                   - task: UseNode@1
                     inputs:
                       version: "22.x"
+
+                  # See the note on AZURE_ARTIFACTS_FEED
+                  - task: npmAuthenticate@0
+                    inputs:
+                      workingFile: .npmrc
 
                   - script: |
                       sudo apt update


### PR DESCRIPTION
CFS requires that we pull packages from our internal package feed.  While perfectly reasonable, doing this unconditionally would create problems for our external contributors, who can't access the feed.  Instead, we leave things as-is on GitHub and update our AzDO pipeline to synthesize the necessary npmrc files.