### PR TITLE
Fix npmAuthenticate in Release stage

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -510,7 +510,7 @@ extends:
                   artifactName: VSIX
                   targetPath: $(System.DefaultWorkingDirectory)/target/vscode
             steps:
-              # We don't want to check this in because it won't work for external contributors.
+              # We don't want to check this .npmrc in because it won't work for external contributors.
               # Unlike in the build stage, there doesn't seem to be a task that consumes AZURE_ARTIFACTS_FEED
               # and creates the compliant .npmrc files, so just make a simple one inline.
               - script: |

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -510,6 +510,14 @@ extends:
                   artifactName: VSIX
                   targetPath: $(System.DefaultWorkingDirectory)/target/vscode
             steps:
+              # We don't want to check this in because it won't work for external contributors.
+              # Unlike in the build stage, there doesn't seem to be a task that consumes AZURE_ARTIFACTS_FEED
+              # and creates the compliant .npmrc files, so just make a simple one inline.
+              - script: |
+                  echo "registry=$(AZURE_ARTIFACTS_FEED)" > .npmrc
+                  echo "always-auth=true" >> .npmrc
+                displayName: Create .npmrc
+
               # See the note on AZURE_ARTIFACTS_FEED
               - task: npmAuthenticate@0
                 inputs:


### PR DESCRIPTION
It appears that, unlike the Build stage, the Release stage doesn't have an injected Secure Supply Chain Analysis task, so nothing reads AZURE_ARTIFACTS_FEED and creates the necessary .npmrc files.  Manually create the one required for the stage.