### PR TITLE
Fix for reading `qdk.qir.profile` pragma in playground

### DIFF
--- a/source/compiler/qsc/src/openqasm.rs
+++ b/source/compiler/qsc/src/openqasm.rs
@@ -53,6 +53,7 @@ pub struct CompileRawQasmResult(
     pub Vec<(PackageId, Option<std::sync::Arc<str>>)>,
     pub Option<OperationSignature>,
     pub Vec<crate::compile::Error>,
+    pub Option<Profile>,
 );
 
 #[must_use]
@@ -113,7 +114,14 @@ pub fn compile_openqasm_with_profile_override(
         compile_errors
     };
 
-    CompileRawQasmResult(store, source_package_id, dependencies, sig, surfaced_errors)
+    CompileRawQasmResult(
+        store,
+        source_package_id,
+        dependencies,
+        sig,
+        surfaced_errors,
+        profile_override.or(pragma_profile),
+    )
 }
 
 #[must_use]

--- a/source/language_service/src/compilation.rs
+++ b/source/language_service/src/compilation.rs
@@ -253,7 +253,7 @@ impl Compilation {
         let res = qsc::openqasm::semantic::parse_sources(&sources);
         let unit = compile_to_qsharp_ast_with_config(res, config);
         let target_profile = unit.profile().unwrap_or(Profile::Unrestricted);
-        let CompileRawQasmResult(store, source_package_id, _, _sig, mut compile_errors) =
+        let CompileRawQasmResult(store, source_package_id, _, _sig, mut compile_errors, _) =
             qsc::openqasm::compile_openqasm(unit, package_type);
 
         let compile_unit = store

--- a/source/wasm/src/lib.rs
+++ b/source/wasm/src/lib.rs
@@ -784,13 +784,19 @@ fn get_configured_interpreter_from_openqasm(
         .expect("There should be at least one source");
     let mut resolver = sources.iter().cloned().collect::<InMemorySourceResolver>();
 
-    let CompileRawQasmResult(store, source_package_id, dependencies, sig, errors) =
+    let CompileRawQasmResult(store, source_package_id, dependencies, sig, errors, profile) =
         qsc::openqasm::parse_and_compile_raw_qasm(
             source.clone(),
             file.clone(),
             Some(&mut resolver),
             PackageType::Exe,
         );
+
+    let capabilities = if let Some(profile) = profile {
+        profile.into()
+    } else {
+        capabilities
+    };
 
     if !errors.is_empty() {
         return Err(errors


### PR DESCRIPTION
This propagates the recently updated logic for detecting and respecting the `#pragma qdk.qir.profile` setting from within OpenQASM source into the playground so that the behavior of the RIR and QIR tabs matches expectation. Specifically:
 - If pragma, use that as profile
 - Else when no pragme default to Adaptive_RIF