### PR TITLE
Fix typo in QEC, shor_detect/index.md  - actually not a typo

### DIFF
--- a/katas/content/qec_shor/shor_detect/index.md
+++ b/katas/content/qec_shor/shor_detect/index.md
@@ -26,7 +26,7 @@ Example return values:
 </tr>
 <tr>
 <td>$Y$ error on qubit $4$</td>
-<td>(4, PauliY)</td>
+<td>(1, PauliY)</td>
 </tr>
 <tr>
 <td>$Z$ error on qubit $8$ (last triplet)</td>


### PR DESCRIPTION
It says it should return 1 for qubits 3...5, but in the example it gives a return value of 4 for qubit 4. Corrected to say 1 instead.