### PR TITLE
OpenQASM parser optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ name = "qdk_openqasm_parser"
 version = "0.0.0"
 dependencies = [
  "bitflags 2.11.0",
+ "criterion 0.8.2",
  "enum-iterator",
  "expect-test",
  "indenter",

--- a/source/compiler/qsc_openqasm_compiler/src/ast_builder.rs
+++ b/source/compiler/qsc_openqasm_compiler/src/ast_builder.rs
@@ -13,13 +13,13 @@ use qsc_ast::ast::{
 };
 use qsc_data_structures::span::Span;
 
-use qdk_openqasm_parser::{
-    parser::ast::{List, list_from_iter},
-    semantic::types::Type,
-    stdlib::angle::Angle,
-};
+use qdk_openqasm_parser::{semantic::types::Type, stdlib::angle::Angle};
 
 use crate::types::{ArrayDimensions, Complex};
+
+fn list_from_iter<T>(iter: impl IntoIterator<Item = T>) -> Box<[Box<T>]> {
+    iter.into_iter().map(Box::new).collect()
+}
 
 pub(crate) fn build_managed_qubit_alloc<S>(
     name: S,
@@ -1464,7 +1464,7 @@ pub(crate) fn build_function_or_operation(
     return_type: Ty,
     kind: CallableKind,
     functors: Option<FunctorExpr>,
-    attrs: List<Attr>,
+    attrs: Box<[Box<Attr>]>,
 ) -> Stmt {
     let args = cargs
         .into_iter()

--- a/source/compiler/qsc_openqasm_compiler/src/compiler.rs
+++ b/source/compiler/qsc_openqasm_compiler/src/compiler.rs
@@ -88,6 +88,10 @@ fn err_expr(span: Span) -> qsast::Expr {
     }
 }
 
+fn boxed_list_from_iter<T>(iter: impl IntoIterator<Item = T>) -> Box<[Box<T>]> {
+    iter.into_iter().map(Box::new).collect()
+}
+
 #[must_use]
 pub fn parse_and_compile_to_qsharp_ast_with_config<
     R: SourceResolver,
@@ -670,9 +674,9 @@ impl QasmCompiler {
         }
     }
 
-    fn compile_stmts(&mut self, stmts: &[Box<qdk_openqasm_parser::semantic::ast::Stmt>]) {
+    fn compile_stmts(&mut self, stmts: &[qdk_openqasm_parser::semantic::ast::Stmt]) {
         for stmt in stmts {
-            let compiled_stmt = self.compile_stmt(stmt.as_ref());
+            let compiled_stmt = self.compile_stmt(stmt);
             if let Some(stmt) = compiled_stmt {
                 self.stmts.push(stmt);
             }
@@ -914,7 +918,7 @@ impl QasmCompiler {
         let block = qsast::Block {
             id: Default::default(),
             span: rhs_span,
-            stmts: list_from_iter(vec![temp_var_stmt, update_stmt, implicit_return]),
+            stmts: boxed_list_from_iter(vec![temp_var_stmt, update_stmt, implicit_return]),
         };
 
         let rhs = qsast::Expr {
@@ -962,7 +966,7 @@ impl QasmCompiler {
 
         let block = qsast::Block {
             id: qsast::NodeId::default(),
-            stmts: list_from_iter(stmts),
+            stmts: boxed_list_from_iter(stmts),
             span: stmt.span,
         };
 
@@ -977,7 +981,7 @@ impl QasmCompiler {
             .collect::<Vec<_>>();
         qsast::Block {
             id: qsast::NodeId::default(),
-            stmts: list_from_iter(stmts),
+            stmts: boxed_list_from_iter(stmts),
             span: block.span,
         }
     }
@@ -1093,9 +1097,7 @@ impl QasmCompiler {
         if let Some(annotation) = annotations
             .iter()
             .find(|annotation| Self::is_noise_intrinsic(annotation))
-            && !annotations
-                .iter()
-                .any(|annotation| Self::is_simulatable_intrinsic(annotation))
+            && !annotations.iter().any(Self::is_simulatable_intrinsic)
         {
             attrs.push(build_attr(
                 QSHARP_QIR_INTRINSIC_ANNOTATION,
@@ -1117,7 +1119,7 @@ impl QasmCompiler {
             return_type,
             kind,
             None,
-            list_from_iter(attrs),
+            boxed_list_from_iter(attrs),
         ))
     }
 
@@ -1519,9 +1521,7 @@ impl QasmCompiler {
         if let Some(annotation) = annotations
             .iter()
             .find(|annotation| Self::is_noise_intrinsic(annotation))
-            && !annotations
-                .iter()
-                .any(|annotation| Self::is_simulatable_intrinsic(annotation))
+            && !annotations.iter().any(Self::is_simulatable_intrinsic)
         {
             attrs.push(build_attr(
                 QSHARP_QIR_INTRINSIC_ANNOTATION,
@@ -1532,10 +1532,7 @@ impl QasmCompiler {
 
         // Determine which functors this gate needs based on how it's called.
         // Do not compile functors if we have the simulatable intrinsic annotation.
-        let functors = if annotations
-            .iter()
-            .any(|annotation| Self::is_simulatable_intrinsic(annotation))
-        {
+        let functors = if annotations.iter().any(Self::is_simulatable_intrinsic) {
             None
         } else {
             // Use the constraint solver results to determine required functors.
@@ -1561,7 +1558,7 @@ impl QasmCompiler {
             build_path_ident_ty("Unit"),
             qsast::CallableKind::Operation,
             functors,
-            list_from_iter(attrs),
+            boxed_list_from_iter(attrs),
         ))
     }
 
@@ -1761,7 +1758,7 @@ impl QasmCompiler {
                 let block_stmt = self.compile_stmt(&stmt.body)?;
                 let block = qsast::Block {
                     id: qsast::NodeId::default(),
-                    stmts: list_from_iter([block_stmt]),
+                    stmts: boxed_list_from_iter([block_stmt]),
                     span: stmt.span,
                 };
                 Some(build_while_stmt(condition, block, stmt.span))
@@ -2824,7 +2821,7 @@ impl QasmCompiler {
             .map(|(name, ast_ty, pat, sym_type)| (name, ast_ty.clone(), pat.span, sym_type))
             .collect::<Vec<_>>();
         let stmts = Self::get_argument_validation_stmts(&args);
-        let stmts = list_from_iter(stmts);
+        let stmts = boxed_list_from_iter(stmts);
         body.stmts = stmts.into_iter().chain(body.stmts).collect();
 
         Some(body)

--- a/source/qdk_openqasm_parser/Cargo.toml
+++ b/source/qdk_openqasm_parser/Cargo.toml
@@ -3,6 +3,7 @@ name = "qdk_openqasm_parser"
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
+autobenches = false
 edition.workspace = true
 license.workspace = true
 version.workspace = true
@@ -28,8 +29,17 @@ rustc-hash = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true, features = ["cargo_bench_support"] }
 expect-test = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-syscall"] }
+
+[[bin]]
+name = "qasm_memtest"
+path = "src/bin/qasm_memtest.rs"
+
+[[bench]]
+name = "qasm_pipeline"
+harness = false
 
 [lints]
 workspace = true

--- a/source/qdk_openqasm_parser/benches/corpus.rs
+++ b/source/qdk_openqasm_parser/benches/corpus.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{fmt::Write as _, sync::Arc};
+
+use qdk_openqasm_parser::io::InMemorySourceResolver;
+
+#[derive(Clone, Debug)]
+pub struct Corpus {
+    pub name: &'static str,
+    pub source: Arc<str>,
+    pub path: Arc<str>,
+    pub statement_count: usize,
+    includes: Vec<(Arc<str>, Arc<str>)>,
+}
+
+impl Corpus {
+    #[must_use]
+    pub fn resolver(&self) -> InMemorySourceResolver {
+        self.includes.iter().cloned().collect()
+    }
+}
+
+#[must_use]
+pub fn flat_gate(repetitions: usize) -> Corpus {
+    let mut source = String::new();
+    source.push_str("OPENQASM 3.0;\n");
+    source.push_str("include \"stdgates.inc\";\n");
+    source.push_str("qubit q0;\n");
+    source.push_str("qubit q1;\n");
+    source.push_str("bit c0;\n");
+
+    for index in 0..repetitions {
+        source.push_str("h q0;\n");
+        source.push_str("cx q0, q1;\n");
+        source.push_str("rz(0.125) q1;\n");
+        if index.is_multiple_of(8) {
+            source.push_str("c0 = measure q1;\n");
+            source.push_str("reset q1;\n");
+        }
+    }
+
+    let measured_cycles = repetitions.div_ceil(8);
+    Corpus {
+        name: "flat_gate",
+        source: Arc::from(source),
+        path: Arc::from("flat_gate.qasm"),
+        statement_count: 5 + (3 * repetitions) + (2 * measured_cycles),
+        includes: Vec::new(),
+    }
+}
+
+#[must_use]
+pub fn broadcast_gate(repetitions: usize, register_width: usize) -> Corpus {
+    let mut source = String::new();
+    source.push_str("OPENQASM 3.0;\n");
+    source.push_str("include \"stdgates.inc\";\n");
+    let _ = writeln!(source, "qubit[{register_width}] left;");
+    let _ = writeln!(source, "qubit[{register_width}] right;");
+
+    for _ in 0..repetitions {
+        source.push_str("h left;\n");
+        source.push_str("cx left, right;\n");
+        source.push_str("rz(0.25) right;\n");
+    }
+
+    Corpus {
+        name: "broadcast_gate",
+        source: Arc::from(source),
+        path: Arc::from("broadcast_gate.qasm"),
+        statement_count: 4 + (3 * repetitions),
+        includes: Vec::new(),
+    }
+}
+
+#[must_use]
+pub fn include_heavy(include_count: usize, statements_per_include: usize) -> Corpus {
+    let mut source = String::new();
+    source.push_str("OPENQASM 3.0;\n");
+    source.push_str("include \"stdgates.inc\";\n");
+    source.push_str("qubit q;\n");
+
+    let mut includes = Vec::with_capacity(include_count);
+    for include_index in 0..include_count {
+        let path = format!("bench/include_{include_index}.inc");
+        let _ = writeln!(source, "include \"{path}\";");
+        let _ = writeln!(source, "g{include_index} q;");
+
+        let mut include_source = String::new();
+        let _ = writeln!(include_source, "gate g{include_index} target {{");
+        for statement_index in 0..statements_per_include {
+            if statement_index.is_multiple_of(3) {
+                include_source.push_str("    h target;\n");
+            } else if statement_index.is_multiple_of(3_usize.saturating_sub(1)) {
+                include_source.push_str("    rz(0.0625) target;\n");
+            } else {
+                include_source.push_str("    x target;\n");
+            }
+        }
+        include_source.push_str("}\n");
+        includes.push((Arc::from(path), Arc::from(include_source)));
+    }
+
+    Corpus {
+        name: "include_heavy",
+        source: Arc::from(source),
+        path: Arc::from("include_heavy.qasm"),
+        statement_count: 3 + (2 * include_count) + (include_count * statements_per_include),
+        includes,
+    }
+}

--- a/source/qdk_openqasm_parser/benches/qasm_pipeline.rs
+++ b/source/qdk_openqasm_parser/benches/qasm_pipeline.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use qdk_openqasm_parser::{analyze_source, parse_source, semantic::lower_parse_result};
+
+mod corpus;
+
+use corpus::{Corpus, broadcast_gate, flat_gate, include_heavy};
+
+fn assert_parse_success(corpus: &Corpus, result: &qdk_openqasm_parser::parser::QasmParseResult) {
+    assert!(
+        !result.has_errors(),
+        "{} parse corpus produced {} errors",
+        corpus.name,
+        result.all_errors().len()
+    );
+}
+
+fn assert_semantic_success(
+    corpus: &Corpus,
+    result: &qdk_openqasm_parser::semantic::QasmSemanticParseResult,
+) {
+    assert!(
+        !result.has_errors(),
+        "{} semantic corpus produced {} errors",
+        corpus.name,
+        result.all_errors().len()
+    );
+}
+
+fn parse(corpus: &Corpus) -> qdk_openqasm_parser::parser::QasmParseResult {
+    let mut resolver = corpus.resolver();
+    let result = parse_source(
+        corpus.source.clone(),
+        corpus.path.clone(),
+        Some(&mut resolver),
+    );
+    assert_parse_success(corpus, &result);
+    result
+}
+
+fn analyze(corpus: &Corpus) -> qdk_openqasm_parser::semantic::QasmSemanticParseResult {
+    let mut resolver = corpus.resolver();
+    let result = analyze_source(
+        corpus.source.clone(),
+        corpus.path.clone(),
+        Some(&mut resolver),
+    );
+    assert_semantic_success(corpus, &result);
+    result
+}
+
+fn bench_corpus(c: &mut Criterion, corpus: &Corpus) {
+    let mut group = c.benchmark_group(corpus.name);
+    group.throughput(criterion::Throughput::Elements(
+        corpus.statement_count.try_into().unwrap_or(u64::MAX),
+    ));
+
+    group.bench_function("parse", |b| {
+        b.iter(|| black_box(parse(black_box(corpus))));
+    });
+
+    group.bench_function("semantic_lower", |b| {
+        b.iter_batched(
+            || parse(corpus),
+            |parse_result| {
+                let result = lower_parse_result(parse_result);
+                assert_semantic_success(corpus, &result);
+                black_box(result);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("analyze", |b| {
+        b.iter(|| black_box(analyze(black_box(corpus))));
+    });
+
+    group.finish();
+}
+
+pub fn qasm_pipeline(c: &mut Criterion) {
+    for corpus in [
+        flat_gate(1_024),
+        broadcast_gate(256, 32),
+        include_heavy(64, 8),
+    ] {
+        bench_corpus(c, &corpus);
+    }
+}
+
+criterion_group!(benches, qasm_pipeline);
+criterion_main!(benches);

--- a/source/qdk_openqasm_parser/src/bin/qasm_memtest.rs
+++ b/source/qdk_openqasm_parser/src/bin/qasm_memtest.rs
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    env,
+    process::ExitCode,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use qdk_openqasm_parser::{analyze_source, parse_source, semantic::lower_parse_result};
+
+#[path = "../../benches/corpus.rs"]
+mod corpus;
+
+use corpus::{Corpus, broadcast_gate, flat_gate, include_heavy};
+
+struct AllocationCounter<A: GlobalAlloc> {
+    allocator: A,
+    current_bytes: AtomicU64,
+    peak_bytes: AtomicU64,
+    allocated_bytes: AtomicU64,
+    deallocated_bytes: AtomicU64,
+    allocation_count: AtomicU64,
+    deallocation_count: AtomicU64,
+}
+
+unsafe impl<A: GlobalAlloc> GlobalAlloc for AllocationCounter<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { self.allocator.alloc(layout) };
+        if !pointer.is_null() {
+            self.record_alloc(layout.size() as u64);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { self.allocator.dealloc(ptr, layout) };
+        self.record_dealloc(layout.size() as u64);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let pointer = unsafe { self.allocator.realloc(ptr, layout, new_size) };
+        if !pointer.is_null() {
+            let old_size = layout.size() as u64;
+            let new_size = new_size as u64;
+            if new_size >= old_size {
+                self.record_alloc(new_size - old_size);
+            } else {
+                self.record_dealloc(old_size - new_size);
+            }
+        }
+        pointer
+    }
+}
+
+impl<A: GlobalAlloc> AllocationCounter<A> {
+    const fn new(allocator: A) -> Self {
+        Self {
+            allocator,
+            current_bytes: AtomicU64::new(0),
+            peak_bytes: AtomicU64::new(0),
+            allocated_bytes: AtomicU64::new(0),
+            deallocated_bytes: AtomicU64::new(0),
+            allocation_count: AtomicU64::new(0),
+            deallocation_count: AtomicU64::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.current_bytes.store(0, Ordering::SeqCst);
+        self.peak_bytes.store(0, Ordering::SeqCst);
+        self.allocated_bytes.store(0, Ordering::SeqCst);
+        self.deallocated_bytes.store(0, Ordering::SeqCst);
+        self.allocation_count.store(0, Ordering::SeqCst);
+        self.deallocation_count.store(0, Ordering::SeqCst);
+    }
+
+    fn snapshot(&self) -> MemoryStats {
+        MemoryStats {
+            peak_bytes: self.peak_bytes.load(Ordering::SeqCst),
+            net_live_bytes: self.current_bytes.load(Ordering::SeqCst),
+            allocated_bytes: self.allocated_bytes.load(Ordering::SeqCst),
+            deallocated_bytes: self.deallocated_bytes.load(Ordering::SeqCst),
+            allocation_count: self.allocation_count.load(Ordering::SeqCst),
+            deallocation_count: self.deallocation_count.load(Ordering::SeqCst),
+        }
+    }
+
+    fn record_alloc(&self, bytes: u64) {
+        let current = self.current_bytes.fetch_add(bytes, Ordering::SeqCst) + bytes;
+        self.allocated_bytes.fetch_add(bytes, Ordering::SeqCst);
+        self.allocation_count.fetch_add(1, Ordering::SeqCst);
+        let mut peak = self.peak_bytes.load(Ordering::SeqCst);
+        while current > peak {
+            match self.peak_bytes.compare_exchange(
+                peak,
+                current,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => break,
+                Err(new_peak) => peak = new_peak,
+            }
+        }
+    }
+
+    fn record_dealloc(&self, bytes: u64) {
+        self.current_bytes.fetch_sub(bytes, Ordering::SeqCst);
+        self.deallocated_bytes.fetch_add(bytes, Ordering::SeqCst);
+        self.deallocation_count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MemoryStats {
+    peak_bytes: u64,
+    net_live_bytes: u64,
+    allocated_bytes: u64,
+    deallocated_bytes: u64,
+    allocation_count: u64,
+    deallocation_count: u64,
+}
+
+#[derive(Clone, Copy)]
+enum Stage {
+    Parse,
+    SemanticLower,
+    Analyze,
+    SemanticLowerBroadcast,
+    AnalyzeBroadcast,
+    ParseInclude,
+    SemanticLowerInclude,
+    AnalyzeInclude,
+}
+
+#[global_allocator]
+static ALLOCATOR: AllocationCounter<System> = AllocationCounter::new(System);
+
+fn main() -> ExitCode {
+    match try_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("{message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn try_main() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    let stage = args
+        .next()
+        .as_deref()
+        .map(parse_stage)
+        .transpose()?
+        .unwrap_or(Stage::Analyze);
+    let iterations = args
+        .next()
+        .map(|arg| {
+            arg.parse::<usize>()
+                .map_err(|error| format!("invalid iteration count '{arg}': {error}"))
+        })
+        .transpose()?
+        .unwrap_or(1);
+
+    if iterations == 0 {
+        return Err("iteration count must be greater than zero".into());
+    }
+
+    let corpus = stage.corpus();
+
+    ALLOCATOR.reset();
+    for _ in 0..iterations {
+        run_stage(stage, &corpus)?;
+    }
+    let stats = ALLOCATOR.snapshot();
+    print_stats(stage.name(), &corpus, iterations, stats);
+    Ok(())
+}
+
+fn parse_stage(stage: &str) -> Result<Stage, String> {
+    match stage {
+        "parse" => Ok(Stage::Parse),
+        "semantic-lower" => Ok(Stage::SemanticLower),
+        "analyze" => Ok(Stage::Analyze),
+        "semantic-lower-broadcast" => Ok(Stage::SemanticLowerBroadcast),
+        "analyze-broadcast" => Ok(Stage::AnalyzeBroadcast),
+        "parse-include" => Ok(Stage::ParseInclude),
+        "semantic-lower-include" => Ok(Stage::SemanticLowerInclude),
+        "analyze-include" => Ok(Stage::AnalyzeInclude),
+        _ => Err(format!(
+            "unknown stage '{stage}'. expected parse, semantic-lower, analyze, semantic-lower-broadcast, analyze-broadcast, parse-include, semantic-lower-include, or analyze-include"
+        )),
+    }
+}
+
+impl Stage {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Parse => "parse",
+            Self::SemanticLower => "semantic-lower",
+            Self::Analyze => "analyze",
+            Self::SemanticLowerBroadcast => "semantic-lower-broadcast",
+            Self::AnalyzeBroadcast => "analyze-broadcast",
+            Self::ParseInclude => "parse-include",
+            Self::SemanticLowerInclude => "semantic-lower-include",
+            Self::AnalyzeInclude => "analyze-include",
+        }
+    }
+
+    fn corpus(self) -> Corpus {
+        match self {
+            Self::SemanticLowerBroadcast | Self::AnalyzeBroadcast => broadcast_gate(256, 32),
+            Self::ParseInclude | Self::SemanticLowerInclude | Self::AnalyzeInclude => {
+                include_heavy(64, 8)
+            }
+            Self::Parse | Self::SemanticLower | Self::Analyze => flat_gate(1_024),
+        }
+    }
+}
+
+fn run_stage(stage: Stage, corpus: &Corpus) -> Result<(), String> {
+    match stage {
+        Stage::SemanticLower | Stage::SemanticLowerBroadcast | Stage::SemanticLowerInclude => {
+            let parse_result = parse(corpus)?;
+            let result = lower_parse_result(parse_result);
+            ensure_semantic_success(corpus, &result)?;
+            std::hint::black_box(result);
+        }
+        Stage::Analyze | Stage::AnalyzeBroadcast | Stage::AnalyzeInclude => {
+            analyze(corpus)?;
+        }
+        Stage::Parse | Stage::ParseInclude => {
+            parse(corpus)?;
+        }
+    }
+    Ok(())
+}
+
+fn parse(corpus: &Corpus) -> Result<qdk_openqasm_parser::parser::QasmParseResult, String> {
+    let mut resolver = corpus.resolver();
+    let result = parse_source(
+        corpus.source.clone(),
+        corpus.path.clone(),
+        Some(&mut resolver),
+    );
+    ensure_parse_success(corpus, &result)?;
+    Ok(std::hint::black_box(result))
+}
+
+fn analyze(
+    corpus: &Corpus,
+) -> Result<qdk_openqasm_parser::semantic::QasmSemanticParseResult, String> {
+    let mut resolver = corpus.resolver();
+    let result = analyze_source(
+        corpus.source.clone(),
+        corpus.path.clone(),
+        Some(&mut resolver),
+    );
+    ensure_semantic_success(corpus, &result)?;
+    Ok(std::hint::black_box(result))
+}
+
+fn ensure_parse_success(
+    corpus: &Corpus,
+    result: &qdk_openqasm_parser::parser::QasmParseResult,
+) -> Result<(), String> {
+    if result.has_errors() {
+        return Err(format!(
+            "{} parse corpus produced {} errors",
+            corpus.name,
+            result.all_errors().len()
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_semantic_success(
+    corpus: &Corpus,
+    result: &qdk_openqasm_parser::semantic::QasmSemanticParseResult,
+) -> Result<(), String> {
+    if result.has_errors() {
+        return Err(format!(
+            "{} semantic corpus produced {} errors",
+            corpus.name,
+            result.all_errors().len()
+        ));
+    }
+    Ok(())
+}
+
+fn print_stats(stage: &str, corpus: &Corpus, iterations: usize, stats: MemoryStats) {
+    println!("stage: {stage}");
+    println!("corpus: {}", corpus.name);
+    println!("statements: {}", corpus.statement_count);
+    println!("iterations: {iterations}");
+    println!("peak_bytes: {}", stats.peak_bytes);
+    println!("net_live_bytes: {}", stats.net_live_bytes);
+    println!("allocated_bytes: {}", stats.allocated_bytes);
+    println!("deallocated_bytes: {}", stats.deallocated_bytes);
+    println!("allocation_count: {}", stats.allocation_count);
+    println!("deallocation_count: {}", stats.deallocation_count);
+}

--- a/source/qdk_openqasm_parser/src/parser.rs
+++ b/source/qdk_openqasm_parser/src/parser.rs
@@ -102,7 +102,9 @@ fn update_offsets(source_map: &SourceMap, source: &mut QasmSource) {
         .for_each(|e| *e = e.clone().with_offset(offset));
     // Update the program's spans with the offset
     let mut offsetter = Offsetter(offset);
-    offsetter.visit_program(&mut source.program);
+    if let Some(program) = &mut source.program {
+        offsetter.visit_program(program);
+    }
 
     // Recursively update the includes, their programs, and errors
     for include in source.includes_mut() {
@@ -155,8 +157,9 @@ pub struct QasmSource {
     path: Arc<str>,
     /// The source code of the file.
     source: Arc<str>,
-    /// The parsed AST of the source file or any parse errors.
-    program: Program,
+    /// The parsed AST of the source file, or `None` once it has been dropped (for
+    /// example after semantic lowering, which no longer needs the syntax tree).
+    program: Option<Program>,
     /// Any parse errors that occurred.
     errors: Vec<Error>,
     /// Any included files that were resolved.
@@ -176,7 +179,7 @@ impl QasmSource {
         QasmSource {
             path,
             source,
-            program,
+            program: Some(program),
             errors,
             included,
         }
@@ -209,8 +212,20 @@ impl QasmSource {
     }
 
     #[must_use]
-    pub fn program(&self) -> &Program {
-        &self.program
+    pub fn program(&self) -> Option<&Program> {
+        self.program.as_ref()
+    }
+
+    /// Drops the parsed syntax tree once it is no longer needed (for example after
+    /// semantic lowering, which produces its own program). Diagnostics rely on the
+    /// source text, the stored parse errors, and the source map rather than the
+    /// syntax tree, so dropping the program avoids retaining a full syntax AST
+    /// alongside the lowered semantic program. Applied recursively to includes.
+    pub(crate) fn drop_program(&mut self) {
+        self.program = None;
+        for include in &mut self.included {
+            include.drop_program();
+        }
     }
 
     #[must_use]
@@ -393,11 +408,11 @@ where
                     QasmSource {
                         path: file_path.clone(),
                         source: Default::default(),
-                        program: Program {
+                        program: Some(Program {
                             span: Span::default(),
                             statements: vec![].into_boxed_slice(),
                             version: None,
-                        },
+                        }),
                         errors: vec![],
                         included: vec![],
                     }

--- a/source/qdk_openqasm_parser/src/parser.rs
+++ b/source/qdk_openqasm_parser/src/parser.rs
@@ -45,10 +45,8 @@ pub struct QasmParseResult {
 
 impl QasmParseResult {
     #[must_use]
-    pub fn new(source: QasmSource) -> QasmParseResult {
-        let source_map = create_source_map(&source);
-        let mut source = source;
-        update_offsets(&source_map, &mut source);
+    pub fn new(mut source: QasmSource) -> QasmParseResult {
+        let source_map = create_source_map_and_update_offsets(&mut source);
         QasmParseResult { source, source_map }
     }
 
@@ -58,25 +56,25 @@ impl QasmParseResult {
     }
 
     pub fn all_errors(&self) -> Vec<WithSource<crate::error::Error>> {
-        let mut self_errors = self.errors();
-        let include_errors = self
-            .source
-            .includes()
-            .iter()
-            .flat_map(QasmSource::all_errors)
-            .map(|e| self.map_error(e))
-            .collect::<Vec<_>>();
+        let mut errors = self.errors();
+        errors.extend(
+            self.source
+                .includes()
+                .iter()
+                .flat_map(QasmSource::all_errors)
+                .map(|e| self.map_error(e)),
+        );
 
-        self_errors.extend(include_errors);
-        self_errors
+        errors
     }
 
     #[must_use]
     pub fn errors(&self) -> Vec<WithSource<crate::error::Error>> {
         self.source
-            .errors()
+            .errors
             .iter()
-            .map(|e| self.map_error(e.clone()))
+            .cloned()
+            .map(|e| self.map_error(e))
             .collect::<Vec<_>>()
     }
 
@@ -88,13 +86,14 @@ impl QasmParseResult {
     }
 }
 
-/// all spans and errors spans are relative to the start of the file
-/// We need to update the spans based on the offset of the file in the source map.
-/// We have to do this after a full parse as we don't know what files will be loaded
-/// until we have parsed all the includes.
-fn update_offsets(source_map: &SourceMap, source: &mut QasmSource) {
-    let source_file = source_map.find_by_name(&source.path());
-    let offset = source_file.map_or(0, |source| source.offset);
+/// All spans and error spans are relative to the start of their own file. Update
+/// them to match the offsets `SourceMap` assigns while collecting files in the same
+/// order `SourceMap` receives them.
+fn collect_source_files_and_update_offsets(
+    source: &mut QasmSource,
+    files: &mut Vec<(Arc<str>, Arc<str>)>,
+    offset: u32,
+) -> u32 {
     // Update the errors' offset
     source
         .errors
@@ -106,10 +105,14 @@ fn update_offsets(source_map: &SourceMap, source: &mut QasmSource) {
         offsetter.visit_program(program);
     }
 
-    // Recursively update the includes, their programs, and errors
-    for include in source.includes_mut() {
-        update_offsets(source_map, include);
+    files.push((source.path.clone(), source.source.clone()));
+
+    let mut next_offset = next_source_offset(offset, &source.source);
+    for include in &mut source.included {
+        next_offset = collect_source_files_and_update_offsets(include, files, next_offset);
     }
+
+    next_offset
 }
 
 /// Parse a QASM file and return the parse result.
@@ -130,23 +133,16 @@ pub fn parse_source<R: SourceResolver, S: Into<Arc<str>>, P: Into<Arc<str>>>(
     QasmParseResult::new(res)
 }
 
-/// Creates a Q# source map from a QASM parse output. The `QasmSource`
-/// has all of the recursive includes resolved with their own source
-/// and parse results.
-fn create_source_map(source: &QasmSource) -> SourceMap {
+/// Creates a Q# source map from a QASM parse output while updating source and
+/// include spans to match the offsets assigned by the source map.
+fn create_source_map_and_update_offsets(source: &mut QasmSource) -> SourceMap {
     let mut files: Vec<(Arc<str>, Arc<str>)> = Vec::new();
-    collect_source_files(source, &mut files);
+    collect_source_files_and_update_offsets(source, &mut files, 0);
     SourceMap::new(files, None)
 }
 
-/// Recursively collect all source files from the includes
-fn collect_source_files(source: &QasmSource, files: &mut Vec<(Arc<str>, Arc<str>)>) {
-    files.push((source.path(), source.source()));
-    // Collect all source files from the includes, this
-    // begins the recursive process of collecting all source files.
-    for include in source.includes() {
-        collect_source_files(include, files);
-    }
+fn next_source_offset(offset: u32, source: &str) -> u32 {
+    1 + offset + u32::try_from(source.len()).expect("contents length should fit into u32")
 }
 
 /// Represents a QASM source file that has been parsed.
@@ -187,28 +183,34 @@ impl QasmSource {
 
     #[must_use]
     pub fn has_errors(&self) -> bool {
-        if !self.errors().is_empty() {
+        if !self.errors.is_empty() {
             return true;
         }
-        self.includes().iter().any(QasmSource::has_errors)
+        self.included.iter().any(QasmSource::has_errors)
     }
 
     #[must_use]
     pub fn all_errors(&self) -> Vec<crate::parser::Error> {
-        let mut self_errors = self.errors();
-        let include_errors = self.includes().iter().flat_map(QasmSource::all_errors);
-        self_errors.extend(include_errors);
-        self_errors
+        let mut errors = Vec::new();
+        self.collect_errors(&mut errors);
+        errors
+    }
+
+    fn collect_errors(&self, errors: &mut Vec<crate::parser::Error>) {
+        errors.extend(self.errors.iter().cloned());
+        for include in &self.included {
+            include.collect_errors(errors);
+        }
     }
 
     #[must_use]
     pub fn includes(&self) -> &Vec<QasmSource> {
-        self.included.as_ref()
+        &self.included
     }
 
     #[must_use]
     pub fn includes_mut(&mut self) -> &mut Vec<QasmSource> {
-        self.included.as_mut()
+        &mut self.included
     }
 
     #[must_use]
@@ -380,10 +382,7 @@ where
             let file_path = &include.filename;
             // Skip the standard gates include file.
             // Handling of this file is done by the compiler.
-            if matches!(
-                file_path.to_lowercase().as_ref(),
-                "stdgates.inc" | "qelib1.inc" | "qdk.inc"
-            ) {
+            if is_standard_include(file_path.as_ref()) {
                 continue;
             }
             let source = match parse_qasm_file(file_path, resolver, stmt.span) {
@@ -423,6 +422,12 @@ where
     }
 
     (includes, errors)
+}
+
+fn is_standard_include(path: &str) -> bool {
+    path.eq_ignore_ascii_case("stdgates.inc")
+        || path.eq_ignore_ascii_case("qelib1.inc")
+        || path.eq_ignore_ascii_case("qdk.inc")
 }
 
 pub(crate) type Result<T> = std::result::Result<T, crate::parser::error::Error>;

--- a/source/qdk_openqasm_parser/src/parser.rs
+++ b/source/qdk_openqasm_parser/src/parser.rs
@@ -148,7 +148,7 @@ fn collect_source_files(source: &QasmSource, files: &mut Vec<(Arc<str>, Arc<str>
 }
 
 /// Represents a QASM source file that has been parsed.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct QasmSource {
     /// The path to the source file. This is used for error reporting.
     /// This path is just a name, it does not have to exist on disk.

--- a/source/qdk_openqasm_parser/src/parser/ast.rs
+++ b/source/qdk_openqasm_parser/src/parser/ast.rs
@@ -17,11 +17,13 @@ use std::{
 
 use super::prim::SeqItem;
 
-/// An alternative to `Vec<T>` that uses less stack space.
-pub type List<T> = Box<[Box<T>]>;
+/// A boxed slice used in place of `Vec<T>`: a thin (pointer + length) handle that
+/// stores its elements inline, avoiding `Vec`'s capacity word and the per-element
+/// heap allocation a `Box<[Box<T>]>` would incur.
+pub type List<T> = Box<[T]>;
 
 pub fn list_from_iter<T>(vals: impl IntoIterator<Item = T>) -> List<T> {
-    vals.into_iter().map(Box::new).collect()
+    vals.into_iter().collect()
 }
 
 #[derive(Clone, Debug, Default)]

--- a/source/qdk_openqasm_parser/src/parser/ast.rs
+++ b/source/qdk_openqasm_parser/src/parser/ast.rs
@@ -24,7 +24,7 @@ pub fn list_from_iter<T>(vals: impl IntoIterator<Item = T>) -> List<T> {
     vals.into_iter().map(Box::new).collect()
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Program {
     pub span: Span,
     pub statements: List<Stmt>,

--- a/source/qdk_openqasm_parser/src/parser/expr.rs
+++ b/source/qdk_openqasm_parser/src/parser/expr.rs
@@ -228,10 +228,12 @@ fn lit_token(lexeme: &str, token: Token) -> Result<Option<Lit>> {
                 }
             }
             Literal::Float => {
-                let lexeme = lexeme.replace('_', "");
-                let value: f64 = lexeme
-                    .parse()
-                    .map_err(|_| Error::new(ErrorKind::Lit("floating-point", token.span)))?;
+                let value: f64 = if lexeme.contains('_') {
+                    lexeme.replace('_', "").parse()
+                } else {
+                    lexeme.parse()
+                }
+                .map_err(|_| Error::new(ErrorKind::Lit("floating-point", token.span)))?;
                 // Reject NaN, Infinity, and Neg-Infinity to ensure only finite floating-point literals are accepted.
                 if !value.is_finite() {
                     return Err(Error::new(ErrorKind::Lit("floating-point", token.span)));

--- a/source/qdk_openqasm_parser/src/parser/expr.rs
+++ b/source/qdk_openqasm_parser/src/parser/expr.rs
@@ -441,7 +441,7 @@ fn funcall(s: &mut ParserContext, ident: Ident) -> Result<ExprKind> {
     Ok(ExprKind::FunctionCall(FunctionCall {
         span: s.span(lo),
         name: ident,
-        args: args.into_iter().map(Box::new).collect(),
+        args: args.into_iter().collect(),
     }))
 }
 

--- a/source/qdk_openqasm_parser/src/parser/mut_visit.rs
+++ b/source/qdk_openqasm_parser/src/parser/mut_visit.rs
@@ -552,11 +552,11 @@ fn walk_pragma_stmt(vis: &mut impl MutVisitor, stmt: &mut Pragma) {
 fn walk_quantum_gate_definition_stmt(vis: &mut impl MutVisitor, stmt: &mut QuantumGateDefinition) {
     vis.visit_span(&mut stmt.span);
     vis.visit_ident(&mut stmt.ident);
-    stmt.params.iter_mut().for_each(|p| match &mut **p {
+    stmt.params.iter_mut().for_each(|p| match &mut *p {
         super::prim::SeqItem::Item(i) => vis.visit_ident(i),
         super::prim::SeqItem::Missing(span) => vis.visit_span(span),
     });
-    stmt.qubits.iter_mut().for_each(|p| match &mut **p {
+    stmt.qubits.iter_mut().for_each(|p| match &mut *p {
         super::prim::SeqItem::Item(i) => vis.visit_ident(i),
         super::prim::SeqItem::Missing(span) => vis.visit_span(span),
     });

--- a/source/qdk_openqasm_parser/src/parser/prgm.rs
+++ b/source/qdk_openqasm_parser/src/parser/prgm.rs
@@ -30,11 +30,7 @@ pub(super) fn parse(s: &mut ParserContext) -> Program {
     Program {
         span: s.span(lo),
         version,
-        statements: stmts
-            .into_iter()
-            .map(Box::new)
-            .collect::<Vec<_>>()
-            .into_boxed_slice(),
+        statements: stmts.into_boxed_slice(),
     }
 }
 

--- a/source/qdk_openqasm_parser/src/parser/prim.rs
+++ b/source/qdk_openqasm_parser/src/parser/prim.rs
@@ -43,7 +43,7 @@ pub(super) fn ident(s: &mut ParserContext) -> Result<Ident> {
     s.expect(WordKinds::PathExpr);
     let peek = s.peek();
     if peek.kind == TokenKind::Identifier {
-        let name = s.read().into();
+        let name = s.intern(s.read());
         s.advance();
         Ok(Ident {
             span: peek.span,
@@ -62,7 +62,7 @@ pub(super) fn ident_or_kw_as_ident(s: &mut ParserContext) -> Result<Ident> {
     s.expect(WordKinds::PathExpr);
     let peek = s.peek();
     if matches!(peek.kind, TokenKind::Identifier | TokenKind::Keyword(..)) {
-        let name = s.read().into();
+        let name = s.intern(s.read());
         s.advance();
         Ok(Ident {
             span: peek.span,
@@ -93,9 +93,16 @@ pub(super) fn opt<T>(s: &mut ParserContext, mut p: impl Parser<T>) -> Result<Opt
 pub(super) fn many<T>(s: &mut ParserContext, mut p: impl Parser<T>) -> Result<Vec<T>> {
     let mut xs = Vec::new();
     while let Some(x) = opt(s, &mut p)? {
-        xs.push(x);
+        push_with_initial_capacity(&mut xs, x);
     }
     Ok(xs)
+}
+
+fn push_with_initial_capacity<T>(xs: &mut Vec<T>, value: T) {
+    if xs.capacity() == 0 {
+        xs.reserve_exact(1);
+    }
+    xs.push(value);
 }
 
 /// Parses a sequence of items separated by commas.
@@ -110,17 +117,17 @@ where
         let mut span = s.peek().span;
         span.hi = span.lo;
         s.push_error(Error::new(ErrorKind::MissingSeqEntry(span)));
-        xs.push(T::default().with_span(span));
+        push_with_initial_capacity(&mut xs, T::default().with_span(span));
         s.advance();
     }
     while let Some(x) = opt(s, &mut p)? {
-        xs.push(x);
+        push_with_initial_capacity(&mut xs, x);
         if token(s, TokenKind::Comma).is_ok() {
             while s.peek().kind == TokenKind::Comma {
                 let mut span = s.peek().span;
                 span.hi = span.lo;
                 s.push_error(Error::new(ErrorKind::MissingSeqEntry(span)));
-                xs.push(T::default().with_span(span));
+                push_with_initial_capacity(&mut xs, T::default().with_span(span));
                 s.advance();
             }
             final_sep = FinalSep::Present;
@@ -179,17 +186,17 @@ pub(super) fn seq_item<T>(
         let mut span = s.peek().span;
         span.hi = span.lo;
         s.push_error(Error::new(ErrorKind::MissingSeqEntry(span)));
-        xs.push(SeqItem::Missing(span));
+        push_with_initial_capacity(&mut xs, SeqItem::Missing(span));
         s.advance();
     }
     while let Some(x) = opt(s, &mut p)? {
-        xs.push(SeqItem::Item(x));
+        push_with_initial_capacity(&mut xs, SeqItem::Item(x));
         if token(s, TokenKind::Comma).is_ok() {
             while s.peek().kind == TokenKind::Comma {
                 let mut span = s.peek().span;
                 span.hi = span.lo;
                 s.push_error(Error::new(ErrorKind::MissingSeqEntry(span)));
-                xs.push(SeqItem::Missing(span));
+                push_with_initial_capacity(&mut xs, SeqItem::Missing(span));
                 s.advance();
             }
             final_sep = FinalSep::Present;

--- a/source/qdk_openqasm_parser/src/parser/scan.rs
+++ b/source/qdk_openqasm_parser/src/parser/scan.rs
@@ -6,6 +6,8 @@ use crate::{
     parser::completion::{collector::ValidWordCollector, word_kinds::WordKinds},
 };
 use qsc_data_structures::span::Span;
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
 
 use super::Error;
 use super::error::ErrorKind;
@@ -25,12 +27,15 @@ pub(crate) struct ParserContext<'a> {
 pub(super) struct Scanner<'a> {
     input: &'a str,
     tokens: Lexer<'a>,
+    interned_strings: InternedStrings<'a>,
     barriers: Vec<&'a [TokenKind]>,
     errors: Vec<Error>,
     recovered_eof: bool,
     peek: Token,
     offset: u32,
 }
+
+type InternedStrings<'a> = FxHashMap<&'a str, Arc<str>>;
 
 impl<'a> ParserContext<'a> {
     pub fn new(input: &'a str) -> Self {
@@ -65,6 +70,10 @@ impl<'a> ParserContext<'a> {
 
     pub(super) fn read_from(&self, from: u32) -> &'a str {
         self.scanner.read_from(from)
+    }
+
+    pub(super) fn intern(&mut self, value: &'a str) -> Arc<str> {
+        self.scanner.intern(value)
     }
 
     /// Advances the scanner to start of the the next valid token.
@@ -126,6 +135,7 @@ impl<'a> Scanner<'a> {
         Self {
             input,
             tokens,
+            interned_strings: InternedStrings::default(),
             barriers: Vec::new(),
             peek: peek.unwrap_or_else(|| eof(input.len())),
             errors: errors
@@ -147,6 +157,16 @@ impl<'a> Scanner<'a> {
 
     pub(super) fn read_from(&self, from: u32) -> &'a str {
         &self.input[self.span(from)]
+    }
+
+    pub(super) fn intern(&mut self, value: &'a str) -> Arc<str> {
+        if let Some(interned) = self.interned_strings.get(value) {
+            return interned.clone();
+        }
+
+        let interned: Arc<str> = Arc::from(value);
+        self.interned_strings.insert(value, interned.clone());
+        interned
     }
 
     pub(super) fn span(&self, from: u32) -> Span {

--- a/source/qdk_openqasm_parser/src/parser/stmt.rs
+++ b/source/qdk_openqasm_parser/src/parser/stmt.rs
@@ -261,7 +261,7 @@ fn disambiguate_ident(
             kind: Box::new(ExprKind::FunctionCall(FunctionCall {
                 span: s.span(lo),
                 name: ident,
-                args: args.into_iter().map(Box::new).collect(),
+                args: args.into_iter().collect(),
             })),
         };
 
@@ -290,7 +290,7 @@ fn disambiguate_ident(
                     },
                     // Index expressions are not allowed to have multi-bracket indices.
                     // i.e.: a[1][2] is disallowed in IndexExpr, instead you must do a[1, 2].
-                    index: *indexed_ident.indices[0].clone(),
+                    index: indexed_ident.indices[0].clone(),
                 })
             }
         };
@@ -1693,7 +1693,7 @@ fn reinterpret_index_expr(
     if let Index::IndexList(set) = index
         && set.values.len() == 1
     {
-        let first_elt: IndexListItem = (*set.values[0]).clone();
+        let first_elt: IndexListItem = set.values[0].clone();
         if let IndexListItem::Expr(expr) = first_elt
             && duration.is_none()
         {

--- a/source/qdk_openqasm_parser/src/parser/tests.rs
+++ b/source/qdk_openqasm_parser/src/parser/tests.rs
@@ -102,7 +102,14 @@ fn int_version_can_be_parsed() -> miette::Result<(), Vec<Report>> {
     let source = r#"OPENQASM 3;"#;
     let res = parse(source)?;
     assert_eq!(
-        Some(format!("{}", res.source.program.version.expect("version"))),
+        Some(format!(
+            "{}",
+            res.source
+                .program()
+                .expect("program")
+                .version
+                .expect("version")
+        )),
         Some("3".to_string())
     );
     Ok(())
@@ -113,7 +120,14 @@ fn dotted_version_can_be_parsed() -> miette::Result<(), Vec<Report>> {
     let source = r#"OPENQASM 3.0;"#;
     let res = parse(source)?;
     assert_eq!(
-        Some(format!("{}", res.source.program.version.expect("version"))),
+        Some(format!(
+            "{}",
+            res.source
+                .program()
+                .expect("program")
+                .version
+                .expect("version")
+        )),
         Some("3.0".to_string())
     );
     Ok(())

--- a/source/qdk_openqasm_parser/src/semantic/ast.rs
+++ b/source/qdk_openqasm_parser/src/semantic/ast.rs
@@ -233,8 +233,8 @@ impl Display for AliasDeclStmt {
 #[derive(Clone, Debug)]
 pub struct AssignStmt {
     pub span: Span,
-    pub lhs: Expr,
-    pub rhs: Expr,
+    pub lhs: Box<Expr>,
+    pub rhs: Box<Expr>,
 }
 
 impl Display for AssignStmt {
@@ -261,7 +261,7 @@ impl Display for BarrierStmt {
 #[derive(Clone, Debug)]
 pub struct BoxStmt {
     pub span: Span,
-    pub duration: Option<Expr>,
+    pub duration: Option<Box<Expr>>,
     pub body: List<Stmt>,
 }
 
@@ -410,7 +410,7 @@ impl Display for DefCalStmt {
 #[derive(Clone, Debug)]
 pub struct DelayStmt {
     pub span: Span,
-    pub duration: Expr,
+    pub duration: Box<Expr>,
     pub qubits: List<GateOperand>,
 }
 
@@ -436,7 +436,7 @@ impl Display for EndStmt {
 #[derive(Clone, Debug)]
 pub struct ExprStmt {
     pub span: Span,
-    pub expr: Expr,
+    pub expr: Box<Expr>,
 }
 
 impl Display for ExprStmt {
@@ -490,7 +490,7 @@ pub struct GateCall {
     pub gate_name_span: Span,
     pub args: List<Expr>,
     pub qubits: List<GateOperand>,
-    pub duration: Option<Expr>,
+    pub duration: Option<Box<Expr>>,
     pub classical_arity: u32,
     pub quantum_arity: u32,
 }
@@ -512,7 +512,7 @@ impl Display for GateCall {
 #[derive(Clone, Debug)]
 pub struct IfStmt {
     pub span: Span,
-    pub condition: Expr,
+    pub condition: Box<Expr>,
     pub if_body: Stmt,
     pub else_body: Option<Stmt>,
 }
@@ -542,9 +542,9 @@ impl Display for IncludeStmt {
 #[derive(Clone, Debug)]
 pub struct IndexedClassicalTypeAssignStmt {
     pub span: Span,
-    pub lhs: Expr,
+    pub lhs: Box<Expr>,
     pub indices: VecDeque<Index>,
-    pub rhs: Expr,
+    pub rhs: Box<Expr>,
 }
 
 impl Display for IndexedClassicalTypeAssignStmt {
@@ -669,7 +669,7 @@ pub struct QubitArrayDeclaration {
     pub symbol_id: SymbolId,
     /// This `Expr` is const, but we don't substitute by the `LiteralKind` yet
     /// to be able to provide Span and Type information to the Language Service.
-    pub size: Expr,
+    pub size: Box<Expr>,
     pub size_span: Span,
 }
 
@@ -713,7 +713,7 @@ impl Display for ReturnStmt {
 #[derive(Clone, Debug)]
 pub struct SwitchStmt {
     pub span: Span,
-    pub target: Expr,
+    pub target: Box<Expr>,
     pub cases: List<SwitchCase>,
     /// Note that `None` is quite different to `[]` in this case; the latter is
     /// an explicitly empty body, whereas the absence of a default might mean
@@ -748,7 +748,7 @@ impl Display for SwitchCase {
 #[derive(Clone, Debug)]
 pub struct WhileLoop {
     pub span: Span,
-    pub condition: Expr,
+    pub condition: Box<Expr>,
     pub body: Stmt,
 }
 

--- a/source/qdk_openqasm_parser/src/semantic/ast.rs
+++ b/source/qdk_openqasm_parser/src/semantic/ast.rs
@@ -862,7 +862,11 @@ impl Expr {
 
         Self {
             span,
-            kind: Box::new(ExprKind::BinaryOp(BinaryOpExpr { op, lhs, rhs })),
+            kind: Box::new(ExprKind::BinaryOp(BinaryOpExpr {
+                op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+            })),
             const_value: None,
             ty,
         }
@@ -883,7 +887,7 @@ pub enum ExprKind {
     BuiltinFunctionCall(BuiltinFunctionCall),
     Cast(Cast),
     IndexedExpr(IndexedExpr),
-    Paren(Expr),
+    Paren(Box<Expr>),
     Measure(MeasureExpr),
     SizeofCall(SizeofCallExpr),
     DurationofCall(DurationofCallExpr),
@@ -1092,7 +1096,7 @@ impl Display for EnumerableSet {
 pub struct UnaryOpExpr {
     pub span: Span,
     pub op: UnaryOp,
-    pub expr: Expr,
+    pub expr: Box<Expr>,
 }
 
 impl Display for UnaryOpExpr {
@@ -1106,8 +1110,8 @@ impl Display for UnaryOpExpr {
 #[derive(Clone, Debug)]
 pub struct BinaryOpExpr {
     pub op: BinOp,
-    pub lhs: Expr,
-    pub rhs: Expr,
+    pub lhs: Box<Expr>,
+    pub rhs: Box<Expr>,
 }
 
 impl BinaryOpExpr {
@@ -1151,9 +1155,9 @@ impl Display for FunctionCall {
 pub struct SizeofCallExpr {
     pub span: Span,
     pub fn_name_span: Span,
-    pub array: Expr,
+    pub array: Box<Expr>,
     pub array_dims: u32,
-    pub dim: Expr,
+    pub dim: Box<Expr>,
 }
 
 impl Display for SizeofCallExpr {
@@ -1227,7 +1231,7 @@ pub struct Cast {
     pub span: Span,
     pub ty: Type,
     pub ty_exprs: List<Expr>,
-    pub expr: Expr,
+    pub expr: Box<Expr>,
     pub kind: CastKind,
 }
 

--- a/source/qdk_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/qdk_openqasm_parser/src/semantic/lowerer.rs
@@ -1423,10 +1423,10 @@ impl Lowerer {
         semantic::Expr::new(expr.span, kind, ty)
     }
 
-    fn lower_annotations(annotations: &[Box<syntax::Annotation>]) -> Vec<semantic::Annotation> {
+    fn lower_annotations(annotations: &[syntax::Annotation]) -> Vec<semantic::Annotation> {
         annotations
             .iter()
-            .map(|annotation| Self::lower_annotation(annotation))
+            .map(Self::lower_annotation)
             .collect::<Vec<_>>()
     }
 
@@ -1782,7 +1782,7 @@ impl Lowerer {
         }
     }
 
-    fn block_always_returns<'a>(stmts: impl IntoIterator<Item = &'a Box<semantic::Stmt>>) -> bool {
+    fn block_always_returns<'a>(stmts: impl IntoIterator<Item = &'a semantic::Stmt>) -> bool {
         for stmt in stmts {
             if Self::stmt_always_returns(stmt) {
                 return true;
@@ -2477,7 +2477,7 @@ impl Lowerer {
             for index in 0..(*indexed_dim_size) {
                 let qubits = qubits
                     .iter()
-                    .map(|qubit| Self::index_into_qubit_register((**qubit).clone(), index));
+                    .map(|qubit| Self::index_into_qubit_register(qubit.clone(), index));
 
                 let qubits = list_from_iter(qubits);
 
@@ -4547,7 +4547,7 @@ impl Lowerer {
         let indices: Vec<_> = list
             .values
             .iter()
-            .filter_map(|index| match &**index {
+            .filter_map(|index| match index {
                 syntax::IndexListItem::RangeDefinition(range) => self
                     .lower_const_range(range)
                     .map(|range| semantic::Index::Range(range.into())),
@@ -4792,7 +4792,7 @@ impl Lowerer {
             != indexed_ident
                 .indices
                 .iter()
-                .map(|i| i.num_indices())
+                .map(syntax::Index::num_indices)
                 .sum::<usize>()
         {
             // Since we can't evaluate all the indices, we can't know the indexed type.

--- a/source/qdk_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/qdk_openqasm_parser/src/semantic/lowerer.rs
@@ -2319,8 +2319,9 @@ impl Lowerer {
         stmt: &syntax::GateCall,
         annotations: &List<semantic::Annotation>,
     ) -> Vec<semantic::Stmt> {
-        let mut stmts = Vec::new();
-        for kind in self.lower_gate_call_stmt(stmt) {
+        let kinds = self.lower_gate_call_stmt(stmt);
+        let mut stmts = Vec::with_capacity(kinds.len());
+        for kind in kinds {
             let stmt = semantic::Stmt {
                 span: stmt.span,
                 annotations: annotations.clone(),
@@ -2488,16 +2489,16 @@ impl Lowerer {
             }
 
             // 6.2 Convert the broadcast call in a list of simple stmts.
-            let mut stmts = Vec::new();
-
             let Type::QubitArray(indexed_dim_size) = register_type else {
                 unreachable!("we set register_type iff we find a QubitArray");
             };
 
+            let mut stmts = Vec::with_capacity(*indexed_dim_size as usize);
+
             for index in 0..(*indexed_dim_size) {
                 let qubits = qubits
                     .iter()
-                    .map(|qubit| Self::index_into_qubit_register(qubit.clone(), index));
+                    .map(|qubit| Self::index_into_qubit_register(qubit, index));
 
                 let qubits = list_from_iter(qubits);
 
@@ -2541,33 +2542,35 @@ impl Lowerer {
         // by all the QASM semantic analysis.
     }
 
-    fn index_into_qubit_register(op: semantic::GateOperand, index: u32) -> semantic::GateOperand {
-        let index = semantic::Index::Expr(semantic::Expr::new(
-            op.span,
-            semantic::ExprKind::Lit(semantic::LiteralKind::Int(index.into())),
-            Type::UInt(None, true),
-        ));
-
-        match op.kind {
+    fn index_into_qubit_register(op: &semantic::GateOperand, index: u32) -> semantic::GateOperand {
+        match &op.kind {
             semantic::GateOperandKind::Expr(expr) => {
                 // Single qubits are allowed in a broadcast call.
                 match &expr.ty {
                     Type::Qubit => semantic::GateOperand {
                         span: op.span,
-                        kind: semantic::GateOperandKind::Expr(expr),
+                        kind: semantic::GateOperandKind::Expr(expr.clone()),
                     },
-                    Type::QubitArray(..) => semantic::GateOperand {
-                        span: op.span,
-                        kind: semantic::GateOperandKind::Expr(Box::new(semantic::Expr::new(
+                    Type::QubitArray(..) => {
+                        let index = semantic::Index::Expr(semantic::Expr::new(
                             op.span,
-                            semantic::ExprKind::IndexedExpr(semantic::IndexedExpr {
-                                span: op.span,
-                                collection: expr,
-                                index: Box::new(index),
-                            }),
-                            Type::Qubit,
-                        ))),
-                    },
+                            semantic::ExprKind::Lit(semantic::LiteralKind::Int(index.into())),
+                            Type::UInt(None, true),
+                        ));
+
+                        semantic::GateOperand {
+                            span: op.span,
+                            kind: semantic::GateOperandKind::Expr(Box::new(semantic::Expr::new(
+                                op.span,
+                                semantic::ExprKind::IndexedExpr(semantic::IndexedExpr {
+                                    span: op.span,
+                                    collection: expr.clone(),
+                                    index: Box::new(index),
+                                }),
+                                Type::Qubit,
+                            ))),
+                        }
+                    }
                     _ => unreachable!("we set register_type iff we find a QubitArray"),
                 }
             }

--- a/source/qdk_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/qdk_openqasm_parser/src/semantic/lowerer.rs
@@ -787,7 +787,11 @@ impl Lowerer {
             return semantic::StmtKind::Err;
         }
 
-        semantic::StmtKind::Assign(semantic::AssignStmt { span, lhs, rhs })
+        semantic::StmtKind::Assign(semantic::AssignStmt {
+            span,
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+        })
     }
 
     fn lower_indexed_assign_stmt(
@@ -841,7 +845,11 @@ impl Lowerer {
             }
         };
 
-        semantic::StmtKind::Assign(semantic::AssignStmt { span, lhs, rhs })
+        semantic::StmtKind::Assign(semantic::AssignStmt {
+            span,
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+        })
     }
 
     fn lower_indexed_classical_type_assign_stmt(
@@ -863,9 +871,9 @@ impl Lowerer {
         // So, if return here, it is guaranteed that the assignment will succeed.
         semantic::StmtKind::IndexedClassicalTypeAssign(semantic::IndexedClassicalTypeAssignStmt {
             span,
-            lhs,
+            lhs: Box::new(lhs),
             indices,
-            rhs,
+            rhs: Box::new(rhs),
         })
     }
 
@@ -926,8 +934,8 @@ impl Lowerer {
 
         semantic::StmtKind::Assign(semantic::AssignStmt {
             span,
-            lhs,
-            rhs: binary_expr,
+            lhs: Box::new(lhs),
+            rhs: Box::new(binary_expr),
         })
     }
 
@@ -985,8 +993,8 @@ impl Lowerer {
 
         semantic::StmtKind::Assign(semantic::AssignStmt {
             span,
-            lhs,
-            rhs: binary_expr,
+            lhs: Box::new(lhs),
+            rhs: Box::new(binary_expr),
         })
     }
 
@@ -1494,7 +1502,7 @@ impl Lowerer {
         let duration = stmt
             .duration
             .as_ref()
-            .map(|d| self.lower_duration_designator(d));
+            .map(|d| Box::new(self.lower_duration_designator(d)));
 
         semantic::StmtKind::Box(semantic::BoxStmt {
             span: stmt.span,
@@ -1892,7 +1900,7 @@ impl Lowerer {
     fn lower_delay(&mut self, stmt: &syntax::DelayStmt) -> semantic::StmtKind {
         let qubits = stmt.qubits.iter().map(|q| self.lower_gate_operand(q));
         let qubits = list_from_iter(qubits);
-        let duration = self.lower_duration_designator(&stmt.duration);
+        let duration = Box::new(self.lower_duration_designator(&stmt.duration));
 
         semantic::StmtKind::Delay(semantic::DelayStmt {
             span: stmt.span,
@@ -1933,7 +1941,7 @@ impl Lowerer {
     }
 
     fn lower_expr_stmt(&mut self, stmt: &syntax::ExprStmt) -> semantic::StmtKind {
-        let expr = self.lower_expr(&stmt.expr);
+        let expr = Box::new(self.lower_expr(&stmt.expr));
         match &*expr.kind {
             semantic::ExprKind::Err => semantic::StmtKind::Err,
             semantic::ExprKind::Ident(id) => {
@@ -2123,7 +2131,7 @@ impl Lowerer {
 
         semantic::StmtKind::If(semantic::IfStmt {
             span: stmt.span,
-            condition,
+            condition: Box::new(condition),
             if_body,
             else_body,
         })
@@ -2363,7 +2371,7 @@ impl Lowerer {
         let duration = stmt
             .duration
             .as_ref()
-            .map(|d| self.lower_duration_designator(d));
+            .map(|d| Box::new(self.lower_duration_designator(d)));
 
         let name = stmt.name.name.to_string();
 
@@ -2740,7 +2748,7 @@ impl Lowerer {
             let measure = self.lower_measure_expr(&stmt.measurement);
             semantic::StmtKind::ExprStmt(semantic::ExprStmt {
                 span: stmt.span,
-                expr: measure,
+                expr: Box::new(measure),
             })
         }
     }
@@ -2890,7 +2898,7 @@ impl Lowerer {
             semantic::StmtKind::QubitArrayDecl(semantic::QubitArrayDeclaration {
                 span: stmt.span,
                 symbol_id,
-                size,
+                size: Box::new(size),
                 size_span,
             })
         } else {
@@ -3003,7 +3011,7 @@ impl Lowerer {
 
         semantic::StmtKind::Switch(semantic::SwitchStmt {
             span: stmt.span,
-            target,
+            target: Box::new(target),
             cases: list_from_iter(cases),
             default,
         })
@@ -3050,7 +3058,7 @@ impl Lowerer {
 
         semantic::StmtKind::WhileLoop(semantic::WhileLoop {
             span: stmt.span,
-            condition: while_condition,
+            condition: Box::new(while_condition),
             body,
         })
     }

--- a/source/qdk_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/qdk_openqasm_parser/src/semantic/lowerer.rs
@@ -148,11 +148,15 @@ impl Lowerer {
     }
 
     pub fn lower(mut self) -> crate::semantic::QasmSemanticParseResult {
+        // Move the parsed source out of `self` so the immutable walk below does
+        // not borrow-conflict with the `&mut self` lowering methods. This avoids
+        // cloning the entire syntax AST just to read it; the source is moved back
+        // into the result at the end.
+        let source = std::mem::take(&mut self.source);
         // Should we fail if we see a version in included files?
-        let source = &self.source.clone();
         self.version = self.lower_version(source.program().version);
 
-        self.lower_source(source);
+        self.lower_source(&source);
 
         assert!(
             self.symbols.is_current_scope_global(),
@@ -166,7 +170,7 @@ impl Lowerer {
         };
 
         super::QasmSemanticParseResult {
-            source: self.source,
+            source,
             source_map: self.source_map,
             symbols: self.symbols,
             program,

--- a/source/qdk_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/qdk_openqasm_parser/src/semantic/lowerer.rs
@@ -120,7 +120,7 @@ impl Lowerer {
     pub fn new(source: QasmSource, source_map: SourceMap) -> Self {
         // do a quick check for the version to set up the symbol table
         // lowering and validation come later
-        let version = source.program().version;
+        let version = source.program().and_then(|p| p.version);
         let symbols = if let Some(version) = version {
             if version.major == 2 && version.minor == Some(0) {
                 SymbolTable::new_qasm2()
@@ -152,9 +152,9 @@ impl Lowerer {
         // not borrow-conflict with the `&mut self` lowering methods. This avoids
         // cloning the entire syntax AST just to read it; the source is moved back
         // into the result at the end.
-        let source = std::mem::take(&mut self.source);
+        let mut source = std::mem::take(&mut self.source);
         // Should we fail if we see a version in included files?
-        self.version = self.lower_version(source.program().version);
+        self.version = self.lower_version(source.program().and_then(|p| p.version));
 
         self.lower_source(&source);
 
@@ -162,6 +162,12 @@ impl Lowerer {
             self.symbols.is_current_scope_global(),
             "scope stack was non popped correctly"
         );
+
+        // Lowering has produced the semantic `program`; the syntax tree is no longer
+        // needed (diagnostics use the source text/errors and the source map, not the
+        // syntax tree). Drop it so the result does not retain a full syntax AST
+        // alongside the semantic program.
+        source.drop_program();
 
         let program = semantic::Program {
             version: self.version,
@@ -214,7 +220,13 @@ impl Lowerer {
         // `source.includes()`
         let mut includes = source.includes().iter();
 
-        for stmt in &source.program().statements {
+        // The syntax program is present during lowering; once a source's program has
+        // been dropped there is nothing to lower.
+        let Some(program) = source.program() else {
+            return;
+        };
+
+        for stmt in &program.statements {
             match &*stmt.kind {
                 syntax::StmtKind::Include(include) => {
                     // if we are not in the root  we should not be able to include

--- a/source/qdk_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/qdk_openqasm_parser/src/semantic/lowerer.rs
@@ -1350,7 +1350,7 @@ impl Lowerer {
     fn lower_paren_expr(&mut self, expr: &syntax::Expr, span: Span) -> semantic::Expr {
         let expr = self.lower_expr(expr);
         let ty = expr.ty.clone();
-        let kind = semantic::ExprKind::Paren(expr);
+        let kind = semantic::ExprKind::Paren(Box::new(expr));
         semantic::Expr::new(span, kind, ty)
     }
 
@@ -1371,7 +1371,7 @@ impl Lowerer {
                 let unary = semantic::UnaryOpExpr {
                     span,
                     op: semantic::UnaryOp::Neg,
-                    expr,
+                    expr: Box::new(expr),
                 };
                 semantic::Expr::new(span, semantic::ExprKind::UnaryOp(unary), ty)
             }
@@ -1390,7 +1390,7 @@ impl Lowerer {
                 let unary = semantic::UnaryOpExpr {
                     span,
                     op: semantic::UnaryOp::NotB,
-                    expr,
+                    expr: Box::new(expr),
                 };
                 semantic::Expr::new(span, semantic::ExprKind::UnaryOp(unary), ty)
             }
@@ -1412,7 +1412,7 @@ impl Lowerer {
                     semantic::ExprKind::UnaryOp(semantic::UnaryOpExpr {
                         span: expr.span,
                         op: semantic::UnaryOp::NotL,
-                        expr,
+                        expr: Box::new(expr),
                     }),
                     ty,
                 )
@@ -2220,9 +2220,9 @@ impl Lowerer {
                 let kind = semantic::ExprKind::SizeofCall(semantic::SizeofCallExpr {
                     span: expr.span,
                     fn_name_span: expr.name.span,
-                    array: first_arg,
+                    array: Box::new(first_arg),
                     array_dims: array_dims.into(),
-                    dim: second_arg,
+                    dim: Box::new(second_arg),
                 });
 
                 Expr::new(expr.span, kind, Type::UInt(None, false))
@@ -4245,8 +4245,8 @@ impl Lowerer {
                 }
                 let bin_expr = semantic::BinaryOpExpr {
                     op: op.into(),
-                    lhs,
-                    rhs,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
                 };
                 let kind = semantic::ExprKind::BinaryOp(bin_expr);
                 let expr = semantic::Expr::new(span, kind, target_ty);
@@ -4263,8 +4263,8 @@ impl Lowerer {
             };
 
             let bin_expr = semantic::BinaryOpExpr {
-                lhs: new_lhs,
-                rhs: new_rhs,
+                lhs: Box::new(new_lhs),
+                rhs: Box::new(new_rhs),
                 op: op.into(),
             };
             let kind = semantic::ExprKind::BinaryOp(bin_expr);
@@ -4382,8 +4382,8 @@ impl Lowerer {
             if is_complex_binop_supported(op) {
                 let bin_expr = semantic::BinaryOpExpr {
                     op: op.into(),
-                    lhs,
-                    rhs,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
                 };
                 let kind = semantic::ExprKind::BinaryOp(bin_expr);
                 semantic::Expr::new(span, kind, ty.clone())
@@ -4396,8 +4396,8 @@ impl Lowerer {
         } else {
             let bin_expr = semantic::BinaryOpExpr {
                 op: op.into(),
-                lhs,
-                rhs,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
             };
             let kind = semantic::ExprKind::BinaryOp(bin_expr);
             semantic::Expr::new(span, kind, ty.clone())
@@ -4501,8 +4501,8 @@ impl Lowerer {
 
         let bin_expr = semantic::BinaryOpExpr {
             op: op.into(),
-            lhs,
-            rhs,
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
         };
         let kind = semantic::ExprKind::BinaryOp(bin_expr);
         let expr = semantic::Expr::new(span, kind, ty);
@@ -5093,7 +5093,7 @@ fn wrap_expr_in_cast_expr(ty: Type, rhs: semantic::Expr) -> semantic::Expr {
         rhs.span,
         semantic::ExprKind::Cast(semantic::Cast {
             span: Span::default(),
-            expr: rhs,
+            expr: Box::new(rhs),
             ty: ty.clone(),
             kind: semantic::CastKind::Implicit,
             ty_exprs: list_from_iter(vec![]),

--- a/source/qdk_openqasm_parser/src/vendor/display.rs
+++ b/source/qdk_openqasm_parser/src/vendor/display.rs
@@ -5,9 +5,25 @@
 
 pub mod core;
 
-use crate::vendor::span::Span;
+use crate::span::Span;
 use core::{set_indentation, with_indentation, write_list};
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Display, Formatter, Write};
+
+/// Displays values separated by the provided string.
+pub fn join(
+    f: &mut Formatter,
+    mut vals: impl Iterator<Item = impl Display>,
+    sep: &str,
+) -> fmt::Result {
+    if let Some(v) = vals.next() {
+        v.fmt(f)?;
+    }
+    for v in vals {
+        write!(f, "{sep}")?;
+        v.fmt(f)?;
+    }
+    Ok(())
+}
 
 /// Writes a list of elements to the given buffer or stream
 /// with an additional indentation level.
@@ -33,14 +49,25 @@ where
 }
 
 /// Writes the name and span of a structure to the given buffer or stream.
-pub fn write_header(f: &mut impl Write, name: &str, span: Span) -> fmt::Result {
+pub fn write_header_with_span(f: &mut impl Write, name: &str, span: Span) -> fmt::Result {
     write!(f, "{name} {span}:")
 }
 
 /// Writes the name and span of a structure to the given buffer or stream.
 /// Inserts a newline afterwards.
-pub fn writeln_header(f: &mut impl Write, name: &str, span: Span) -> fmt::Result {
+pub fn writeln_header_with_span(f: &mut impl Write, name: &str, span: Span) -> fmt::Result {
     writeln!(f, "{name} {span}:")
+}
+
+/// Writes the name of a structure to the given buffer or stream.
+pub fn write_header(f: &mut impl Write, name: &str) -> fmt::Result {
+    write!(f, "{name}:")
+}
+
+/// Writes the name of a structure to the given buffer or stream.
+/// Inserts a newline afterwards.
+pub fn writeln_header(f: &mut impl Write, name: &str) -> fmt::Result {
+    writeln!(f, "{name}:")
 }
 
 /// Writes a field of a structure to the given buffer
@@ -140,4 +167,22 @@ where
         let mut indent = with_indentation(f);
         write!(indent, "{field_name}: <none>")
     }
+}
+
+/// Writes an optional field of a structure to the given buffer
+/// or stream with an additional indentation level.
+/// The field must be an iterable.
+/// Inserts a newline afterwards.
+pub fn writeln_opt_list_field<'write, 'itemref, 'item, T, I>(
+    f: &mut impl Write,
+    field_name: &str,
+    opt_vals: Option<I>,
+) -> fmt::Result
+where
+    'item: 'itemref,
+    T: Display + 'item,
+    I: IntoIterator<Item = &'itemref T>,
+{
+    write_opt_list_field(f, field_name, opt_vals)?;
+    writeln!(f)
 }

--- a/source/qdk_openqasm_parser/src/vendor/display/core.rs
+++ b/source/qdk_openqasm_parser/src/vendor/display/core.rs
@@ -21,8 +21,8 @@ where
 /// Takes an `indenter::Indented` and changes its indentation level.
 ///
 /// Note: This function is a very low level primitive. It's only
-///       public to maintain backwards compatibility with existing code.
-///       Prefer using the functions in the `display` module instead.
+///       public to mantain backwards compatibility with existing code.
+///       Prefer using the functions in [`crate::display`] instead.
 #[must_use]
 pub fn set_indentation<T>(
     indent: indenter::Indented<'_, T>,


### PR DESCRIPTION
# OpenQASM parser optimization: before vs after

Input sizes used: 1 MiB (63,001 statements) and 5 MiB (302,908 statements).

- **Peak memory: −48%** (≈ halved)
- **Retained memory: −59%** (semantic-lowering's retained set alone is down **−77%**)
- **Time: −30%**
- Allocation count (using `dhat`): **−50%** at analyze — the root driver of both the time and peak wins

In addition, a follow-up change was added which reduced OpenQASM parser/lexer hot-path allocations, compared to the above, this reduced syntax parse time `19-25%`, allocs `22%`, reallocs `90%`, allocated bytes `38%`.

## What changed

| Change | Targets |
---|---|
| Remove the whole-source `clone()` in `lower()` (walk via `mem::take`) | transient peak |
| `List<T>`: `Box<[Box<T>]>` → `Box<[T]>` (drop per-element box) | allocation count + time |
| Drop the retained syntax AST after lowering (`program: Option<Program>`) | retained/net-live |
| Box inline `Expr` fields in big `ExprKind` variants (264 → 96 B) | both |
| Box inline `Expr` fields in big `StmtKind` variants (280 → 96 B) | both |

## Time — criterion median

| Stage | 1 MiB before | 1 MiB after | Δ | 5 MiB before | 5 MiB after | Δ |
|---|---|---|---|---|---|---|
| tokenize | 11.3 ms | 11.2 ms | ~0% | 54.4 ms | 55.0 ms | ~0% |
| parse | 79.5 ms | 68.9 ms | −13% | 378.7 ms | 335.1 ms | −12% |
| semantic_lower | 67.5 ms | 44.4 ms | −34% | 336.4 ms | 214.4 ms | −36% |
| analyze (e2e) | 161.9 ms | 113.6 ms | −30% | 789.6 ms | 552.2 ms | −30% |

Tokenize is unchanged (no lexer changes).

## Memory — peak

| Stage | 1 MiB before | 1 MiB after | Δ | 5 MiB before | 5 MiB after | Δ |
|---|---|---|---|---|---|---|
| parse | 45.8 MB | 43.2 MB | −6% | 227 MB | 214 MB | −6% |
| semantic_lower | 170.0 MB | 70.3 MB | −59% | 824 MB | 345 MB | −58% |
| analyze (e2e) | 213.7 MB | 111.3 MB | −48% | 1034 MB | 542 MB | −48% |

## Memory — retained (net-live, after the stage returns)

| Stage | 1 MiB before | 1 MiB after | Δ | 5 MiB before | 5 MiB after | Δ |
|---|---|---|---|---|---|---|
| parse | 43.7 MB | 41.1 MB | −6% | 210 MB | 198 MB | −6% |
| semantic_lower | 128.7 MB | 30.2 MB | −77% | 619 MB | 145 MB | −77% |
| analyze (e2e) | 172.5 MB | 71.2 MB | −59% | 829 MB | 343 MB | −59% |
