### PR TITLE
Always lower into single HIR stmt from AST

### DIFF
--- a/source/compiler/qsc_frontend/src/compile/tests.rs
+++ b/source/compiler/qsc_frontend/src/compile/tests.rs
@@ -1482,3 +1482,25 @@ fn export_namespace_with_same_name_as_newtype_does_not_cause_panic() {
     let unit = default_compile(sources);
     expect!["[]"].assert_eq(&format!("{:?}", unit.errors));
 }
+
+#[test]
+fn export_multiple_items_from_local_scope_does_not_cause_panic() {
+    let sources = SourceMap::new(
+        [(
+            "test".into(),
+            indoc! {"
+                function A() : Unit {}
+                function B() : Unit {}
+                function C() : Unit {
+                    export A, B;
+                }
+            "}
+            .into(),
+        )],
+        None,
+    );
+
+    let unit = default_compile(sources);
+    expect!["[Error(Resolve(ExportFromLocalScope(Span { lo: 72, hi: 84 })))]"]
+        .assert_eq(&format!("{:?}", unit.errors));
+}

--- a/source/compiler/qsc_frontend/src/lower.rs
+++ b/source/compiler/qsc_frontend/src/lower.rs
@@ -654,26 +654,31 @@ impl With<'_> {
             stmts: block
                 .stmts
                 .iter()
-                .flat_map(|s| self.lower_stmt(s))
+                .filter_map(|s| self.lower_stmt(s))
                 .collect(),
         }
     }
 
-    pub(super) fn lower_stmt(&mut self, stmt: &ast::Stmt) -> Vec<hir::Stmt> {
+    pub(super) fn lower_stmt(&mut self, stmt: &ast::Stmt) -> Option<hir::Stmt> {
         let id = self.lower_id(stmt.id);
-        let mut stmts = Vec::new();
-        match &*stmt.kind {
-            ast::StmtKind::Empty | ast::StmtKind::Err => {}
-            ast::StmtKind::Expr(expr) => stmts.push(hir::StmtKind::Expr(self.lower_expr(expr))),
+        let stmt_kind = match &*stmt.kind {
+            ast::StmtKind::Empty | ast::StmtKind::Err => None,
+            ast::StmtKind::Expr(expr) => Some(hir::StmtKind::Expr(self.lower_expr(expr))),
             ast::StmtKind::Item(item) => {
-                stmts.extend(self.lower_item(item).into_iter().map(hir::StmtKind::Item));
+                // The only kind of item that can result in multiple lowered entries is an export, and those are invalid
+                // from statements. Only lower the first one to prevent a duplicate ID panic and allow the normal name
+                // resolution error to occur.
+                self.lower_item(item)
+                    .drain(..)
+                    .next()
+                    .map(hir::StmtKind::Item)
             }
-            ast::StmtKind::Local(mutability, lhs, rhs) => stmts.push(hir::StmtKind::Local(
+            ast::StmtKind::Local(mutability, lhs, rhs) => Some(hir::StmtKind::Local(
                 lower_mutability(*mutability),
                 self.lower_pat(lhs),
                 self.lower_expr(rhs),
             )),
-            ast::StmtKind::Qubit(source, lhs, rhs, block) => stmts.push(hir::StmtKind::Qubit(
+            ast::StmtKind::Qubit(source, lhs, rhs, block) => Some(hir::StmtKind::Qubit(
                 match source {
                     ast::QubitSource::Fresh => hir::QubitSource::Fresh,
                     ast::QubitSource::Dirty => hir::QubitSource::Dirty,
@@ -682,17 +687,14 @@ impl With<'_> {
                 self.lower_qubit_init(rhs),
                 block.as_ref().map(|b| self.lower_block(b)),
             )),
-            ast::StmtKind::Semi(expr) => stmts.push(hir::StmtKind::Semi(self.lower_expr(expr))),
-        }
+            ast::StmtKind::Semi(expr) => Some(hir::StmtKind::Semi(self.lower_expr(expr))),
+        };
 
-        stmts
-            .into_iter()
-            .map(|kind| hir::Stmt {
-                id,
-                span: stmt.span,
-                kind,
-            })
-            .collect()
+        stmt_kind.map(|kind| hir::Stmt {
+            id,
+            span: stmt.span,
+            kind,
+        })
     }
 
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
The duplicate stmt id panic was because multi-exports produce two items during lowering (ie: `export a, b;` effectively becomes `export a` and `export b`) that then get turned into two HIR stmts with the same node id. Since `export` items as stmts are always invalid there is no reason to reproduce all of them, so this updates the lowerer to only produce the first item-as-stmt so that the previous name-resolution-time error can be reported and the panic avoided. Fixes #3369