### PR TITLE
[QRE] Use context keyword

### DIFF
--- a/source/qdk_package/qdk/qre/interop/_cirq.py
+++ b/source/qdk_package/qdk/qre/interop/_cirq.py
@@ -279,7 +279,7 @@ class _CirqTraceBuilder:
                     for sub_op in gate._to_trace(self, op):  # type: ignore
                         self.handle_op(sub_op)
                 elif hasattr(gate, "_decompose_with_context_"):
-                    for sub_op in gate._decompose_with_context_(op.qubits, self.decomp_context):  # type: ignore
+                    for sub_op in gate._decompose_with_context_(op.qubits, context=self.decomp_context):  # type: ignore
                         self.handle_op(sub_op)
                 elif hasattr(gate, "_decompose_"):
                     # decompose the gate and handle the resulting operations recursively


### PR DESCRIPTION
In Cirq, the [decompose](https://github.com/quantumlib/Cirq/blob/8cb539e2fd7df2b2ce5934a13c64ecfbab347953/cirq-core/cirq/protocols/decompose_protocol.py#L123) protocol defines defines `_decompose_with_context_` as:

```
def _decompose_with_context_(self, *, context: DecompositionContext) -> DecomposeResult:
    pass
```

Some gates inside cirq library take context as third positional argument named "context", others take it as keyword-only argument named "context" (i.e. preceded by asterisk).

We must pass "context" as keyword argument when calling `_decompose_with_context_` to match the Cirq protocol. Otherwise, this fails with gates where "context" is keyword-only argument, such as `_InverseCompositeGate`.
