### PR TITLE
Add code fix for double literal without dot

### DIFF
--- a/source/language_service/src/code_action.rs
+++ b/source/language_service/src/code_action.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 mod auto_import;
+mod int_to_double;
 mod wrap_in_array;
 mod wrapper_refactor;
 
@@ -43,6 +44,12 @@ pub(crate) fn get_code_actions(
         position_encoding,
     ));
     actions.extend(wrap_in_array::wrap_in_array_fixes(
+        compilation,
+        source_name,
+        span,
+        position_encoding,
+    ));
+    actions.extend(int_to_double::int_to_double_fixes(
         compilation,
         source_name,
         span,

--- a/source/language_service/src/code_action/int_to_double.rs
+++ b/source/language_service/src/code_action/int_to_double.rs
@@ -95,7 +95,7 @@ pub(crate) fn int_to_double_fixes(
     code_actions
 }
 
-/// Finds the AST expression whose span exactly matches `target` and returns its `NodeId`.
+/// Finds the AST expression whose span exactly matches `target`.
 fn find_expr_at(package: &ast::Package, target: Span) -> Option<&ast::Expr> {
     let mut finder = ExprSpanFinder {
         target,

--- a/source/language_service/src/code_action/int_to_double.rs
+++ b/source/language_service/src/code_action/int_to_double.rs
@@ -55,14 +55,8 @@ pub(crate) fn int_to_double_fixes(
             };
 
             // Strip off any + or - unary operators
-            loop {
-                if let ExprKind::UnOp(un_op, expr2) = expr.kind.as_ref()
-                    && (matches!(un_op, UnOp::Pos) || matches!(un_op, UnOp::Neg))
-                {
-                    expr = expr2;
-                } else {
-                    break;
-                }
+            while let ExprKind::UnOp(UnOp::Pos | UnOp::Neg, inner) = expr.kind.as_ref() {
+                expr = inner;
             }
 
             if !matches!(expr.kind.as_ref(), ExprKind::Lit(_)) {

--- a/source/language_service/src/code_action/int_to_double.rs
+++ b/source/language_service/src/code_action/int_to_double.rs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Code action: "Convert to integer literal to double"
+//! Detects when an integer literal is passed where a double is expected and
+//! offers to add a trailing `.` to make it into a double literal.
+
+#[cfg(test)]
+mod tests;
+
+use qsc::{
+    Span,
+    ast::{self, Expr, ExprKind},
+    compile::{ErrorKind, TyInfoKind},
+    hir::ty::Prim,
+    line_column::Encoding,
+};
+
+use super::is_error_relevant;
+use crate::{
+    compilation::Compilation,
+    protocol::{CodeAction, CodeActionKind, TextEdit, WorkspaceEdit},
+    qsc_utils::into_range,
+};
+
+pub(crate) fn int_to_double_fixes(
+    compilation: &Compilation,
+    source_name: &str,
+    span: Span,
+    encoding: Encoding,
+) -> Vec<CodeAction> {
+    let mut code_actions = Vec::new();
+
+    let unit = compilation.user_unit();
+    let package = &unit.ast.package;
+    let source_map = &unit.sources;
+
+    let ty_mismatches = compilation
+        .compile_errors
+        .iter()
+        .filter(|error| is_error_relevant(error, span))
+        .filter_map(|error| match error.error() {
+            ErrorKind::Frontend(frontend_error) => frontend_error.ty_mismatch(),
+            _ => None,
+        });
+
+    for (expected, actual, error_span) in ty_mismatches {
+        // Check if expected is Array(T) and actual is a matching primitive T.
+        // Scoped to primitives to include Qubit, exclude tuples, and provide an intelligible stopping point.
+        if matches!(&expected.kind, TyInfoKind::Prim(Prim::Double))
+            && matches!(&actual.kind, TyInfoKind::Prim(Prim::Int))
+        {
+            // Confirm that it's a literal and not just some expression of type int
+            let Some(expr) = find_expr_at(package, error_span) else {
+                continue;
+            };
+
+            if !matches!(expr.kind.as_ref(), ExprKind::Lit(_)) {
+                continue;
+            }
+
+            // Generate the fix: add a trailing `.`
+            // Note that this depends on the error span excluding surrounding parens
+            // so we don't end up with something like `(q).`.
+            let dot_range = into_range(
+                encoding,
+                Span {
+                    lo: error_span.hi,
+                    hi: error_span.hi,
+                },
+                source_map,
+            );
+
+            code_actions.push(CodeAction {
+                title: "Convert to double literal".to_string(),
+                edit: Some(WorkspaceEdit {
+                    changes: vec![(
+                        source_name.to_string(),
+                        vec![TextEdit {
+                            new_text: ".".to_string(),
+                            range: dot_range,
+                        }],
+                    )],
+                }),
+                kind: Some(CodeActionKind::QuickFix),
+                is_preferred: Some(true),
+            });
+        }
+    }
+
+    code_actions
+}
+
+/// Finds the AST expression whose span exactly matches `target` and returns its `NodeId`.
+fn find_expr_at(package: &ast::Package, target: Span) -> Option<&ast::Expr> {
+    let mut finder = ExprSpanFinder {
+        target,
+        found: None,
+    };
+    ast::visit::Visitor::visit_package(&mut finder, package);
+    finder.found
+}
+
+struct ExprSpanFinder<'a> {
+    target: Span,
+    found: Option<&'a ast::Expr>,
+}
+
+impl<'a> ast::visit::Visitor<'a> for ExprSpanFinder<'a> {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if expr.span == self.target {
+            self.found = Some(expr);
+        } else if self.target.intersection(&expr.span).is_some() {
+            ast::visit::walk_expr(self, expr);
+        }
+    }
+}

--- a/source/language_service/src/code_action/int_to_double.rs
+++ b/source/language_service/src/code_action/int_to_double.rs
@@ -10,7 +10,7 @@ mod tests;
 
 use qsc::{
     Span,
-    ast::{self, Expr, ExprKind},
+    ast::{self, Expr, ExprKind, UnOp},
     compile::{ErrorKind, TyInfoKind},
     hir::ty::Prim,
     line_column::Encoding,
@@ -54,8 +54,12 @@ pub(crate) fn int_to_double_fixes(
                 continue;
             };
 
-            if !matches!(expr.kind.as_ref(), ExprKind::Lit(_)) {
-                continue;
+            match expr.kind.as_ref() {
+                ExprKind::Lit(_) => (),
+                ExprKind::UnOp(un_op, expr)
+                    if (matches!(un_op, UnOp::Pos) || matches!(un_op, UnOp::Neg))
+                        && matches!(expr.kind.as_ref(), ExprKind::Lit(_)) => {}
+                _ => continue,
             }
 
             // Generate the fix: add a trailing `.`

--- a/source/language_service/src/code_action/int_to_double.rs
+++ b/source/language_service/src/code_action/int_to_double.rs
@@ -50,16 +50,23 @@ pub(crate) fn int_to_double_fixes(
             && matches!(&actual.kind, TyInfoKind::Prim(Prim::Int))
         {
             // Confirm that it's a literal and not just some expression of type int
-            let Some(expr) = find_expr_at(package, error_span) else {
+            let Some(mut expr) = find_expr_at(package, error_span) else {
                 continue;
             };
 
-            match expr.kind.as_ref() {
-                ExprKind::Lit(_) => (),
-                ExprKind::UnOp(un_op, expr)
-                    if (matches!(un_op, UnOp::Pos) || matches!(un_op, UnOp::Neg))
-                        && matches!(expr.kind.as_ref(), ExprKind::Lit(_)) => {}
-                _ => continue,
+            // Strip off any + or - unary operators
+            loop {
+                if let ExprKind::UnOp(un_op, expr2) = expr.kind.as_ref()
+                    && (matches!(un_op, UnOp::Pos) || matches!(un_op, UnOp::Neg))
+                {
+                    expr = expr2;
+                } else {
+                    break;
+                }
+            }
+
+            if !matches!(expr.kind.as_ref(), ExprKind::Lit(_)) {
+                continue;
             }
 
             // Generate the fix: add a trailing `.`

--- a/source/language_service/src/code_action/int_to_double.rs
+++ b/source/language_service/src/code_action/int_to_double.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Code action: "Convert to integer literal to double"
+//! Code action: "Convert integer literal to double"
 //! Detects when an integer literal is passed where a double is expected and
 //! offers to add a trailing `.` to make it into a double literal.
 
@@ -45,8 +45,7 @@ pub(crate) fn int_to_double_fixes(
         });
 
     for (expected, actual, error_span) in ty_mismatches {
-        // Check if expected is Array(T) and actual is a matching primitive T.
-        // Scoped to primitives to include Qubit, exclude tuples, and provide an intelligible stopping point.
+        // Check if expected is Double and actual is Int.
         if matches!(&expected.kind, TyInfoKind::Prim(Prim::Double))
             && matches!(&actual.kind, TyInfoKind::Prim(Prim::Int))
         {

--- a/source/language_service/src/code_action/int_to_double/tests.rs
+++ b/source/language_service/src/code_action/int_to_double/tests.rs
@@ -29,7 +29,7 @@ fn get_int_to_double_actions(source: &str) -> (Vec<Location>, Vec<crate::protoco
 }
 
 #[test]
-fn int_literal_to_double() {
+fn int_literal_to_double_fix_offered() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         Foo(1◉◉);
@@ -47,7 +47,7 @@ fn int_literal_to_double() {
 }
 
 #[test]
-fn int_literal_to_double_with_parens() {
+fn int_literal_to_double_with_parens_fix_offered() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         Foo((1◉◉));
@@ -65,7 +65,7 @@ fn int_literal_to_double_with_parens() {
 }
 
 #[test]
-fn int_literal_to_double_with_pos() {
+fn int_literal_to_double_with_pos_fix_offered() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         Foo((+1◉◉));
@@ -83,7 +83,7 @@ fn int_literal_to_double_with_pos() {
 }
 
 #[test]
-fn int_literal_to_double_with_neg() {
+fn int_literal_to_double_with_neg_fix_offered() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         Foo((-1◉◉));
@@ -101,7 +101,7 @@ fn int_literal_to_double_with_neg() {
 }
 
 #[test]
-fn int_literal_to_double_with_neg_neg() {
+fn int_literal_to_double_with_neg_neg_fix_offered() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         Foo((--1◉◉));
@@ -119,7 +119,7 @@ fn int_literal_to_double_with_neg_neg() {
 }
 
 #[test]
-fn int_literal_to_double_with_notb() {
+fn int_literal_to_double_with_notb_fix_not_offered() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         Foo((~~~1));
@@ -131,7 +131,7 @@ fn int_literal_to_double_with_notb() {
 }
 
 #[test]
-fn int_local_to_double() {
+fn int_local_to_double_fix_not_offered() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         let x = 1;
@@ -145,7 +145,7 @@ fn int_local_to_double() {
 
 // We'd like this to work but the TyMismatch flags the whole array, not the elements
 #[test]
-fn int_array_to_double() {
+fn int_array_to_double_fix_not_offered() {
     let source = "namespace A {
     function Foo(d: Double[]) : Unit {
         Foo([1,2,3]);

--- a/source/language_service/src/code_action/int_to_double/tests.rs
+++ b/source/language_service/src/code_action/int_to_double/tests.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::{
+    code_action,
+    test_utils::{compile_project_with_markers_no_cursor, whole_document_range},
+};
+use qsc::{line_column::Encoding, location::Location};
+
+fn get_int_to_double_actions(source: &str) -> (Vec<Location>, Vec<crate::protocol::CodeAction>) {
+    let (compilation, targets) =
+        compile_project_with_markers_no_cursor(&[("<source>", source)], false);
+    let range = whole_document_range(source);
+    let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
+    (
+        targets,
+        actions
+            .into_iter()
+            .filter(|a| a.title == "Convert to double literal")
+            .collect(),
+    )
+}
+
+#[test]
+fn int_literal_to_double() {
+    let source = "namespace A {
+    function Foo(d: Double) : Unit {
+        Foo(1◉◉);
+    }
+}
+";
+    let (locations, actions) = get_int_to_double_actions(source);
+    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
+    let action = &actions[0];
+    let edit = action.edit.as_ref().expect("expected edit");
+    assert_eq!(edit.changes.len(), 1);
+    let (_, text_edits) = &edit.changes[0];
+    assert_eq!(text_edits.len(), locations.len());
+    assert_eq!(text_edits[0].range, locations[0].range);
+    assert_eq!(text_edits[0].new_text, ".");
+}
+
+#[test]
+fn int_literal_to_double_with_parens() {
+    let source = "namespace A {
+    function Foo(d: Double) : Unit {
+        Foo((1◉◉));
+    }
+}
+";
+    let (locations, actions) = get_int_to_double_actions(source);
+    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
+    let action = &actions[0];
+    let edit = action.edit.as_ref().expect("expected edit");
+    assert_eq!(edit.changes.len(), 1);
+    let (_, text_edits) = &edit.changes[0];
+    assert_eq!(text_edits.len(), locations.len());
+    assert_eq!(text_edits[0].range, locations[0].range);
+    assert_eq!(text_edits[0].new_text, ".");
+}
+
+#[test]
+fn int_local_to_double() {
+    let source = "namespace A {
+    function Foo(d: Double) : Unit {
+        let x = 1;
+        Foo((x◉◉));
+    }
+}
+";
+    let (_, actions) = get_int_to_double_actions(source);
+    assert_eq!(actions.len(), 0, "Expected 0 actions, got: {actions:?}");
+}

--- a/source/language_service/src/code_action/int_to_double/tests.rs
+++ b/source/language_service/src/code_action/int_to_double/tests.rs
@@ -7,6 +7,13 @@ use crate::{
 };
 use qsc::{line_column::Encoding, location::Location};
 
+fn expect_single<T: std::fmt::Debug>(items: &[T]) -> &T {
+    let [item] = items else {
+        panic!("expected a single item, got: {items:?}");
+    };
+    item
+}
+
 fn get_int_to_double_actions(source: &str) -> (Vec<Location>, Vec<crate::protocol::CodeAction>) {
     let (compilation, targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
@@ -30,14 +37,13 @@ fn int_literal_to_double() {
 }
 ";
     let (locations, actions) = get_int_to_double_actions(source);
-    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
-    let action = &actions[0];
+    let action = expect_single(&actions);
     let edit = action.edit.as_ref().expect("expected edit");
-    assert_eq!(edit.changes.len(), 1);
-    let (_, text_edits) = &edit.changes[0];
-    assert_eq!(text_edits.len(), locations.len());
-    assert_eq!(text_edits[0].range, locations[0].range);
-    assert_eq!(text_edits[0].new_text, ".");
+    let (_, text_edits) = expect_single(&edit.changes);
+    let text_edit = expect_single(text_edits);
+    let location = expect_single(&locations);
+    assert_eq!(text_edit.range, location.range);
+    assert_eq!(text_edit.new_text, ".");
 }
 
 #[test]
@@ -49,14 +55,61 @@ fn int_literal_to_double_with_parens() {
 }
 ";
     let (locations, actions) = get_int_to_double_actions(source);
-    assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
-    let action = &actions[0];
+    let action = expect_single(&actions);
     let edit = action.edit.as_ref().expect("expected edit");
-    assert_eq!(edit.changes.len(), 1);
-    let (_, text_edits) = &edit.changes[0];
-    assert_eq!(text_edits.len(), locations.len());
-    assert_eq!(text_edits[0].range, locations[0].range);
-    assert_eq!(text_edits[0].new_text, ".");
+    let (_, text_edits) = expect_single(&edit.changes);
+    let text_edit = expect_single(text_edits);
+    let location = expect_single(&locations);
+    assert_eq!(text_edit.range, location.range);
+    assert_eq!(text_edit.new_text, ".");
+}
+
+#[test]
+fn int_literal_to_double_with_pos() {
+    let source = "namespace A {
+    function Foo(d: Double) : Unit {
+        Foo((+1◉◉));
+    }
+}
+";
+    let (locations, actions) = get_int_to_double_actions(source);
+    let action = expect_single(&actions);
+    let edit = action.edit.as_ref().expect("expected edit");
+    let (_, text_edits) = expect_single(&edit.changes);
+    let text_edit = expect_single(text_edits);
+    let location = expect_single(&locations);
+    assert_eq!(text_edit.range, location.range);
+    assert_eq!(text_edit.new_text, ".");
+}
+
+#[test]
+fn int_literal_to_double_with_neg() {
+    let source = "namespace A {
+    function Foo(d: Double) : Unit {
+        Foo((-1◉◉));
+    }
+}
+";
+    let (locations, actions) = get_int_to_double_actions(source);
+    let action = expect_single(&actions);
+    let edit = action.edit.as_ref().expect("expected edit");
+    let (_, text_edits) = expect_single(&edit.changes);
+    let text_edit = expect_single(text_edits);
+    let location = expect_single(&locations);
+    assert_eq!(text_edit.range, location.range);
+    assert_eq!(text_edit.new_text, ".");
+}
+
+#[test]
+fn int_literal_to_double_with_notb() {
+    let source = "namespace A {
+    function Foo(d: Double) : Unit {
+        Foo((~~~1◉◉));
+    }
+}
+";
+    let (_, actions) = get_int_to_double_actions(source);
+    assert_eq!(actions.len(), 0, "Expected 0 actions, got: {actions:?}");
 }
 
 #[test]

--- a/source/language_service/src/code_action/int_to_double/tests.rs
+++ b/source/language_service/src/code_action/int_to_double/tests.rs
@@ -101,10 +101,28 @@ fn int_literal_to_double_with_neg() {
 }
 
 #[test]
+fn int_literal_to_double_with_neg_neg() {
+    let source = "namespace A {
+    function Foo(d: Double) : Unit {
+        Foo((--1◉◉));
+    }
+}
+";
+    let (locations, actions) = get_int_to_double_actions(source);
+    let action = expect_single(&actions);
+    let edit = action.edit.as_ref().expect("expected edit");
+    let (_, text_edits) = expect_single(&edit.changes);
+    let text_edit = expect_single(text_edits);
+    let location = expect_single(&locations);
+    assert_eq!(text_edit.range, location.range);
+    assert_eq!(text_edit.new_text, ".");
+}
+
+#[test]
 fn int_literal_to_double_with_notb() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
-        Foo((~~~1◉◉));
+        Foo((~~~1));
     }
 }
 ";
@@ -117,7 +135,20 @@ fn int_local_to_double() {
     let source = "namespace A {
     function Foo(d: Double) : Unit {
         let x = 1;
-        Foo((x◉◉));
+        Foo((x));
+    }
+}
+";
+    let (_, actions) = get_int_to_double_actions(source);
+    assert_eq!(actions.len(), 0, "Expected 0 actions, got: {actions:?}");
+}
+
+// We'd like this to work but the TyMismatch flags the whole array, not the elements
+#[test]
+fn int_array_to_double() {
+    let source = "namespace A {
+    function Foo(d: Double[]) : Unit {
+        Foo([1,2,3]);
     }
 }
 ";

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -22,7 +22,7 @@ fn get_wrap_in_array_actions(source: &str) -> (Vec<Location>, Vec<crate::protoco
 }
 
 #[test]
-fn single_arg_qubit_to_qubit_array() {
+fn single_arg_qubit_to_qubit_array_fix_offered() {
     let source = "namespace A {
     operation Foo(qs: Qubit[]) : Unit is Adj {
         use q = Qubit();
@@ -43,7 +43,7 @@ fn single_arg_qubit_to_qubit_array() {
 }
 
 #[test]
-fn multi_arg_second_param_is_array() {
+fn multi_arg_second_param_is_array_fix_offered() {
     let source = "namespace A {
     operation Bar(x: Int, qs: Qubit[]) : Unit {
         use q = Qubit();
@@ -64,7 +64,7 @@ fn multi_arg_second_param_is_array() {
 }
 
 #[test]
-fn no_action_when_types_already_match() {
+fn types_already_match_fix_not_offered() {
     let source = "namespace A {
     operation Foo(qs: Qubit[]) : Unit is Adj {
         use q = Qubit();
@@ -77,7 +77,7 @@ fn no_action_when_types_already_match() {
 }
 
 #[test]
-fn no_action_for_unrelated_mismatch() {
+fn unrelated_mismatch_fix_not_offered() {
     // Int passed where String expected - should NOT offer wrap in array.
     let source = "namespace A {
     function Foo(s: String) : Unit {}
@@ -91,7 +91,7 @@ fn no_action_for_unrelated_mismatch() {
 }
 
 #[test]
-fn no_action_for_tuple_to_tuple_array() {
+fn tuple_to_tuple_array_fix_not_offered() {
     // (Qubit, Qubit) passed where (Qubit, Qubit)[] expected - not a primitive type.
     let source = "namespace A {
     operation Foo(qs: (Qubit, Qubit)[]) : Unit {}
@@ -106,7 +106,7 @@ fn no_action_for_tuple_to_tuple_array() {
 }
 
 #[test]
-fn no_action_for_array_to_nested_array() {
+fn array_to_nested_array_fix_not_offered() {
     // Qubit[] passed where Qubit[][] expected - the expression type is Qubit[] (not
     // a primitive), so the code action should not be offered.
     let source = "namespace A {
@@ -121,7 +121,7 @@ fn no_action_for_array_to_nested_array() {
 }
 
 #[test]
-fn no_action_for_arrow_to_arrow_array() {
+fn arrow_to_arrow_array_fix_not_offered() {
     // An operation value passed where ((Qubit) => Unit)[] expected - not a primitive type.
     let source = "namespace A {
     operation MyOp(q: Qubit) : Unit {}
@@ -136,7 +136,7 @@ fn no_action_for_arrow_to_arrow_array() {
 }
 
 #[test]
-fn no_action_for_param_to_param_array() {
+fn param_to_param_array_fix_not_offered() {
     // A generic type parameter passed where 'T[] expected - not a primitive type.
     let source = "namespace A {
     operation Foo<'T>(ts: 'T[]) : Unit {}
@@ -150,7 +150,7 @@ fn no_action_for_param_to_param_array() {
 }
 
 #[test]
-fn no_action_for_udt_to_udt_array() {
+fn udt_to_udt_array_fix_not_offered() {
     // A UDT value passed where MyType[] expected - not a primitive type.
     let source = "namespace A {
     newtype MyType = Int;

--- a/source/language_service/src/code_action/wrap_in_array/tests.rs
+++ b/source/language_service/src/code_action/wrap_in_array/tests.rs
@@ -5,17 +5,20 @@ use crate::{
     code_action,
     test_utils::{compile_project_with_markers_no_cursor, whole_document_range},
 };
-use qsc::line_column::Encoding;
+use qsc::{line_column::Encoding, location::Location};
 
-fn get_wrap_in_array_actions(source: &str) -> Vec<crate::protocol::CodeAction> {
-    let (compilation, _targets) =
+fn get_wrap_in_array_actions(source: &str) -> (Vec<Location>, Vec<crate::protocol::CodeAction>) {
+    let (compilation, targets) =
         compile_project_with_markers_no_cursor(&[("<source>", source)], false);
     let range = whole_document_range(source);
     let actions = code_action::get_code_actions(&compilation, "<source>", range, Encoding::Utf8);
-    actions
-        .into_iter()
-        .filter(|a| a.title == "Convert to single-element array")
-        .collect()
+    (
+        targets,
+        actions
+            .into_iter()
+            .filter(|a| a.title == "Convert to single-element array")
+            .collect(),
+    )
 }
 
 #[test]
@@ -23,18 +26,20 @@ fn single_arg_qubit_to_qubit_array() {
     let source = "namespace A {
     operation Foo(qs: Qubit[]) : Unit is Adj {
         use q = Qubit();
-        Foo(q);
+        Foo(◉◉q◉◉);
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (locations, actions) = get_wrap_in_array_actions(source);
     assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
     let action = &actions[0];
     let edit = action.edit.as_ref().expect("expected edit");
     let (_, text_edits) = &edit.changes[0];
-    assert_eq!(text_edits.len(), 2);
+    assert_eq!(text_edits.len(), locations.len());
     assert_eq!(text_edits[0].new_text, "[");
+    assert_eq!(text_edits[0].range, locations[0].range);
     assert_eq!(text_edits[1].new_text, "]");
+    assert_eq!(text_edits[1].range, locations[1].range);
 }
 
 #[test]
@@ -42,18 +47,20 @@ fn multi_arg_second_param_is_array() {
     let source = "namespace A {
     operation Bar(x: Int, qs: Qubit[]) : Unit {
         use q = Qubit();
-        Bar(1, q);
+        Bar(1, ◉◉q◉◉);
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (locations, actions) = get_wrap_in_array_actions(source);
     assert_eq!(actions.len(), 1, "Expected 1 action, got: {actions:?}");
     let action = &actions[0];
     let edit = action.edit.as_ref().expect("expected edit");
     let (_, text_edits) = &edit.changes[0];
-    assert_eq!(text_edits.len(), 2);
+    assert_eq!(text_edits.len(), locations.len());
     assert_eq!(text_edits[0].new_text, "[");
+    assert_eq!(text_edits[0].range, locations[0].range);
     assert_eq!(text_edits[1].new_text, "]");
+    assert_eq!(text_edits[1].range, locations[1].range);
 }
 
 #[test]
@@ -65,7 +72,7 @@ fn no_action_when_types_already_match() {
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (_, actions) = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }
 
@@ -79,7 +86,7 @@ fn no_action_for_unrelated_mismatch() {
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (_, actions) = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }
 
@@ -94,7 +101,7 @@ fn no_action_for_tuple_to_tuple_array() {
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (_, actions) = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }
 
@@ -109,7 +116,7 @@ fn no_action_for_array_to_nested_array() {
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (_, actions) = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }
 
@@ -124,7 +131,7 @@ fn no_action_for_arrow_to_arrow_array() {
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (_, actions) = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }
 
@@ -138,7 +145,7 @@ fn no_action_for_param_to_param_array() {
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (_, actions) = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }
 
@@ -153,6 +160,6 @@ fn no_action_for_udt_to_udt_array() {
     }
 }
 ";
-    let actions = get_wrap_in_array_actions(source);
+    let (_, actions) = get_wrap_in_array_actions(source);
     assert!(actions.is_empty(), "Expected no actions, got: {actions:?}");
 }


### PR DESCRIPTION
It's very easy to write `2` when you mean `2.`.  Offer a code fix.