### PR TITLE
Add multi-course support and Python notebook courses to QDK Learning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ __pycache__/
 .idea/
 *.so
 samples/scratch/
-samples/qdk-learning/
-samples/qdk-learning.json
+qdk-learning/
+qdk-learning.json
 *.pyd
 /python_doc/
 /logs/

--- a/courses/circuit-diagrams-new/01-intro/_exercises.json
+++ b/courses/circuit-diagrams-new/01-intro/_exercises.json
@@ -1,0 +1,16 @@
+{
+  "exercises": [
+    {
+      "id": "forty_two",
+      "cellIndex": 7,
+      "title": "Your first Q# expression",
+      "description": "Implement the forty_two() function so it returns 42.",
+      "hints": [
+        "The function just needs to return a value equal to the integer 42.",
+        "The simplest answer is to return the literal `42` itself."
+      ],
+      "solution": "@exercise\ndef forty_two():\n    return qsharp.eval(\"40 + 2\")",
+      "solutionExplanation": "Any Q# expression that evaluates to the integer 42 works. The simplest options are the literal `42` or an arithmetic expression like `40 + 2`."
+    }
+  ]
+}

--- a/courses/circuit-diagrams-new/01-intro/_unit.py
+++ b/courses/circuit-diagrams-new/01-intro/_unit.py
@@ -1,0 +1,19 @@
+"""Unit helpers — course-infrastructure imports for the notebook."""
+
+import sys
+from pathlib import Path
+
+_course_root = str(Path(__file__).resolve().parent.parent)
+if _course_root not in sys.path:
+    sys.path.insert(0, _course_root)
+
+# Re-export only the course meta-helpers — not the QDK product API.
+from _check_env import check as check_env  # noqa: E402, F401
+from _course_lib import (  # noqa: E402, F401
+    exercise,
+    register_value_exercise,
+    complete_unit,
+)
+
+# Register this unit's exercises.
+register_value_exercise("forty_two", expected=42)

--- a/courses/circuit-diagrams-new/01-intro/intro.ipynb
+++ b/courses/circuit-diagrams-new/01-intro/intro.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0928290d",
+   "metadata": {},
+   "source": [
+    "# Circuit Diagrams: Intro\n",
+    "\n",
+    "Welcome to the first unit of the QDK Circuit Diagrams course.\n",
+    "\n",
+    "## How to use this notebook\n",
+    "\n",
+    "There are four kinds of code cells:\n",
+    "\n",
+    "- **Environment check** — run this first. If anything's wrong, follow the instructions in the output.\n",
+    "- **Example** — run it and observe the output.\n",
+    "- **Exercise** — these cells contain a function decorated with `@exercise` that you will implement according to instructions. Fill in the missing code, then run the cell to check your work.\n",
+    "- **Complete this unit** — the last cell. Run it once you've finished all the exercises.\n",
+    "\n",
+    "Each cell builds on the ones above it, so work top-to-bottom and run each cell before moving on. You can re-run any cell as many times as you like.\n",
+    "\n",
+    "Try the cell below to get started!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7d51066",
+   "metadata": {},
+   "source": [
+    "## Environment Check\n",
+    "\n",
+    "First, let's make sure your Python environment is all set up and contains the packages we'll need for this course. Run the cell below. If the checks fail, follow the instructions in the output to fix any issues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab1b16cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from _unit import check_env\n",
+    "\n",
+    "check_env()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d2e0171",
+   "metadata": {},
+   "source": [
+    "## Example: Running Q# from Python\n",
+    "\n",
+    "The QDK lets you write and run Q# code directly from Python. Run the cell below to see it in action — you don't need to edit anything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b52a1de9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qdk import qsharp\n",
+    "\n",
+    "# Evaluate a Q# expression. The result is returned as a Python value.\n",
+    "result = qsharp.eval(\"1 + 1\")\n",
+    "print(f\"Q# says 1 + 1 = {result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac9151de",
+   "metadata": {},
+   "source": [
+    "## Exercise: Your first Q# expression\n",
+    "\n",
+    "Your turn! Each exercise asks you to implement a function. Edit the function body, then run the cell. The checker will verify your answer.\n",
+    "\n",
+    "Edit the `forty_two` function below so it returns `42`, then run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db329ce6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from _unit import exercise\n",
+    "\n",
+    "\n",
+    "@exercise\n",
+    "def forty_two():\n",
+    "    # ========================================================================\n",
+    "    # YOUR TASK: change the expression below so forty_two() returns 42.\n",
+    "    # ========================================================================\n",
+    "    return qsharp.eval(\"0\")  # <-- edit this expression"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9a84106",
+   "metadata": {},
+   "source": [
+    "## Restarting the Python kernel\n",
+    "\n",
+    "If you get into a bad state, restart the kernel using the **Restart** action in VS Code. A bad state can happen because all cells share the same Python session: a variable from an earlier cell, a redefined Q# operation, or a half-finished exercise can linger and affect later cells.\n",
+    "\n",
+    "Restarting clears the runtime state: variables, imported modules, and defined Q# operations. Any code you wrote or edited will remain untouched. \n",
+    "\n",
+    "After restarting, use **Execute Above Cells** (the action button in the top-right corner of any cell) to quickly re-run everything up to where you left off.\n",
+    "\n",
+    "## Running all cells at once\n",
+    "\n",
+    "You can also click **Run All** — it will run every cell in order and stop at the first incomplete exercise.\n",
+    "\n",
+    "Try it now — we'll meet you down here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af2ee582",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raise Exception(\"An exception! Comment out this line and rerun this cell to continue.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72c9c7ef",
+   "metadata": {},
+   "source": [
+    "## Complete this unit\n",
+    "\n",
+    "Run this cell once you've completed all exercises above. This will mark the unit complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4733e5f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from _unit import complete_unit\n",
+    "\n",
+    "complete_unit()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qdk",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/courses/circuit-diagrams-new/01-intro/intro.md
+++ b/courses/circuit-diagrams-new/01-intro/intro.md
@@ -1,0 +1,24 @@
+# Getting Started
+
+Welcome to the first unit of the **Generating Circuit Diagrams** course!
+
+In this unit you'll learn the basics of running Q# code from Python using the QDK. You'll:
+
+- Run your first Q# expression from a Python notebook
+- Learn how the notebook exercises and verification work
+- Practice editing and running cells
+
+## How it works
+
+1. Click **Open Notebook** below to open the unit notebook.
+2. Work through the cells top-to-bottom — read the instructions, run examples, and fill in exercises.
+3. When you've completed all exercises, run the final cell to mark the unit complete.
+4. Come back here and click **Next** to continue to the next unit.
+
+## Before you start
+
+This course runs in its own Python environment. If the notebook's kernel
+won't start, or the first cell reports a problem, set up and check your
+environment here first:
+
+👉 [Check my environment](command:qsharp-vscode.learningDoctor)

--- a/courses/circuit-diagrams-new/02-circuits/_exercises.json
+++ b/courses/circuit-diagrams-new/02-circuits/_exercises.json
@@ -1,0 +1,28 @@
+{
+  "exercises": [
+    {
+      "id": "cat_circuit",
+      "cellIndex": 22,
+      "title": "Render with operation=",
+      "description": "Implement cat_circuit() to return a circuit built with circuit() using the operation= parameter for PrepareCatState.",
+      "hints": [
+        "The `operation=` parameter takes a string — the name of a Q# operation that accepts only qubits or qubit arrays.",
+        "Return `circuit(operation=\"PrepareCatState\")`."
+      ],
+      "solution": "@exercise\ndef cat_circuit():\n    return circuit(operation=\"PrepareCatState\")",
+      "solutionExplanation": "The `operation=` parameter lets the renderer decide the qubit allocation. Pass the operation name as a string without parentheses or arguments."
+    },
+    {
+      "id": "flat_circuit",
+      "cellIndex": 24,
+      "title": "Flatten a grouped circuit",
+      "description": "Implement flat_circuit() to return a circuit for GHZ(3) with grouping disabled so each gate is shown individually.",
+      "hints": [
+        "Pass `group_by_scope=False` to `circuit()` to disable grouping.",
+        "Return `circuit(\"GHZ(3)\", group_by_scope=False)`."
+      ],
+      "solution": "@exercise\ndef flat_circuit():\n    return circuit(\"GHZ(3)\", group_by_scope=False)",
+      "solutionExplanation": "Setting `group_by_scope=False` tells the renderer to flatten all operations instead of grouping them by their containing scope (function calls, loops)."
+    }
+  ]
+}

--- a/courses/circuit-diagrams-new/02-circuits/_unit.py
+++ b/courses/circuit-diagrams-new/02-circuits/_unit.py
@@ -1,0 +1,79 @@
+"""Unit helpers — course-infrastructure imports for the notebook."""
+
+import json
+import sys
+from pathlib import Path
+
+from IPython.display import display
+
+_course_root = str(Path(__file__).resolve().parent.parent)
+if _course_root not in sys.path:
+    sys.path.insert(0, _course_root)
+
+from _check_env import check as check_env  # noqa: E402, F401
+from _course_lib import (  # noqa: E402, F401
+    exercise,
+    register_exercise,
+    complete_unit,
+)
+
+
+def _missing_gates(circuit, required_gates: list[str]) -> list[str]:
+    diagram = str(circuit)
+    return [g for g in required_gates if g not in diagram]
+
+
+def _is_flat(circuit) -> bool:
+    """True if the circuit has no grouped (nested) operations."""
+    data = json.loads(circuit.json())
+    operations = data.get("operations", [])
+    return not any("children" in op for op in operations)
+
+
+def _display_circuit(circuit) -> None:
+    from qdk.widgets import Circuit
+
+    display(Circuit(circuit))
+
+
+def register_circuit_exercise(
+    name: str, *, required_gates: list[str], flat: bool = False
+) -> str:
+    """Register an exercise whose function must return a ``Circuit``.
+
+    Verifies the circuit contains ``required_gates`` (and, when ``flat`` is
+    True, that no operations are grouped), then displays the widget as
+    confirmation. The learner returns the circuit; rendering is our job.
+    """
+
+    def validate(circuit) -> str | None:
+        if circuit is None:
+            return (
+                f"<code>{name}()</code> returned <code>None</code>. "
+                "Did you forget to <code>return</code> the circuit?"
+            )
+        missing = _missing_gates(circuit, required_gates)
+        if missing:
+            gate_list = ", ".join(f"<code>{g}</code>" for g in missing)
+            return (
+                f"Your circuit is missing: {gate_list}. "
+                "Check your code and re-run the cell."
+            )
+        if flat and not _is_flat(circuit):
+            return (
+                "Your circuit still has grouped operations. "
+                "Did you set <code>group_by_scope=False</code>?"
+            )
+        return None
+
+    return register_exercise(
+        name,
+        validate,
+        success_message=f"Correct! Here's your <code>{name}</code> circuit:",
+        on_success=_display_circuit,
+    )
+
+
+# Register the this unit's exercises.
+register_circuit_exercise("cat_circuit", required_gates=["H", "X"])
+register_circuit_exercise("flat_circuit", required_gates=["H", "X"], flat=True)

--- a/courses/circuit-diagrams-new/02-circuits/circuits.ipynb
+++ b/courses/circuit-diagrams-new/02-circuits/circuits.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3db5183b",
+   "metadata": {},
+   "source": [
+    "# Rendering Circuit Diagrams\n",
+    "\n",
+    "In this unit you'll learn how to use the `circuit()` API and the `Circuit` widget to generate and display circuit diagrams from Q# operations.\n",
+    "\n",
+    "We'll assume you're already familiar with Q# and quantum circuits. The focus here is on the **Python API** — what options are available and how they affect the rendered output.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bda994e6",
+   "metadata": {},
+   "source": [
+    "## Environment Check\n",
+    "\n",
+    "Run the cell below to verify your environment is set up correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaf39e45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from _unit import check_env\n",
+    "\n",
+    "check_env()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34989e87",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "First, let's import the tools we'll use and define some Q# operations to work with throughout this unit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c2e67c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qdk import qsharp\n",
+    "from qdk.qsharp import circuit\n",
+    "from qdk.widgets import Circuit\n",
+    "\n",
+    "# Define a few operations we'll use throughout this unit.\n",
+    "OPERATIONS = \"\"\"\n",
+    "    operation BellPair() : (Result, Result) {\n",
+    "        use (a, b) = (Qubit(), Qubit());\n",
+    "        H(a);\n",
+    "        CNOT(a, b);\n",
+    "        return (M(a), M(b));\n",
+    "    }\n",
+    "\n",
+    "    operation GHZ(n : Int) : Result[] {\n",
+    "        use qs = Qubit[n];\n",
+    "        H(qs[0]);\n",
+    "        for i in 1..n-1 {\n",
+    "            CNOT(qs[0], qs[i]);\n",
+    "        }\n",
+    "        let results = MeasureEachZ(qs);\n",
+    "        ResetAll(qs);\n",
+    "        return results;\n",
+    "    }\n",
+    "\n",
+    "    operation PrepareCatState(qs : Qubit[]) : Unit {\n",
+    "        H(qs[0]);\n",
+    "        for i in 1..Length(qs)-1 {\n",
+    "            CNOT(qs[0], qs[i]);\n",
+    "        }\n",
+    "    }\n",
+    "\"\"\"\n",
+    "\n",
+    "qsharp.eval(OPERATIONS)\n",
+    "\n",
+    "print(\"Operations defined.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09c7e760",
+   "metadata": {},
+   "source": [
+    "## Example: Basic circuit generation with an entry expression\n",
+    "\n",
+    "`circuit()` takes an **entry expression** — a string that calls a Q# operation — and returns a `Circuit` object. Wrap it in the `Circuit` widget to render it in the notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab1207cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a circuit from an entry expression\n",
+    "bell = circuit(\"BellPair()\")\n",
+    "Circuit(bell)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e0ed73",
+   "metadata": {},
+   "source": [
+    "## Exercise: Render with `operation=`\n",
+    "\n",
+    "Use `circuit()` with the `operation=` parameter to generate a circuit for the `PrepareCatState` operation we defined earlier. Return it from `cat_circuit()`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12d649d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from _unit import exercise\n",
+    "\n",
+    "\n",
+    "@exercise\n",
+    "def cat_circuit():\n",
+    "    # ========================================================================\n",
+    "    # YOUR TASK: use circuit() with operation= to build the circuit for\n",
+    "    # PrepareCatState, and return it.\n",
+    "    # ========================================================================\n",
+    "    return None  # <-- replace this"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4d8a1e1",
+   "metadata": {},
+   "source": [
+    "## Exercise: Flatten a grouped circuit\n",
+    "\n",
+    "Generate a circuit for `GHZ(3)` with grouping **disabled**, so each gate is shown individually. Assign the result to `flat_circuit`. Return it from `flat_circuit()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8d8aca1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from _unit import exercise\n",
+    "\n",
+    "\n",
+    "@exercise\n",
+    "def flat_circuit():\n",
+    "    # ========================================================================\n",
+    "    # YOUR TASK: generate a circuit for GHZ(3) with group_by_scope=False,\n",
+    "    # and return it.\n",
+    "    # ========================================================================\n",
+    "    return None  # <-- replace this"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d81eb01",
+   "metadata": {},
+   "source": [
+    "## Complete this unit\n",
+    "\n",
+    "You've learned how to use `circuit()` to generate diagrams from entry expressions and qubit-only operations, and how to control grouping with `group_by_scope`.\n",
+    "\n",
+    "Run the cell below to mark the unit complete.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68d48e2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from _unit import complete_unit\n",
+    "\n",
+    "complete_unit()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/courses/circuit-diagrams-new/02-circuits/intro.md
+++ b/courses/circuit-diagrams-new/02-circuits/intro.md
@@ -1,0 +1,25 @@
+# Circuit Diagrams
+
+In this unit you'll learn how to generate and display circuit diagrams from Q# operations using the Python API.
+
+You'll explore:
+
+- Rendering circuits with `qsharp.circuit()` and the `Circuit` widget
+- Using `operation=` for qubit-only operations
+- Controlling grouping with `group_by_scope`
+- Handling measurement-based conditionals with `generation_method`
+- Limiting output with `max_operations`
+
+## How it works
+
+1. Click **Open Notebook** below to open the unit notebook.
+2. Work through the examples and exercises in order.
+3. Run the final cell to mark the unit complete, then come back here.
+
+## Before you start
+
+This course runs in its own Python environment. If the notebook's kernel
+won't start, or the first cell reports a problem, set up and check your
+environment here first:
+
+👉 [Check my environment](command:qsharp-vscode.learningDoctor)

--- a/courses/circuit-diagrams-new/README.md
+++ b/courses/circuit-diagrams-new/README.md
@@ -1,0 +1,24 @@
+# Generating Circuit Diagrams
+
+A short, hands-on course that shows how to generate and visualize circuit
+diagrams from Q# operations using the QDK Python API in a Jupyter notebook.
+
+## What you'll learn
+
+- Run Q# code from Python with the `qdk` package.
+- Generate a circuit from a Q# operation with `qdk.qsharp.circuit()`.
+- Display an interactive circuit diagram with the `qdk.widgets.Circuit` widget.
+- Control the rendered output with options like `operation=` and
+  `group_by_scope`.
+
+## Requirements
+
+This course runs in a per-course Python environment that pins:
+
+- `qdk[jupyter]`
+- `ipympl`
+- `ipykernel`
+
+The course environment is created automatically the first time you open the
+course. If anything looks wrong, run **QDK Learning: Run Course Diagnostics**
+to diagnose it.

--- a/courses/circuit-diagrams-new/_check_env.py
+++ b/courses/circuit-diagrams-new/_check_env.py
@@ -1,0 +1,220 @@
+"""Course environment check utility.
+
+Called from the first code cell of each unit notebook. Validates that the
+notebook kernel is running in the course .venv and that all required packages
+are importable. Renders results as styled HTML in the notebook output.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from IPython.display import HTML, display
+
+
+def check(notebook_dir: str | Path | None = None) -> None:
+    """Run the environment check and display results.
+
+    Raises EnvironmentError if anything is wrong, which stops "Run All"
+    from continuing past this cell.
+
+    Parameters
+    ----------
+    notebook_dir : path-like, optional
+        Directory containing the notebook. Defaults to Path.cwd().
+    """
+    nb_dir = Path(notebook_dir) if notebook_dir else Path.cwd()
+
+    # --- Locate course.json ---
+    course_json = _find_course_json(nb_dir)
+    if course_json is None:
+        raise FileNotFoundError(
+            "Could not find course.json. Make sure you opened this notebook "
+            "from the QDK course folder."
+        )
+
+    course = json.loads(course_json.read_text())
+    env_cfg = course.get("environment", {})
+    requirements = env_cfg.get("requirements", [])
+    import_checks = env_cfg.get("importChecks", [])
+
+    results: list[tuple[str, str, bool]] = []  # (label, detail, ok)
+    errors: list[str] = []
+
+    # --- Check 1: Python version ---
+    py_version = sys.version.split()[0]
+    results.append(("Python version", py_version, True))
+
+    # --- Check 2: course .venv exists and has a Python interpreter ---
+    course_root = course_json.resolve().parent
+    expected_venv = (course_root / ".venv").resolve()
+    venv_exists = expected_venv.is_dir()
+    venv_python = _find_venv_python(expected_venv) if venv_exists else None
+
+    if not venv_exists:
+        results.append(("Course venv", f"{expected_venv} — not found", False))
+        errors.append(
+            "The course virtual environment does not exist yet.<br>"
+            "Run <b>QDK Learning: Doctor</b> from the Command Palette "
+            "(<code>Ctrl+Shift+P</code> / <code>Cmd+Shift+P</code>) "
+            "and choose <b>Set up environment</b>."
+            + _command_link("qsharp-vscode.learningDoctor", "Run Doctor now")
+        )
+    elif not venv_python:
+        results.append(("Course venv", f"{expected_venv} — corrupt (no python)", False))
+        errors.append(
+            "The course virtual environment exists but has no Python interpreter.<br>"
+            "Run <b>QDK Learning: Doctor</b> from the Command Palette "
+            "and choose <b>Set up environment</b> to recreate it."
+            + _command_link("qsharp-vscode.learningDoctor", "Run Doctor now")
+        )
+    else:
+        results.append(("Course venv", str(expected_venv), True))
+
+    # --- Check 3: kernel is actually using the course .venv ---
+    prefix = Path(sys.prefix).resolve()
+
+    in_course_venv = False
+    if venv_exists:
+        try:
+            prefix.relative_to(expected_venv)
+            in_course_venv = True
+        except ValueError:
+            pass
+
+    if venv_exists and venv_python and not in_course_venv:
+        results.append(("Kernel", f"Expected {expected_venv}, got {prefix}", False))
+        errors.append(
+            "This kernel is not the course environment. "
+            "Click <b>Select Kernel</b> (top-right of the notebook) "
+            "and pick the course <code>.venv</code>, then re-run this cell."
+        )
+
+    # --- Check 4: required packages ---
+    missing = [m for m in import_checks if importlib.util.find_spec(m) is None]
+
+    if missing:
+        results.append(
+            ("Packages", ", ".join(f"<code>{m}</code> missing" for m in missing), False)
+        )
+        # Check if this course uses pyproject.toml (uv sync) or legacy requirements.
+        has_pyproject = (course_root / "pyproject.toml").exists()
+        if has_pyproject:
+            errors.append(
+                "Some packages are missing from the course environment.<br>"
+                "Run <b>QDK Learning: Doctor</b> to re-sync, or manually run "
+                "<code>uv sync</code> in the course folder."
+                + _command_link("qsharp-vscode.learningDoctor", "Run Doctor now")
+            )
+        else:
+            pip_cmd = f"%pip install {' '.join(requirements)}"
+            errors.append(
+                "Install missing packages by running this in a new cell, then re-run this one:"
+                f"<pre>  {pip_cmd}</pre>"
+                "Or run <b>QDK Learning: Doctor</b> to set up the full environment."
+                + _command_link("qsharp-vscode.learningDoctor", "Run Doctor now")
+            )
+    elif import_checks and in_course_venv:
+        results.append(("Packages", ", ".join(import_checks), True))
+
+    # --- Render ---
+    _render(results, errors)
+
+    if errors:
+        raise EnvironmentError(
+            "Environment check failed. See output above for details."
+        )
+
+
+def _find_venv_python(venv: Path) -> Path | None:
+    """Return the venv's Python interpreter path, or None if missing."""
+    candidates = [
+        venv / "bin" / "python",
+        venv / "bin" / "python3",
+        venv / "Scripts" / "python.exe",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def _command_link(command_id: str, label: str) -> str:
+    """Return an HTML link that invokes a VS Code command when clicked.
+
+    VS Code renders `vscode://` and `command:` URIs in trusted notebook
+    HTML output, so clicking the link runs the command directly.
+    """
+    from urllib.parse import quote
+
+    return (
+        f'<br><a href="command:{quote(command_id)}" '
+        f'style="display:inline-block;margin-top:6px;padding:4px 10px;'
+        f"background:#1976d2;color:#fff;border-radius:4px;"
+        f'text-decoration:none;font-size:0.9em">'
+        f"{label}</a>"
+    )
+
+
+def _find_course_json(nb_dir: Path) -> Path | None:
+    """Walk up from nb_dir looking for course.json."""
+    candidate = nb_dir / "course.json"
+    if candidate.exists():
+        return candidate
+    # One level up (unit notebook inside a subdirectory).
+    candidate = (nb_dir / ".." / "course.json").resolve()
+    if candidate.exists():
+        return candidate
+    # Two levels up (deeply nested unit).
+    candidate = (nb_dir / ".." / ".." / "course.json").resolve()
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _render(results: list[tuple[str, str, bool]], errors: list[str]) -> None:
+    """Display a styled HTML summary."""
+    rows = ""
+    for label, detail, ok in results:
+        icon = "&#x2705;" if ok else "&#x274C;"
+        color = "#2e7d32" if ok else "#c62828"
+        rows += (
+            f'<tr style="border-bottom:1px solid #eee">'
+            f'<td style="padding:4px 12px 4px 0;font-size:1.1em">{icon}</td>'
+            f'<td style="padding:4px 12px;font-weight:600">{label}</td>'
+            f'<td style="padding:4px 0;color:{color}">{detail}</td>'
+            f"</tr>"
+        )
+
+    html = (
+        '<div style="font-family:system-ui,sans-serif;margin:8px 0">'
+        '<table style="border-collapse:collapse">'
+        f"{rows}"
+        "</table>"
+    )
+
+    if errors:
+        error_items = "".join(f"<li style='margin:4px 0'>{e}</li>" for e in errors)
+        html += (
+            '<div style="margin-top:12px;padding:10px 14px;'
+            "background:#fff3e0;border-left:4px solid #e65100;"
+            'border-radius:4px">'
+            f"<strong>Action needed:</strong><ul style='margin:6px 0 0 0;padding-left:18px'>{error_items}</ul>"
+            "</div>"
+        )
+    else:
+        html += (
+            '<div style="margin-top:12px;padding:10px 14px;'
+            "background:#e8f5e9;border-left:4px solid #2e7d32;"
+            'border-radius:4px">'
+            "<strong>Environment looks good. You're ready to continue!</strong>"
+            "</div>"
+        )
+
+    html += "</div>"
+    display(HTML(html))
+
+
+if __name__ == "__main__":
+    check()

--- a/courses/circuit-diagrams-new/_course_lib.py
+++ b/courses/circuit-diagrams-new/_course_lib.py
@@ -1,0 +1,204 @@
+"""Shared course utilities — the exercise harness and unit completion.
+
+This module lives at the course root. Per-unit helper files (`_unit.py`) import
+from it and re-export the small surface the notebooks need.
+
+The exercise model
+------------------
+Learners solve an exercise by implementing a function decorated with ``@exercise``.
+
+A unit registers a checker for each exercise *by function name* (see
+``register_value_exercise`` / ``register_circuit_exercise``). When the learner
+runs their decorated cell, ``exercise`` looks up the matching checker, calls the
+learner's function, validates the result and renders a pass/fail banner and other
+relevant visuals or output.
+"""
+
+import re
+from pathlib import Path
+from typing import Callable
+
+from IPython.display import HTML, display
+
+# Registry of exercises that have passed in this kernel session.
+_passed: set[str] = set()
+
+# A checker takes the learner's function and verifies it.
+Checker = Callable[[Callable[[], object]], None]
+
+# Registry of checkers, keyed by exercise function name.
+_checkers: dict[str, Checker] = {}
+
+# Exercise names in registration order. A unit's required set is derived from
+# this, so each exercise name is written exactly once (in its register call).
+_registered: list[str] = []
+
+
+def _register(name: str, checker: Checker) -> str:
+    """Record a checker under ``name`` and return the name."""
+    _checkers[name] = checker
+    if name not in _registered:
+        _registered.append(name)
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _pass(message: str) -> None:
+    """Render a green success banner."""
+    display(
+        HTML(
+            '<div style="font-family:system-ui,sans-serif;margin:8px 0;'
+            "padding:10px 14px;background:#e8f5e9;border-left:4px solid #2e7d32;"
+            'border-radius:4px">'
+            f"&#x2705; <strong>{message}</strong>"
+            "</div>"
+        )
+    )
+
+
+def _fail(message: str) -> None:
+    """Render an orange failure banner and raise AssertionError."""
+    display(
+        HTML(
+            '<div style="font-family:system-ui,sans-serif;margin:8px 0;'
+            "padding:10px 14px;background:#fff3e0;border-left:4px solid #e65100;"
+            'border-radius:4px">'
+            f"&#x274C; <strong>{message}</strong>"
+            "</div>"
+        )
+    )
+    raise AssertionError(message)
+
+
+# ---------------------------------------------------------------------------
+# The exercise decorator
+# ---------------------------------------------------------------------------
+
+
+def exercise(fn):
+    """Decorator for a learner's exercise function.
+
+    Looks up the checker registered for ``fn.__name__`` and runs it. The
+    learner just writes the function body and a ``return`` — running the cell
+    runs the verification.
+    """
+    checker = _checkers.get(fn.__name__)
+    if checker is None:
+        _fail(
+            f"No checker is registered for an exercise named "
+            f"<code>{fn.__name__}</code>. Don't rename the function — "
+            "it must keep the name we gave you."
+        )
+        return fn
+    checker(fn)
+    return fn
+
+
+def _run(fn):
+    """Call the learner's function, surfacing errors as a failure banner."""
+    try:
+        return fn()
+    except Exception as e:  # noqa: BLE001 — surface any learner error nicely
+        _fail(
+            f"Your <code>{fn.__name__}</code> function raised an error: "
+            f"<code>{type(e).__name__}: {e}</code>"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Value exercises
+# ---------------------------------------------------------------------------
+
+
+def register_value_exercise(name: str, *, expected) -> str:
+    """Register an exercise whose function must return ``expected``."""
+
+    def checker(fn) -> None:
+        actual = _run(fn)
+        if actual != expected:
+            _fail(
+                f"<code>{name}()</code> returned <code>{actual!r}</code>, "
+                f"but expected <code>{expected!r}</code>."
+            )
+        else:
+            _passed.add(name)
+            _pass(f"Correct! <code>{name}()</code> returned {actual!r}.")
+
+    return _register(name, checker)
+
+
+# ---------------------------------------------------------------------------
+# Custom exercises
+# ---------------------------------------------------------------------------
+
+
+def register_exercise(
+    name: str,
+    validate: Callable[[object], str | None],
+    *,
+    success_message: str = "Correct!",
+    on_success: Callable[[object], None] | None = None,
+) -> str:
+    """Register an exercise with a unit-defined validation function.
+
+    Use this when a unit needs bespoke checking that isn't covered by the
+    generic helpers above. ``validate(result)`` inspects the value returned by
+    the learner's function and returns an HTML error message if it's wrong, or
+    ``None`` if it's correct. On success a banner with ``success_message`` is
+    shown, ``on_success(result)`` is called (e.g. to display a widget), and the
+    exercise is recorded as passed.
+    """
+
+    def checker(fn) -> None:
+        result = _run(fn)
+        error = validate(result)
+        if error:
+            _fail(error)
+            return
+        _passed.add(name)
+        _pass(success_message)
+        if on_success is not None:
+            on_success(result)
+
+    return _register(name, checker)
+
+
+# ---------------------------------------------------------------------------
+# Unit completion
+# ---------------------------------------------------------------------------
+
+
+def complete_unit(required_exercises: list[str] | None = None) -> None:
+    """Verify all exercises passed and write the unit-complete marker.
+
+    When ``required_exercises`` is omitted, every exercise registered in this
+    kernel session is required — i.e. all of the current unit's exercises.
+    """
+    if required_exercises is None:
+        required_exercises = _registered
+    missing = [e for e in required_exercises if e not in _passed]
+    if missing:
+        names = ", ".join(f"`{e}`" for e in missing)
+        raise AssertionError(
+            f"Not all exercises are complete. Missing: {names}. "
+            "Run the exercise cells above first."
+        )
+
+    unit_id = re.sub(r"^\d+-", "", Path.cwd().name)
+
+    marker = Path(".qdk-unit-complete")
+    marker.write_text(f"{unit_id}\n")
+
+    display(
+        HTML(
+            '<div style="font-family:system-ui,sans-serif;margin:12px 0;'
+            "padding:14px 18px;background:#e8f5e9;border-left:4px solid #2e7d32;"
+            'border-radius:4px;font-size:1.1em">'
+            "&#x1F389; <strong>Congratulations — you've completed this unit!</strong>"
+            "</div>"
+        )
+    )

--- a/courses/circuit-diagrams-new/course.json
+++ b/courses/circuit-diagrams-new/course.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "circuit-diagrams",
+  "title": "Generating Circuit Diagrams",
+  "shortDescription": "Build and visualize quantum circuits with the QDK in Python notebooks.",
+  "readme": "README.md",
+  "units": [
+    {
+      "id": "intro",
+      "title": "Getting Started",
+      "dir": "01-intro"
+    },
+    {
+      "id": "circuits",
+      "title": "Circuit Diagrams",
+      "dir": "02-circuits"
+    }
+  ],
+  "environment": {
+    "importChecks": ["qdk", "qdk.widgets"]
+  }
+}

--- a/courses/circuit-diagrams-new/pyproject.toml
+++ b/courses/circuit-diagrams-new/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "circuit-diagrams"
+version = "0.1.0"
+description = "QDK Course: Generating Circuit Diagrams"
+requires-python = ">=3.11"
+dependencies = [
+    "qdk[jupyter]>=1.29",
+    "ipympl>=0.10",
+    "ipykernel>=7.3",
+]

--- a/source/vscode/agents/qdk-learning.agent.md
+++ b/source/vscode/agents/qdk-learning.agent.md
@@ -1,22 +1,24 @@
 ---
 name: QDK Learning
-description: "Learn quantum computing interactively with the Quantum Katas — guided lessons, hands-on exercises, and Q# code you can run, check, and explore right in VS Code."
+description: "Learn quantum computing interactively in VS Code — guided lessons, hands-on exercises, and code you can run, check, and explore. Includes the Quantum Katas and other learning courses."
 model: "Claude Haiku 4.5 (copilot)"
 ---
 
 # Quantum Development Kit Learning
 
-You are an agent that helps users navigate and interact with the Quantum Katas panel in VS Code. Your role is to respond to chat prompts related to the katas, provide hints, explanations, and guidance.
+You are an agent that helps users navigate and interact with the QDK Learning feature in VS Code. Your role is to respond to chat prompts related to the active course, provide hints, explanations, and guidance.
 
-The `qdk-learning-*` tools drive a **Quantum Katas panel** in VS Code. The panel renders the current activity, action bar, and progress bar. Its buttons handle navigation, run, check, etc. directly — they bypass the LLM. Your job: set up the workspace, show the current activity, then step aside. You only handle chat prompts and concept questions.
+The `qdk-learning-*` tools drive the QDK Learning UI in VS Code. The Lesson panel renders the current activity, action bar, and progress bar. Its buttons handle navigation, run, check, etc. directly — they bypass the LLM. Your job: set up the workspace, show the current activity, then step aside. You only handle chat prompts and concept questions.
+
+A user can work through more than one **course**. The **Quantum Katas** is the default course. Additional courses may also be available in the workspace. Each course has its own units, activities, and progress.
 
 ## Definitions
 
-Following is a user-ready description of the Quantum Katas. You may refer to it if the user asks what the katas are or how they work.
+The **Quantum Katas** is the flagship course. Following is a user-ready description. You may refer to it if the user asks what the katas are or how they work.
 
 > Quantum Katas (_kaˑta_ | kah-tuh — Japanese for "form", a pattern of learning and practicing new skills) are self-paced, AI-assisted tutorials for quantum computing and Q# programming. Each tutorial includes relevant theory and interactive hands-on exercises designed to test knowledge.
 
-The tools refer to each kata as a "unit." Each unit contains ordered activities (lessons, examples, exercises).
+The tools refer to each unit of a course as a "unit." Each unit contains ordered activities (lessons, examples, exercises).
 
 **Tool naming:** All learning tools share the `qdk-learning-` prefix. This document uses short names (e.g. `show` for `qdk-learning-show`).
 
@@ -28,12 +30,30 @@ The tools refer to each kata as a "unit." Each unit contains ordered activities 
 
 ## Startup
 
-Call `get-state` first. It never requires confirmation and tells you whether the workspace is initialized.
+Call `get-state` first. It never requires confirmation and tells you whether the workspace is initialized and which course is active.
 
-- **If `initialized: true`** — you have the current position and progress. Greet the user briefly, then call `show` to open the activity panel. Direct the user's attention to the Quantum Katas panel so they can continue where they left off.
+- **If `initialized: true`** — you have the current position, active course, and progress. Greet the user briefly, then call `show` to open the activity panel. Direct the user's attention to the Learning panel so they can continue where they left off.
 - **If `initialized: false`** — the workspace hasn't been set up yet. Greet the user warmly and explain what the Quantum Katas are (use the description from **Definitions** above). Then call `show` to initialize the workspace — let the user know they'll be asked to confirm workspace creation. Once initialized, direct them to the panel to get started.
 
 Mention that they can chat with you at any time for hints, explanations, or guidance. Don't explain how the agent works, list tools, or show menus.
+
+## Courses
+
+Multiple courses may be available. The active course is reported by `get-state` (the `course` field) and is the context for all activity, run, and check operations. The **Quantum Katas** is the default course.
+
+| Intent                                | Tool            | Notes                                                                     |
+| ------------------------------------- | --------------- | ------------------------------------------------------------------------- |
+| "What courses are available?"         | `list-courses`  | Returns the available courses and the active course id.                   |
+| "Switch to …" / "Open the … course"   | `switch-course` | Pass the `courseId`. Switching changes the active course and position.    |
+| "Tell me about this course"           | `course-info`   | Returns the course descriptor and README (defaults to the active course). |
+| "Diagnose" / "Set up the environment" | `doctor`        | Runs environment diagnostics for the active course (Python courses).      |
+
+**Handling guidance:**
+
+- When the user asks to change courses, call `list-courses` first if you're unsure of the exact `courseId`, match the user's request to a course, then call `switch-course`. After switching, call `show` to surface the new course's current activity and briefly tell the user where they landed.
+- Drop-in courses run author-provided code and only load in a **trusted** workspace. If a drop-in course doesn't appear or won't run, the workspace may be in Restricted Mode — suggest trusting the workspace.
+- Python notebook courses use a per-course environment. If running or checking a task reports environment or kernel problems, call `doctor` to diagnose; it reports which checks fail and whether a one-click setup can fix them. Q# courses need no environment and always pass `doctor`.
+- Don't switch courses unless the user clearly asks. Panel and tree actions can also switch courses without involving you, so always call `get-state` to learn the current course before answering.
 
 ## Tone
 
@@ -68,6 +88,8 @@ Call `show`. Use the returned state for your greeting. Don't call on every turn 
 
 To start a specific unit: `list-units` → find `unitId` → `goto`.
 
+To change courses: `list-courses` → find `courseId` → `switch-course` → `show`.
+
 ### 2. Route Chat Input
 
 Call `get-state` first. If the user is asking to navigate, run, check, reset, etc., call the matching tool directly. Notable cases:
@@ -75,6 +97,7 @@ Call `get-state` first. If the user is asking to navigate, run, check, reset, et
 - **hint** → use the **Hint Strategy** below instead of just calling the tool
 - **solution** → warn about spoilers before calling
 - **reset** → confirm the user wants to lose their code before calling
+- **switch course / list courses / course info** → use the **Courses** tools (`switch-course`, `list-courses`, `course-info`); call `show` after a switch
 - **"help with my code" / "debug"** → call `read-code`, then give personalized feedback
 - **Q# or QDK question** → if the answer isn't obvious from the current lesson context, **always** read the `/qdk-programming` skill before responding.
 - **free-form question** → answer using knowledge + current state; no tool needed

--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -341,6 +341,22 @@
         {
           "command": "qsharp-vscode.learningAskInChat",
           "when": "false"
+        },
+        {
+          "command": "qsharp-vscode.learningSwitchCourse",
+          "when": "false"
+        },
+        {
+          "command": "qsharp-vscode.learningCourseInfo",
+          "when": "false"
+        },
+        {
+          "command": "qsharp-vscode.learningCheckEnvironment",
+          "when": "qsharp-vscode.learningWorkspaceDetected"
+        },
+        {
+          "command": "qsharp-vscode.learningNotebookHint",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -371,6 +387,28 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "qsharp-vscode.learningSwitchCourse",
+          "group": "inline",
+          "when": "view == qsharp-vscode.learningTree && (viewItem == course || viewItem == coursePython)"
+        },
+        {
+          "command": "qsharp-vscode.learningCourseInfo",
+          "group": "inline",
+          "when": "view == qsharp-vscode.learningTree && (viewItem == course || viewItem == coursePython)"
+        },
+        {
+          "command": "qsharp-vscode.learningSwitchCourse",
+          "when": "view == qsharp-vscode.learningTree && (viewItem == course || viewItem == coursePython)"
+        },
+        {
+          "command": "qsharp-vscode.learningCourseInfo",
+          "when": "view == qsharp-vscode.learningTree && (viewItem == course || viewItem == coursePython)"
+        },
+        {
+          "command": "qsharp-vscode.learningCheckEnvironment",
+          "when": "view == qsharp-vscode.learningTree && viewItem == coursePython"
+        },
         {
           "command": "qsharp-vscode.workspaceOpenPortal",
           "group": "inline",
@@ -418,6 +456,20 @@
           "command": "qsharp-vscode.learningAskInChat",
           "group": "inline",
           "when": "view == qsharp-vscode.learningTree && (viewItem == continue || viewItem == unit || viewItem == lesson || viewItem == exercise || viewItem == example)"
+        }
+      ],
+      "notebook/toolbar": [
+        {
+          "command": "qsharp-vscode.learningNotebookHint",
+          "when": "notebookType == 'jupyter-notebook' && qsharp-vscode.learningWorkspaceDetected",
+          "group": "navigation@100"
+        }
+      ],
+      "notebook/cell/title": [
+        {
+          "command": "qsharp-vscode.learningNotebookHint",
+          "when": "notebookType == 'jupyter-notebook' && qsharp-vscode.learningWorkspaceDetected && notebookCellType == 'code'",
+          "group": "inline/cell@50"
         }
       ],
       "explorer/context": [
@@ -699,6 +751,30 @@
         "title": "Show Current Activity",
         "category": "QDK Learning",
         "icon": "$(mortar-board)"
+      },
+      {
+        "command": "qsharp-vscode.learningSwitchCourse",
+        "title": "Switch Course",
+        "category": "QDK Learning",
+        "icon": "$(arrow-swap)"
+      },
+      {
+        "command": "qsharp-vscode.learningCourseInfo",
+        "title": "Course Info",
+        "category": "QDK Learning",
+        "icon": "$(info)"
+      },
+      {
+        "command": "qsharp-vscode.learningCheckEnvironment",
+        "title": "Run Course Diagnostics",
+        "category": "QDK Learning",
+        "icon": "$(pulse)"
+      },
+      {
+        "command": "qsharp-vscode.learningNotebookHint",
+        "title": "Ask for a Hint",
+        "category": "QDK Learning",
+        "icon": "$(comment-discussion-sparkle)"
       }
     ],
     "breakpoints": [
@@ -1306,6 +1382,94 @@
         "toolReferenceName": "qdkLearningListUnits",
         "displayName": "QDK Learning: List Units",
         "modelDescription": "List all available units with completion status.",
+        "canBeReferencedInPrompt": true,
+        "icon": "./resources/file-icon-light.svg",
+        "inputSchema": {
+          "type": "object",
+          "properties": {},
+          "required": [],
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "qdk-learning-list-courses",
+        "tags": [
+          "qdk",
+          "qdk-learning",
+          "quantum-katas"
+        ],
+        "toolReferenceName": "qdkLearningListCourses",
+        "displayName": "QDK Learning: List Courses",
+        "modelDescription": "List all available learning courses (loaded or not) with their ids, titles, kinds, and the id of the currently-active course. Use the course ids with switch-course or goto.",
+        "canBeReferencedInPrompt": true,
+        "icon": "./resources/file-icon-light.svg",
+        "inputSchema": {
+          "type": "object",
+          "properties": {},
+          "required": [],
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "qdk-learning-switch-course",
+        "tags": [
+          "qdk",
+          "qdk-learning",
+          "quantum-katas"
+        ],
+        "toolReferenceName": "qdkLearningSwitchCourse",
+        "displayName": "QDK Learning: Switch Course",
+        "modelDescription": "Switch the active learning course. Moves to the first incomplete activity in that course and updates the panel. Use a courseId from list-courses.",
+        "canBeReferencedInPrompt": true,
+        "icon": "./resources/file-icon-light.svg",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "courseId": {
+              "type": "string",
+              "description": "ID of the course to switch to (from list-courses)."
+            }
+          },
+          "required": [
+            "courseId"
+          ],
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "qdk-learning-course-info",
+        "tags": [
+          "qdk",
+          "qdk-learning",
+          "quantum-katas"
+        ],
+        "toolReferenceName": "qdkLearningCourseInfo",
+        "displayName": "QDK Learning: Course Info",
+        "modelDescription": "Return the descriptor and README content (if any) for a course. Defaults to the active course when no courseId is provided.",
+        "canBeReferencedInPrompt": true,
+        "icon": "./resources/file-icon-light.svg",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "courseId": {
+              "type": "string",
+              "description": "ID of the course. Omit for the active course."
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "qdk-learning-check-environment",
+        "tags": [
+          "qdk",
+          "qdk-learning",
+          "quantum-katas"
+        ],
+        "toolReferenceName": "qdkLearningCheckEnvironment",
+        "displayName": "QDK Learning: Check Environment",
+        "modelDescription": "Run environment diagnostics for the active learning course. Returns structured checks (Python interpreter, virtual environment, fingerprint, required packages) and whether a one-click environment setup can fix any failures. Q# courses need no environment and pass trivially.",
         "canBeReferencedInPrompt": true,
         "icon": "./resources/file-icon-light.svg",
         "inputSchema": {

--- a/source/vscode/prompts/qdk-learning.prompt.md
+++ b/source/vscode/prompts/qdk-learning.prompt.md
@@ -5,4 +5,4 @@ agent: QDK Learning
 argument-hint: Chat with the QDK Learning agent. e.g. "give me a hint", "check my solution", "run my code"
 ---
 
-Let's do the Quantum Katas.
+Let's learn quantum computing with the QDK. Start with the Quantum Katas, or switch to another available course.

--- a/source/vscode/src/extension.ts
+++ b/source/vscode/src/extension.ts
@@ -17,6 +17,7 @@ import { startOtherQSharpDiagnostics } from "./diagnostics.js";
 import { removeDeprecatedCopilotInstructions } from "./gh-copilot/instructions.js";
 import { registerLanguageModelTools } from "./gh-copilot/tools.js";
 import { initLearning } from "./learning/index.js";
+import type { LearningService } from "./learning/index.js";
 import { activateLanguageService } from "./language-service/activate.js";
 import {
   Logging,
@@ -104,6 +105,11 @@ export async function activate(
   if (vscode.env.uiKind !== vscode.UIKind.Web) {
     const learningService = initLearning(context);
     registerLanguageModelTools(context, learningService);
+    if (context.extensionMode === vscode.ExtensionMode.Test) {
+      // Test-only seam: expose the learning service so integration tests can
+      // drive multi-course flows without UI automation.
+      api.learning = learningService;
+    }
   }
   // fire-and-forget
   removeDeprecatedCopilotInstructions(context);
@@ -214,6 +220,8 @@ export interface ExtensionApi {
   // Only available in test mode. Allows listening to extension log events.
   logging?: Logging;
   setGithubEndpoint: (endpoint: string) => void;
+  // Only available in test mode on desktop. The multi-course learning service.
+  learning?: LearningService;
 }
 
 export class QsTextDocumentContentProvider

--- a/source/vscode/src/gh-copilot/learningTools.ts
+++ b/source/vscode/src/gh-copilot/learningTools.ts
@@ -7,6 +7,8 @@ import {
   LEARNING_WORKSPACE_FOLDER,
   detectLearningWorkspace,
   resolveNewWorkspaceRoot,
+  type CourseDescriptor,
+  type EnvironmentCheckReport,
   type HintContext,
   type UnitSummary,
   type OverallProgress,
@@ -24,6 +26,8 @@ import { CopilotToolError } from "./types.js";
  * curriculum without needing a separate round-trip.
  */
 export interface SerializedLearningState {
+  /** The currently-active course. */
+  course: { id: string; title: string; kind: string };
   position: CurrentActivity;
   progress: {
     totalActivities: number;
@@ -137,12 +141,83 @@ export class LearningTools {
   }
 
   /**
-   * Read the user's current Q# code at the active exercise or example.
+   * List all available courses (loaded or not) with the active course id.
+   */
+  async listCourses(): Promise<{
+    courses: CourseDescriptor[];
+    activeCourseId: string;
+  }> {
+    await this.ensureInitialized();
+    return {
+      courses: await this.service.getCourses(),
+      activeCourseId: this.service.getActiveCourseId(),
+    };
+  }
+
+  /**
+   * Switch the active course, moving to its first incomplete activity.
+   */
+  async switchCourse(input: { courseId: string }): Promise<StateSnapshot> {
+    await this.ensureInitialized();
+    return this.invoke(async () => {
+      await this.service.switchCourse(input.courseId, "chat");
+      await this.showActivity();
+      return { state: this.serializeState() };
+    });
+  }
+
+  /**
+   * Return descriptor and README content (if any) for a course. Defaults
+   * to the active course when no id is provided.
+   */
+  async courseInfo(input?: { courseId?: string }): Promise<{
+    descriptor: CourseDescriptor | undefined;
+    readme?: string;
+  }> {
+    await this.ensureInitialized();
+    return this.invoke(async () => {
+      const courseId = input?.courseId ?? this.service.getActiveCourseId();
+      const courses = await this.service.getCourses();
+      const descriptor = courses.find((c) => c.id === courseId);
+      let readme: string | undefined;
+      if (descriptor?.readmePath) {
+        try {
+          const bytes = await vscode.workspace.fs.readFile(
+            vscode.Uri.parse(descriptor.readmePath),
+          );
+          readme = new TextDecoder().decode(bytes);
+        } catch {
+          readme = undefined;
+        }
+      }
+      return { descriptor, readme };
+    });
+  }
+
+  /**
+   * Run environment diagnostics for the active course and return the
+   * structured report (passing/failing checks plus whether a one-click
+   * environment setup is available).
+   */
+  async checkEnvironment(): Promise<EnvironmentCheckReport> {
+    await this.ensureInitialized();
+    return this.invoke(() => this.service.runEnvironmentCheck());
+  }
+
+  /**
+   * Read the user's current code at the active exercise or example.
+   * For python-notebook courses, returns the notebook file path.
    */
   async readCode(): Promise<{ code: string; filePath: string }> {
     await this.ensureInitialized();
     return this.invoke(async () => {
       const uri = this.getCurrentFileUri();
+      if (this.service.getActiveCourseInfo().kind === "python-notebook") {
+        return {
+          code: "",
+          filePath: uri.fsPath,
+        };
+      }
       const code = await this.service.readUserCode();
       return { code, filePath: uri.fsPath };
     });
@@ -311,6 +386,7 @@ export class LearningTools {
       : undefined;
 
     return {
+      course: this.service.getActiveCourseInfo(),
       position: state.position,
       progress: {
         totalActivities: progress.stats.totalActivities,

--- a/source/vscode/src/gh-copilot/tools.ts
+++ b/source/vscode/src/gh-copilot/tools.ts
@@ -126,6 +126,26 @@ const toolDefinitions: {
     confirm: async () => learningTools!.confirmInit(),
   },
   {
+    name: "qdk-learning-list-courses",
+    tool: async () => await learningTools!.listCourses(),
+    confirm: async () => learningTools!.confirmInit(),
+  },
+  {
+    name: "qdk-learning-switch-course",
+    tool: async (input) => await learningTools!.switchCourse(input),
+    confirm: async () => learningTools!.confirmInit(),
+  },
+  {
+    name: "qdk-learning-course-info",
+    tool: async (input) => await learningTools!.courseInfo(input),
+    confirm: async () => learningTools!.confirmInit(),
+  },
+  {
+    name: "qdk-learning-check-environment",
+    tool: async () => await learningTools!.checkEnvironment(),
+    confirm: async () => learningTools!.confirmInit(),
+  },
+  {
     name: "qdk-learning-next",
     tool: async () => await learningTools!.next(),
     confirm: async () => learningTools!.confirmInit(),

--- a/source/vscode/src/learning/catalog.ts
+++ b/source/vscode/src/learning/catalog.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 import { getAllKatas } from "qsharp-lang/katas-md";
+import * as vscode from "vscode";
 import { KATAS_COURSE_ID } from "./constants.js";
+import { CourseRegistry, KatasProvider } from "./courseProvider.js";
+import { DropInCourseProvider } from "./dropInCourseProvider.js";
 import type {
   CatalogUnit,
   CatalogCourse,
@@ -80,5 +83,21 @@ export async function loadKatasCourse(): Promise<CatalogCourse> {
     }),
   }));
 
-  return { id: KATAS_COURSE_ID, title: "Quantum Katas", units };
+  return { id: KATAS_COURSE_ID, title: "Quantum Katas", kind: "qsharp", units };
+}
+
+/**
+ * Create the {@link CourseRegistry} with all available course providers.
+ *
+ * Registers the built-in Quantum Katas provider plus a
+ * {@link DropInCourseProvider} that discovers courses authored on disk
+ * (under `qdk-learning/courses/*`).
+ */
+export function createCourseRegistry(
+  workspaceRoot: vscode.Uri,
+): CourseRegistry {
+  return new CourseRegistry([
+    new KatasProvider(),
+    new DropInCourseProvider(workspaceRoot),
+  ]);
 }

--- a/source/vscode/src/learning/commands.ts
+++ b/source/vscode/src/learning/commands.ts
@@ -59,7 +59,10 @@ export function registerLearningCommands(
     vscode.commands.registerCommand(
       "qsharp-vscode.learningContinue",
       async () => {
-        // No position recorded yet — open chat with a generic start prompt.
+        // Initialize the workspace before opening chat so the agent
+        // finds it already set up and skips the confirmation prompt.
+        await service.tryInitialize({ createIfMissing: true });
+
         await vscode.commands.executeCommand("workbench.action.chat.open", {
           query: "/qdk-learning Let's start the Quantum Katas.",
           isPartialQuery: false,
@@ -75,8 +78,69 @@ export function registerLearningCommands(
           return;
         }
 
+        // If the activity lives in a non-active course, switch first so the
+        // service's active course matches before navigating.
+        if (
+          service.initialized &&
+          location.courseId !== service.getActiveCourseId()
+        ) {
+          await service.switchCourse(location.courseId, "tree");
+        }
+
         await service.goTo(location, "tree");
+
+        // For python-notebook exercise activities, open the notebook
+        // directly instead of showing the lesson panel.
+        if (
+          service.getActiveCourseInfo().kind === "python-notebook" &&
+          node.kind === "activity" &&
+          node.activity.type === "exercise"
+        ) {
+          const notebookUri = service.getCurrentCodeFileUri();
+          if (notebookUri) {
+            await vscode.commands.executeCommand(
+              "vscode.openWith",
+              notebookUri,
+              "jupyter-notebook",
+              { viewColumn: vscode.ViewColumn.Active, preview: false },
+            );
+            return;
+          }
+        }
+
         await panelManager.show();
+      },
+    ),
+
+    // Multi-course commands
+
+    vscode.commands.registerCommand(
+      "qsharp-vscode.learningSwitchCourse",
+      async (node?: LearningProgressNode) => {
+        const courseId = await resolveCourseId(service, node);
+        if (!courseId) {
+          return;
+        }
+        await service.switchCourse(courseId, "tree");
+        await panelManager.show();
+      },
+    ),
+
+    vscode.commands.registerCommand(
+      "qsharp-vscode.learningCourseInfo",
+      async (node?: LearningProgressNode) => {
+        const courseId = await resolveCourseId(service, node);
+        if (!courseId) {
+          return;
+        }
+        await showCourseInfo(service, courseId);
+      },
+    ),
+
+    vscode.commands.registerCommand(
+      "qsharp-vscode.learningCheckEnvironment",
+      async (node?: LearningProgressNode) => {
+        await runEnvironmentCheckCommand(service, node);
       },
     ),
 
@@ -101,11 +165,46 @@ export function registerLearningCommands(
         });
       },
     ),
+
+    vscode.commands.registerCommand(
+      "qsharp-vscode.learningNotebookHint",
+      async (arg?: number | { cell: vscode.NotebookCell }) => {
+        if (!service.initialized) {
+          return;
+        }
+
+        const courseInfo = service.getActiveCourseInfo();
+        if (courseInfo.kind !== "python-notebook") {
+          return;
+        }
+
+        // Resolve 1-based cell number from the argument:
+        // - number: passed directly from the cell status bar item
+        // - { cell }: passed by VS Code when invoked from notebook/cell/title
+        let cellNumber: number | undefined;
+        if (typeof arg === "number") {
+          cellNumber = arg;
+        } else if (arg && "cell" in arg) {
+          cellNumber = arg.cell.index + 1;
+        }
+
+        // Navigate to the exercise so the service state matches.
+        if (cellNumber) {
+          await service.goToExerciseByCellIndex(cellNumber, "panel");
+        }
+
+        await vscode.commands.executeCommand("workbench.action.chat.open", {
+          query: `/qdk-learning Give me a hint`,
+        });
+      },
+    ),
   );
 }
 
 function nodeToTitle(node: LearningProgressNode): string {
   switch (node.kind) {
+    case "course":
+      return node.descriptor.title;
     case "continue":
       return node.activityTitle;
     case "activity":
@@ -119,6 +218,8 @@ function nodeToLocation(
   node: LearningProgressNode,
 ): ActivityLocation | undefined {
   switch (node.kind) {
+    case "course":
+      return undefined;
     case "continue":
       return node.location;
     case "activity":
@@ -136,5 +237,132 @@ function nodeToLocation(
         activityId: first.id,
       };
     }
+  }
+}
+
+/**
+ * Resolve a target course id from a tree node, or prompt the user with a
+ * quick pick when invoked without one (e.g. from the command palette).
+ */
+async function resolveCourseId(
+  service: LearningService,
+  node?: LearningProgressNode,
+): Promise<string | undefined> {
+  if (node?.kind === "course") {
+    return node.descriptor.id;
+  }
+  if (!service.initialized) {
+    const ok = await service.tryInitialize({ createIfMissing: true });
+    if (!ok) {
+      return undefined;
+    }
+  }
+  const courses = await service.getCourses();
+  if (courses.length === 0) {
+    return undefined;
+  }
+  const activeId = service.getActiveCourseId();
+  const picked = await vscode.window.showQuickPick(
+    courses.map((c) => ({
+      label: c.title,
+      description: c.id === activeId ? "current" : undefined,
+      detail: c.shortDescription,
+      id: c.id,
+    })),
+    { placeHolder: "Select a course" },
+  );
+  return picked?.id;
+}
+
+/** Show a course's README in a markdown preview, or a fallback message. */
+async function showCourseInfo(
+  service: LearningService,
+  courseId: string,
+): Promise<void> {
+  const courses = await service.getCourses();
+  const descriptor = courses.find((c) => c.id === courseId);
+  if (!descriptor) {
+    return;
+  }
+  if (descriptor.readmePath) {
+    const uri = vscode.Uri.parse(descriptor.readmePath);
+    await vscode.commands.executeCommand("markdown.showPreview", uri);
+    return;
+  }
+  const detail = descriptor.shortDescription
+    ? `\n\n${descriptor.shortDescription}`
+    : "";
+  await vscode.window.showInformationMessage(`${descriptor.title}${detail}`, {
+    modal: false,
+  });
+}
+
+/**
+ * Run environment diagnostics for a course and present a rich, readable
+ * report, offering the fixes the report surfaces (e.g. one-click
+ * environment setup, install extensions).
+ */
+async function runEnvironmentCheckCommand(
+  service: LearningService,
+  node?: LearningProgressNode,
+): Promise<void> {
+  if (!service.initialized) {
+    const ok = await service.tryInitialize({ createIfMissing: true });
+    if (!ok) {
+      vscode.window.showWarningMessage("Open a learning workspace first.");
+      return;
+    }
+  }
+  // If invoked on a specific course node, diagnose that course.
+  const courseId = node?.kind === "course" ? node.descriptor.id : undefined;
+  if (courseId && courseId !== service.getActiveCourseId()) {
+    await service.switchCourse(courseId, "tree");
+  }
+
+  const report = await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "Running course diagnostics…",
+    },
+    () => service.runEnvironmentCheck(),
+  );
+
+  const icon: Record<string, string> = {
+    ok: "✓",
+    warn: "▲",
+    fail: "✗",
+    skip: "–",
+  };
+  const statusBadge: Record<string, string> = {
+    ok: "✓ OK",
+    warning: "▲ Warning",
+    error: "✗ Error",
+  };
+
+  const lines = report.checks.map((c) => {
+    const head = `${icon[c.status] ?? "•"} ${c.label}`;
+    const detail = c.detail ? `\n    ${c.detail}` : "";
+    const hint = c.hint ? `\n    → ${c.hint}` : "";
+    return `${head}${detail}${hint}`;
+  });
+
+  const body = [
+    `${statusBadge[report.overallStatus] ?? report.overallStatus} · ${report.summary}`,
+    "",
+    ...lines,
+  ].join("\n");
+
+  const actions = report.fixes.map((r) => r.label);
+  const choice = await vscode.window.showInformationMessage(
+    body,
+    { modal: true },
+    ...actions,
+  );
+  if (!choice) {
+    return;
+  }
+  const fix = report.fixes.find((r) => r.label === choice);
+  if (fix) {
+    await service.applyEnvironmentCheckFix(fix);
   }
 }

--- a/source/vscode/src/learning/constants.ts
+++ b/source/vscode/src/learning/constants.ts
@@ -10,12 +10,21 @@ export const LEARNING_WORKSPACE_RELATIVE_PATH = `./${LEARNING_WORKSPACE_FOLDER}`
 /** Well-known file that marks a workspace folder as a katas workspace. */
 export const LEARNING_FILE = "qdk-learning.json";
 
+/** Subfolder (under the learning folder) that holds drop-in courses. */
+export const LEARNING_COURSES_SUBDIR = "courses";
+
+/** Filename describing a drop-in course. */
+export const COURSE_MANIFEST_FILE = "course.json";
+
 /** Context key set when a learning workspace is detected. */
 export const LEARNING_WORKSPACE_DETECTED_CONTEXT =
   "qsharp-vscode.learningWorkspaceDetected";
 
 /** Course ID for the built-in Quantum Katas. */
 export const KATAS_COURSE_ID = "katas";
+
+/** Per-course virtual environment folder (under the course working copy). */
+export const LEARNING_VENV_DIR = ".venv";
 
 /** Tree view ID for the learning progress panel. */
 export const LEARNING_TREE_VIEW_ID = "qsharp-vscode.learningTree";

--- a/source/vscode/src/learning/courseProvider.ts
+++ b/source/vscode/src/learning/courseProvider.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { loadKatasCourse } from "./catalog.js";
+import { KATAS_COURSE_ID } from "./constants.js";
+import type { CatalogCourse, CourseDescriptor } from "./types.js";
+
+/**
+ * A source of learning courses. Implementations know how to enumerate the
+ * courses they provide and how to fully load a course by id.
+ *
+ * Loading is intentionally split from enumeration so the UI can list
+ * available courses cheaply without materializing every course.
+ */
+export interface CourseProvider {
+  /** Stable identifier for this provider (for diagnostics/telemetry). */
+  readonly id: string;
+  /** Enumerate the descriptors for all courses this provider offers. */
+  listCourses(): Promise<CourseDescriptor[]>;
+  /** Fully load a course by id. Returns `undefined` if not provided here. */
+  loadCourse(id: string): Promise<CatalogCourse | undefined>;
+}
+
+/**
+ * Aggregates multiple {@link CourseProvider}s into a single catalog of
+ * courses. The registry is the single entry point the service uses to
+ * discover and load courses regardless of where they come from.
+ */
+export class CourseRegistry {
+  constructor(private readonly providers: CourseProvider[]) {}
+
+  /** Enumerate descriptors across all providers, in provider order. */
+  async listCourses(): Promise<CourseDescriptor[]> {
+    const all: CourseDescriptor[] = [];
+    const seen = new Set<string>();
+    for (const provider of this.providers) {
+      let descriptors: CourseDescriptor[];
+      try {
+        descriptors = await provider.listCourses();
+      } catch {
+        // A misbehaving provider should not break the whole catalog.
+        continue;
+      }
+      for (const descriptor of descriptors) {
+        if (seen.has(descriptor.id)) {
+          continue;
+        }
+        seen.add(descriptor.id);
+        all.push(descriptor);
+      }
+    }
+    return all;
+  }
+
+  /** Look up a single descriptor by id, or `undefined` if not found. */
+  async getDescriptor(id: string): Promise<CourseDescriptor | undefined> {
+    const all = await this.listCourses();
+    return all.find((d) => d.id === id);
+  }
+
+  /**
+   * Fully load a course by id. Tries each provider in order and returns
+   * the first match. Throws if no provider can load the course.
+   */
+  async loadCourse(id: string): Promise<CatalogCourse> {
+    for (const provider of this.providers) {
+      const course = await provider.loadCourse(id);
+      if (course) {
+        return course;
+      }
+    }
+    throw new Error(`No provider could load course "${id}".`);
+  }
+}
+
+/** Provider for the built-in Quantum Katas course. */
+export class KatasProvider implements CourseProvider {
+  readonly id = "katas-provider";
+
+  async listCourses(): Promise<CourseDescriptor[]> {
+    return [
+      {
+        id: KATAS_COURSE_ID,
+        title: "Quantum Katas",
+        shortDescription:
+          "Hands-on quantum computing tutorials and exercises in Q#.",
+        kind: "qsharp",
+      },
+    ];
+  }
+
+  async loadCourse(id: string): Promise<CatalogCourse | undefined> {
+    if (id !== KATAS_COURSE_ID) {
+      return undefined;
+    }
+    return await loadKatasCourse();
+  }
+}

--- a/source/vscode/src/learning/dropInCourseProvider.ts
+++ b/source/vscode/src/learning/dropInCourseProvider.ts
@@ -1,0 +1,439 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { log } from "qsharp-lang";
+import * as vscode from "vscode";
+import {
+  COURSE_MANIFEST_FILE,
+  LEARNING_COURSES_SUBDIR,
+  LEARNING_WORKSPACE_FOLDER,
+} from "./constants.js";
+import type { CourseProvider } from "./courseProvider.js";
+import type {
+  CatalogActivity,
+  CatalogCourse,
+  CatalogExercise,
+  CatalogLesson,
+  CatalogUnit,
+  CourseDescriptor,
+  CourseEnvironment,
+  NotebookExerciseInfo,
+} from "./types.js";
+
+/**
+ * On-disk shape of a `course.json` manifest. Author-controlled, so every
+ * field is validated before use.
+ */
+interface CourseManifest {
+  schemaVersion?: number;
+  id?: unknown;
+  title?: unknown;
+  shortDescription?: unknown;
+  readme?: unknown;
+  units?: unknown;
+  environment?: unknown;
+}
+
+interface ManifestUnit {
+  id: string;
+  title: string;
+  dir: string;
+}
+
+/** A resolved course folder containing a parsed manifest. */
+interface CourseLocation {
+  /** Folder that contains `course.json`. */
+  dir: vscode.Uri;
+  manifest: CourseManifest;
+}
+
+/**
+ * Loads "drop-in" courses authored as folders on disk. A course is a
+ * folder containing a `course.json` manifest plus per-unit subfolders.
+ * Each unit is a Python notebook (`*.ipynb`) with an `intro.md` for the
+ * lesson panel and optional exercise metadata in `_exercises.json`.
+ *
+ * Course folders are discovered under `qdk-learning/courses/*` in the
+ * workspace. Malformed courses are skipped with a warning rather than
+ * failing the whole load.
+ */
+export class DropInCourseProvider implements CourseProvider {
+  readonly id = "drop-in-provider";
+
+  constructor(private readonly workspaceRoot: vscode.Uri) {}
+
+  async listCourses(): Promise<CourseDescriptor[]> {
+    const locations = await this.discover();
+    const seen = new Set<string>();
+    const descriptors: CourseDescriptor[] = [];
+    for (const loc of locations) {
+      const descriptor = await this.toDescriptor(loc);
+      if (!descriptor || seen.has(descriptor.id)) {
+        if (descriptor && seen.has(descriptor.id)) {
+          log.warn(
+            `Duplicate drop-in course id "${descriptor.id}" ignored at ${loc.dir.toString()}`,
+          );
+        }
+        continue;
+      }
+      seen.add(descriptor.id);
+      descriptors.push(descriptor);
+    }
+    return descriptors;
+  }
+
+  async loadCourse(id: string): Promise<CatalogCourse | undefined> {
+    const locations = await this.discover();
+    for (const loc of locations) {
+      if (manifestString(loc.manifest.id) === id) {
+        return this.parseCourse(loc);
+      }
+    }
+    return undefined;
+  }
+
+  // ─── Discovery ───
+
+  /** Enumerate candidate course folders and parse their manifests. */
+  private async discover(): Promise<CourseLocation[]> {
+    const dirs: vscode.Uri[] = [];
+
+    // The well-known in-workspace courses folder.
+    const coursesRoot = vscode.Uri.joinPath(
+      this.workspaceRoot,
+      LEARNING_WORKSPACE_FOLDER,
+      LEARNING_COURSES_SUBDIR,
+    );
+    for (const child of await readDirSafe(coursesRoot)) {
+      if (child.type === vscode.FileType.Directory) {
+        dirs.push(vscode.Uri.joinPath(coursesRoot, child.name));
+      }
+    }
+
+    const locations: CourseLocation[] = [];
+    for (const dir of dirs) {
+      const manifest = await this.readManifest(dir);
+      if (manifest) {
+        locations.push({ dir, manifest });
+      }
+    }
+    return locations;
+  }
+
+  /** Read and JSON-parse a course manifest, or `undefined` if absent/invalid. */
+  private async readManifest(
+    dir: vscode.Uri,
+  ): Promise<CourseManifest | undefined> {
+    const manifestUri = vscode.Uri.joinPath(dir, COURSE_MANIFEST_FILE);
+    const text = await tryReadText(manifestUri);
+    if (text === undefined) {
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(text) as CourseManifest;
+      if (
+        manifestString(parsed.id) === undefined ||
+        manifestString(parsed.title) === undefined
+      ) {
+        log.warn(
+          `Ignoring drop-in course at ${dir.toString()}: "id" and "title" are required.`,
+        );
+        return undefined;
+      }
+      return parsed;
+    } catch (e) {
+      log.warn(`Failed to parse ${manifestUri.toString()}: ${String(e)}`);
+      return undefined;
+    }
+  }
+
+  // ─── Parsing ───
+
+  private async toDescriptor(
+    loc: CourseLocation,
+  ): Promise<CourseDescriptor | undefined> {
+    const id = manifestString(loc.manifest.id);
+    const title = manifestString(loc.manifest.title);
+    if (id === undefined || title === undefined) {
+      return undefined;
+    }
+    const descriptor: CourseDescriptor = {
+      id,
+      title,
+      kind: "python-notebook",
+      shortDescription: manifestString(loc.manifest.shortDescription),
+      environment: manifestEnvironment(loc.manifest.environment),
+    };
+    const readme = manifestString(loc.manifest.readme);
+    if (readme) {
+      const readmeUri = vscode.Uri.joinPath(loc.dir, readme);
+      if (await uriExists(readmeUri)) {
+        descriptor.readmePath = readmeUri.toString();
+      }
+    }
+    return descriptor;
+  }
+
+  private async parseCourse(
+    loc: CourseLocation,
+  ): Promise<CatalogCourse | undefined> {
+    const id = manifestString(loc.manifest.id);
+    const title = manifestString(loc.manifest.title);
+    if (id === undefined || title === undefined) {
+      return undefined;
+    }
+
+    const units: CatalogUnit[] = [];
+    for (const manifestUnit of manifestUnits(loc.manifest.units, loc.dir)) {
+      const unitDir = vscode.Uri.joinPath(loc.dir, manifestUnit.dir);
+      if (!(await uriExists(unitDir))) {
+        log.warn(
+          `Skipping unit "${manifestUnit.id}" in course "${id}": dir not found (${manifestUnit.dir}).`,
+        );
+        continue;
+      }
+      const { activities, notebookExercises, notebookRel } =
+        await this.parseNotebookUnit(unitDir, manifestUnit);
+      if (activities.length === 0) {
+        log.warn(
+          `Unit "${manifestUnit.id}" in course "${id}" has no activities.`,
+        );
+      }
+      units.push({
+        id: manifestUnit.id,
+        title: manifestUnit.title,
+        activities,
+        notebookExercises,
+        notebookRel,
+      });
+    }
+
+    return {
+      id,
+      title,
+      kind: "python-notebook",
+      units,
+      sourceDir: loc.dir.toString(),
+      environment: manifestEnvironment(loc.manifest.environment),
+    };
+  }
+
+  /**
+   * Parse a `python-notebook` unit. Each unit produces a single text-lesson
+   * activity from `intro.md` in the unit dir. The notebook itself is
+   * opened by the user through the panel's "Open Notebook" action; the
+   * extension does not parse or execute cells.
+   *
+   * Exercise metadata (hints, solutions) is loaded from `_exercises.json`
+   * if present and attached to the returned unit for use by chat LM tools.
+   */
+  private async parseNotebookUnit(
+    unitDir: vscode.Uri,
+    unit: ManifestUnit,
+  ): Promise<{
+    activities: CatalogActivity[];
+    notebookExercises?: NotebookExerciseInfo[];
+    notebookRel?: string;
+  }> {
+    // Find the source notebook file in the unit dir. Materialized working
+    // copies (`*.workbook.ipynb`) sit beside the source and must be ignored
+    // here so they are never mistaken for the authored source notebook.
+    const entries = await readDirSafe(unitDir);
+    const notebookEntry = entries
+      .filter(
+        (e) =>
+          e.type === vscode.FileType.File &&
+          e.name.toLowerCase().endsWith(".ipynb") &&
+          !e.name.toLowerCase().endsWith(".workbook.ipynb"),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name))[0];
+    if (!notebookEntry) {
+      log.warn(
+        `Unit "${unit.id}" has no .ipynb notebook in ${unitDir.fsPath}.`,
+      );
+      return { activities: [] };
+    }
+
+    const notebookRel = `${unit.dir}/${notebookEntry.name}`;
+
+    // Read intro.md for the lesson panel content.
+    const introContent =
+      (await tryReadText(vscode.Uri.joinPath(unitDir, "intro.md"))) ?? "";
+
+    const activities: CatalogActivity[] = [];
+    if (introContent.length > 0) {
+      activities.push({
+        type: "lesson",
+        id: "intro",
+        title: firstHeading(introContent) ?? humanize(unit.id),
+        content: introContent,
+      } satisfies CatalogLesson);
+    } else {
+      // Even without intro.md, emit a minimal lesson so navigation works.
+      activities.push({
+        type: "lesson",
+        id: "intro",
+        title: unit.title,
+        content: `Open the notebook to begin this unit.`,
+      } satisfies CatalogLesson);
+    }
+
+    // Load exercise metadata from _exercises.json (optional).
+    const exercisesJson = await tryReadText(
+      vscode.Uri.joinPath(unitDir, "_exercises.json"),
+    );
+    let notebookExercises: NotebookExerciseInfo[] | undefined;
+    if (exercisesJson) {
+      try {
+        const parsed = JSON.parse(exercisesJson) as {
+          exercises?: unknown;
+        };
+        if (Array.isArray(parsed.exercises)) {
+          notebookExercises = parsed.exercises.filter(
+            (e): e is NotebookExerciseInfo =>
+              !!e &&
+              typeof e === "object" &&
+              typeof (e as NotebookExerciseInfo).id === "string",
+          );
+        }
+      } catch (e) {
+        log.warn(
+          `Failed to parse _exercises.json in unit "${unit.id}": ${String(e)}`,
+        );
+      }
+    }
+
+    // Surface each notebook exercise as a catalog activity so it appears
+    // in the progress tree and can be navigated to.
+    if (notebookExercises) {
+      for (const ex of notebookExercises) {
+        activities.push({
+          type: "exercise",
+          id: ex.id,
+          title: ex.title,
+          description: ex.description,
+          placeholderCode: "",
+          sourceIds: [],
+          hints: ex.hints,
+          solutionCodes: ex.solution ? [ex.solution] : [],
+          solutionExplanation: ex.solutionExplanation ?? "",
+        } satisfies CatalogExercise);
+      }
+    }
+
+    return { activities, notebookExercises, notebookRel };
+  }
+}
+
+// ─── Manifest field validation ───
+
+function manifestString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function manifestEnvironment(value: unknown): CourseEnvironment | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const obj = value as {
+    requirements?: unknown;
+    python?: unknown;
+    importChecks?: unknown;
+  };
+  const env: CourseEnvironment = {};
+
+  if (
+    Array.isArray(obj.requirements) &&
+    obj.requirements.every((r) => typeof r === "string")
+  ) {
+    env.requirements = obj.requirements as string[];
+  }
+
+  if (typeof obj.python === "string" && obj.python.length > 0) {
+    env.python = obj.python;
+  }
+
+  if (
+    Array.isArray(obj.importChecks) &&
+    obj.importChecks.every((r) => typeof r === "string")
+  ) {
+    env.importChecks = obj.importChecks as string[];
+  }
+
+  return env;
+}
+
+function manifestUnits(value: unknown, dir: vscode.Uri): ManifestUnit[] {
+  if (!Array.isArray(value)) {
+    log.warn(`Course at ${dir.toString()} has no "units" array.`);
+    return [];
+  }
+  const units: ManifestUnit[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object") {
+      continue;
+    }
+    const id = manifestString((raw as { id?: unknown }).id);
+    const title = manifestString((raw as { title?: unknown }).title);
+    const unitDir = manifestString((raw as { dir?: unknown }).dir);
+    if (id === undefined || title === undefined || unitDir === undefined) {
+      log.warn(
+        `Ignoring malformed unit in course at ${dir.toString()} (requires id, title, dir).`,
+      );
+      continue;
+    }
+    units.push({ id, title, dir: unitDir });
+  }
+  return units;
+}
+
+// ─── Filesystem helpers ───
+
+async function readDirSafe(
+  uri: vscode.Uri,
+): Promise<{ name: string; type: vscode.FileType }[]> {
+  try {
+    const entries = await vscode.workspace.fs.readDirectory(uri);
+    return entries.map(([name, type]) => ({ name, type }));
+  } catch {
+    return [];
+  }
+}
+
+async function tryReadText(uri: vscode.Uri): Promise<string | undefined> {
+  try {
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+async function uriExists(uri: vscode.Uri): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(uri);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Text helpers ───
+
+/** First markdown ATX heading (`# Title`) in the text, if any. */
+function firstHeading(markdown: string): string | undefined {
+  const match = markdown.match(/^#{1,6}\s+(.+?)\s*$/m);
+  return match ? match[1].trim() : undefined;
+}
+
+/** Turn a file/dir slug into a human-readable title. */
+function humanize(slug: string): string {
+  return slug
+    .replace(/^\d+[-_.\s]*/, "")
+    .split(/[-_\s]+/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/source/vscode/src/learning/index.ts
+++ b/source/vscode/src/learning/index.ts
@@ -8,6 +8,7 @@ import {
 } from "./codeLens.js";
 import { registerLearningCommands } from "./commands.js";
 import { LessonPanelManager, registerLessonPanelSerializer } from "./panel.js";
+import { createNotebookCellStatusBarProvider } from "./notebookCellStatusBar.js";
 import { registerLearningProgressView } from "./progressTreeView.js";
 import { LearningService } from "./service.js";
 import { registerLearningWelcomeView } from "./welcomeView.js";
@@ -30,6 +31,34 @@ export function initLearning(
       createLearningCodeLensProvider(),
     ),
   );
+  context.subscriptions.push(
+    vscode.notebooks.registerNotebookCellStatusBarItemProvider(
+      "jupyter-notebook",
+      createNotebookCellStatusBarProvider(learningService),
+    ),
+  );
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeNotebookDocument((e) => {
+      // When a cell finishes executing (executionSummary changes), check
+      // if it corresponds to an exercise in the active python-notebook
+      // course and update focus. If execution succeeded, mark complete.
+      if (
+        !learningService.initialized ||
+        learningService.getActiveCourseInfo().kind !== "python-notebook"
+      ) {
+        return;
+      }
+      for (const change of e.cellChanges) {
+        if (change.executionSummary !== undefined) {
+          const cellIndex = change.cell.index + 1;
+          void learningService.goToExerciseByCellIndex(cellIndex, "panel");
+          if (change.executionSummary.success) {
+            void learningService.markExerciseCompleteByCellIndex(cellIndex);
+          }
+        }
+      }
+    }),
+  );
   registerLearningProgressView(context, learningService);
   registerLearningWelcomeView(context, learningService);
   registerLearningCommands(context, learningService, panelManager);
@@ -38,7 +67,10 @@ export function initLearning(
 }
 
 export type {
+  CourseDescriptor,
+  CourseKind,
   CurrentActivity,
+  EnvironmentCheckReport,
   HintContext,
   OverallProgress,
   RunResult,

--- a/source/vscode/src/learning/notebookCellStatusBar.ts
+++ b/source/vscode/src/learning/notebookCellStatusBar.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from "vscode";
+import type { LearningService } from "./service.js";
+
+/**
+ * Pattern that identifies exercise/verification cells in python-notebook
+ * courses. These cells import check functions from the per-unit `_unit`
+ * module (e.g. `from _unit import check_value`).
+ */
+const exerciseCellPattern = /from\s+_unit\s+import\s+check/;
+
+/**
+ * Registers a {@link vscode.NotebookCellStatusBarItemProvider} that adds a
+ * "Ask for a Hint" button to exercise code cells in python-notebook courses.
+ */
+export function createNotebookCellStatusBarProvider(
+  service: LearningService,
+): vscode.NotebookCellStatusBarItemProvider {
+  return {
+    provideCellStatusBarItems(
+      cell: vscode.NotebookCell,
+    ): vscode.NotebookCellStatusBarItem[] {
+      if (!service.initialized) {
+        return [];
+      }
+
+      const courseInfo = service.getActiveCourseInfo();
+      if (courseInfo.kind !== "python-notebook") {
+        return [];
+      }
+
+      // Only annotate code cells whose text contains a check import.
+      if (cell.kind !== vscode.NotebookCellKind.Code) {
+        return [];
+      }
+
+      const text = cell.document.getText();
+      if (!exerciseCellPattern.test(text)) {
+        return [];
+      }
+
+      // Use 1-based cell index as a definitive reference.
+      const cellNumber = cell.index + 1;
+
+      const item = new vscode.NotebookCellStatusBarItem(
+        "$(comment-discussion-sparkle) Ask for a Hint",
+        vscode.NotebookCellStatusBarAlignment.Right,
+      );
+      item.command = {
+        title: "Ask for a Hint",
+        command: "qsharp-vscode.learningNotebookHint",
+        arguments: [cellNumber],
+      };
+      item.tooltip = "Open Copilot Chat for a hint on this exercise";
+      return [item];
+    },
+  };
+}

--- a/source/vscode/src/learning/panel.ts
+++ b/source/vscode/src/learning/panel.ts
@@ -47,6 +47,14 @@ export class LessonPanelManager {
     private readonly service: LearningService,
   ) {}
 
+  /** True when the active course is a python-notebook course. */
+  private get isPythonNotebook(): boolean {
+    return (
+      this.service.initialized &&
+      this.service.getActiveCourseInfo().kind === "python-notebook"
+    );
+  }
+
   /**
    * Show or create the Lesson panel.
    */
@@ -68,16 +76,7 @@ export class LessonPanelManager {
       "qsharp-lesson",
       "Lesson",
       { viewColumn: vscode.ViewColumn.One, preserveFocus: false },
-      {
-        enableScripts: true,
-        enableFindWidget: true,
-        retainContextWhenHidden: true,
-        localResourceRoots: [
-          vscode.Uri.joinPath(this.extensionUri, "out"),
-          vscode.Uri.joinPath(this.extensionUri, "resources"),
-          this.service.learningContentRoot,
-        ],
-      },
+      this.getWebviewOptions(),
     );
 
     this.panel.iconPath = {
@@ -112,6 +111,10 @@ export class LessonPanelManager {
     }
 
     this.panel = panel;
+
+    // Restored panels predate any webview-option changes, so re-apply the
+    // current options (e.g. allowlisted command URIs) before re-rendering.
+    this.panel.webview.options = this.getWebviewOptions();
 
     // Re-set HTML — webview resource URIs change across sessions.
     this.panel.webview.html = this.getWebviewContent(this.panel.webview);
@@ -183,7 +186,10 @@ export class LessonPanelManager {
     if (!this.service.initialized) {
       return;
     }
-    this.sendMessage({ command: "state", state: this.service.getState() });
+    this.sendMessage({
+      command: "state",
+      state: this.service.getStateForPanel(),
+    });
   }
 
   /**
@@ -262,7 +268,7 @@ export class LessonPanelManager {
       command: "result",
       action,
       result,
-      state: this.service.getState(),
+      state: this.service.getStateForPanel(),
     } as Extract<HostToWebviewMessage, { command: "result" }>);
   }
 
@@ -304,6 +310,29 @@ export class LessonPanelManager {
       return;
     }
 
+    if (msg.command === "switchCourse") {
+      await this.service.switchCourse(msg.courseId, "panel");
+      this.sendState();
+      return;
+    }
+
+    if (msg.command === "courseInfo") {
+      await vscode.commands.executeCommand(
+        "qsharp-vscode.learningCourseInfo",
+        msg.courseId
+          ? { kind: "course", descriptor: { id: msg.courseId } }
+          : undefined,
+      );
+      return;
+    }
+
+    if (msg.command === "browseCourses") {
+      await vscode.commands.executeCommand(
+        "qsharp-vscode.learningSwitchCourse",
+      );
+      return;
+    }
+
     if (msg.command === "action") {
       await this.handleAction(msg.action);
     }
@@ -317,12 +346,16 @@ export class LessonPanelManager {
     try {
       switch (action) {
         case "next": {
-          const result = await this.service.next("panel");
+          const result = this.isPythonNotebook
+            ? await this.service.nextUnit("panel")
+            : await this.service.next("panel");
           this.sendResult("next", result);
           break;
         }
         case "back": {
-          const result = await this.service.previous("panel");
+          const result = this.isPythonNotebook
+            ? await this.service.previousUnit("panel")
+            : await this.service.previous("panel");
           this.sendResult("back", result);
           break;
         }
@@ -338,7 +371,7 @@ export class LessonPanelManager {
         }
         case "reset": {
           const confirmed = await vscode.window.showWarningMessage(
-            "Reset this exercise to the original placeholder code? Your current code will be lost.",
+            "Reset this unit to the original notebook? Your current work will be lost.",
             { modal: true },
             "Reset",
           );
@@ -346,6 +379,10 @@ export class LessonPanelManager {
             await this.service.resetExercise("panel");
           }
           this.sendState();
+          break;
+        }
+        case "open-notebook": {
+          await this.openCourseNotebook();
           break;
         }
         default:
@@ -374,6 +411,54 @@ export class LessonPanelManager {
       `${qsharpExtensionId}.runProgram`,
       fileUri,
     );
+  }
+
+  /**
+   * Open the current unit's notebook in the Jupyter editor (column 2).
+   */
+  private async openCourseNotebook(): Promise<void> {
+    if (!this.service.initialized) {
+      return;
+    }
+    const notebookUri = this.service.getCurrentCodeFileUri();
+    if (!notebookUri) {
+      return;
+    }
+    // Set a two-column layout: lesson panel left, notebook right.
+    await vscode.commands.executeCommand("vscode.setEditorLayout", {
+      orientation: 0,
+      groups: [{ size: 0.35 }, { size: 0.65 }],
+    });
+    await vscode.commands.executeCommand(
+      "vscode.openWith",
+      notebookUri,
+      "jupyter-notebook",
+      { viewColumn: vscode.ViewColumn.Two, preview: false },
+    );
+  }
+
+  /**
+   * Webview options for the lesson panel.
+   *
+   * `enableCommandUris` is restricted to an allowlist so author-supplied
+   * markdown (drop-in courses) can link to specific learning commands — e.g.
+   * a "Check my environment" button in a unit overview that runs the
+   * environment check — without granting the ability to invoke arbitrary VS
+   * Code commands.
+   */
+  private getWebviewOptions(): vscode.WebviewPanelOptions &
+    vscode.WebviewOptions {
+    return {
+      enableScripts: true,
+      enableFindWidget: true,
+      retainContextWhenHidden: true,
+      enableCommandUris: ["qsharp-vscode.learningCheckEnvironment"],
+      localResourceRoots: [
+        vscode.Uri.joinPath(this.extensionUri, "out"),
+        vscode.Uri.joinPath(this.extensionUri, "resources"),
+        this.service.learningContentRoot,
+      ],
+    };
   }
 
   private getWebviewContent(webview: vscode.Webview): string {
@@ -415,12 +500,12 @@ export class LessonPanelManager {
   private async checkSolutionAndSendResult(
     source?: TelemetrySource,
   ): Promise<boolean> {
-    const { result, state } = await this.service.checkSolution(source);
+    const { result } = await this.service.checkSolution(source);
     this.sendMessage({
       command: "result",
       action: "check",
       result,
-      state,
+      state: this.service.getStateForPanel(),
     });
     return result.passed;
   }

--- a/source/vscode/src/learning/progressTreeView.ts
+++ b/source/vscode/src/learning/progressTreeView.ts
@@ -4,6 +4,8 @@
 import * as vscode from "vscode";
 import type {
   ActivityLocation,
+  CourseDescriptor,
+  CourseKind,
   UnitProgress,
   OverallProgress,
   ActivityProgress,
@@ -12,14 +14,15 @@ import type { LearningService } from "./service.js";
 import { LEARNING_TREE_VIEW_ID } from "./constants.js";
 
 /**
- * Wire up the QDK Learning progress panel, a `TreeView` of Unit → Activity
- * nodes with action buttons and progress indicators.
+ * Wire up the QDK Learning progress panel, a `TreeView` of
+ * Course → Unit → Activity nodes with action buttons and progress
+ * indicators.
  */
 export function registerLearningProgressView(
   context: vscode.ExtensionContext,
   service: LearningService,
 ): void {
-  const treeDataProvider = new LearningProgressTreeProvider();
+  const treeDataProvider = new LearningProgressTreeProvider(service);
   const treeView = vscode.window.createTreeView(LEARNING_TREE_VIEW_ID, {
     treeDataProvider,
     showCollapseAll: true,
@@ -53,12 +56,48 @@ class LearningProgressTreeProvider implements vscode.TreeDataProvider<LearningPr
 
   private snapshot: OverallProgress | undefined;
 
+  constructor(private readonly service: LearningService) {}
+
   update(snapshot: OverallProgress | undefined): void {
     this.snapshot = snapshot;
     this.emitter.fire(undefined);
   }
 
   getTreeItem(node: LearningProgressNode): vscode.TreeItem {
+    if (node.kind === "course") {
+      const { descriptor, progress, isActive } = node;
+      const totalUnits = progress.units.length;
+      const completedUnits = progress.units.filter(
+        (u) => u.total > 0 && u.completed === u.total,
+      ).length;
+      const item = new vscode.TreeItem(
+        descriptor.title,
+        isActive
+          ? vscode.TreeItemCollapsibleState.Expanded
+          : vscode.TreeItemCollapsibleState.Collapsed,
+      );
+      item.description =
+        totalUnits > 0 ? `${completedUnits}/${totalUnits}` : undefined;
+      item.iconPath =
+        descriptor.kind === "python-notebook" ? iconPython : iconCourse;
+      // The context value drives which package.json menu actions appear.
+      // Python courses get a distinct value so Python-only actions (the
+      // environment check) can be scoped to them.
+      item.contextValue =
+        descriptor.kind === "python-notebook" ? "coursePython" : "course";
+      const envNote =
+        descriptor.kind === "python-notebook"
+          ? " \u00b7 Python environment"
+          : "";
+      item.tooltip = `${descriptor.title}${envNote}${
+        descriptor.shortDescription ? `\n${descriptor.shortDescription}` : ""
+      }`;
+      item.id = isActive
+        ? `course:${descriptor.id}:active`
+        : `course:${descriptor.id}`;
+      return item;
+    }
+
     if (node.kind === "continue") {
       const item = new vscode.TreeItem(
         `Up next: ${node.activityTitle}`,
@@ -128,48 +167,98 @@ class LearningProgressTreeProvider implements vscode.TreeDataProvider<LearningPr
     return item;
   }
 
-  getChildren(node?: LearningProgressNode): LearningProgressNode[] {
-    const snap = this.snapshot;
-    if (!snap) {
-      return [];
+  async getChildren(
+    node?: LearningProgressNode,
+  ): Promise<LearningProgressNode[]> {
+    // Root: one node per available course.
+    if (!node) {
+      if (!this.service.initialized) {
+        return [];
+      }
+      let descriptors: CourseDescriptor[];
+      try {
+        descriptors = await this.service.getCourses();
+      } catch {
+        return [];
+      }
+      const activeCourseId = this.service.getActiveCourseId();
+      const nodes: LearningProgressNode[] = [];
+      for (const descriptor of descriptors) {
+        const isActive = descriptor.id === activeCourseId;
+        let progress: OverallProgress | undefined;
+        if (isActive && this.snapshot) {
+          progress = this.snapshot;
+        } else {
+          try {
+            progress = await this.service.getCourseProgress(descriptor.id);
+          } catch {
+            progress = undefined;
+          }
+        }
+        if (!progress) {
+          continue;
+        }
+        nodes.push({ kind: "course", descriptor, progress, isActive });
+      }
+      return nodes;
     }
 
-    if (!node) {
+    if (node.kind === "course") {
+      const { descriptor, progress, isActive } = node;
       const children: LearningProgressNode[] = [];
-      const { courseId, unitId, activityId } = snap.currentPosition;
 
-      const unit = snap.units.find((u) => u.id === unitId);
-      const activity = unit?.activities.find((a) => a.id === activityId);
-      if (unit && activity) {
-        children.push({
-          kind: "continue",
-          location: { courseId, unitId: unit.id, activityId: activity.id },
-          unitTitle: unit.title,
-          activityTitle: activity.title,
-        });
+      // The "Up next" shortcut targets the active course's saved position.
+      if (isActive) {
+        const { courseId, unitId, activityId } = progress.currentPosition;
+        const unit = progress.units.find((u) => u.id === unitId);
+        const activity = unit?.activities.find((a) => a.id === activityId);
+        if (unit && activity) {
+          children.push({
+            kind: "continue",
+            location: { courseId, unitId: unit.id, activityId: activity.id },
+            unitTitle: unit.title,
+            activityTitle: activity.title,
+          });
+        }
       }
 
-      for (const u of snap.units) {
+      const currentUnitId = isActive
+        ? progress.currentPosition.unitId
+        : undefined;
+      for (const u of progress.units) {
         children.push({
           kind: "unit",
-          courseId,
+          courseId: descriptor.id,
+          courseKind: descriptor.kind,
           unit: u,
-          isCurrent: u.id === unitId,
+          isCurrent: u.id === currentUnitId,
         });
       }
-
       return children;
     }
 
     if (node.kind === "unit") {
-      const { unitId, activityId } = snap.currentPosition;
-      return node.unit.activities.map<LearningProgressNode>((activity) => ({
+      const currentUnitId = this.snapshot?.currentPosition.unitId;
+      const currentActivityId = this.snapshot?.currentPosition.activityId;
+      const isActiveCourse =
+        this.service.initialized &&
+        node.courseId === this.service.getActiveCourseId();
+      // Hide the synthetic "intro" lesson for python-notebook courses —
+      // the panel already shows unit-level content.
+      const activities =
+        node.courseKind === "python-notebook"
+          ? node.unit.activities.filter((a) => a.id !== "intro")
+          : node.unit.activities;
+      return activities.map<LearningProgressNode>((activity) => ({
         kind: "activity",
         courseId: node.courseId,
         unitId: node.unit.id,
         unitTitle: node.unit.title,
         activity,
-        isCurrent: node.unit.id === unitId && activity.id === activityId,
+        isCurrent:
+          isActiveCourse &&
+          node.unit.id === currentUnitId &&
+          activity.id === currentActivityId,
       }));
     }
 
@@ -218,8 +307,15 @@ function buildTreeMessage(
   return `${completedUnits}/${units.length} units complete — ${encouragement}`;
 }
 
-/** Discriminated union for the three kinds of tree nodes. */
+/** Discriminated union for the four kinds of tree nodes. */
 export type LearningProgressNode =
+  | {
+      /** Top-level course node (expandable). */
+      kind: "course";
+      descriptor: CourseDescriptor;
+      progress: OverallProgress;
+      isActive: boolean;
+    }
   | {
       /** Pinned "Up next" shortcut at the top of the tree. */
       kind: "continue";
@@ -231,6 +327,7 @@ export type LearningProgressNode =
       /** Unit node (expandable). */
       kind: "unit";
       courseId: string;
+      courseKind: CourseKind;
       unit: UnitProgress;
       isCurrent: boolean;
     }
@@ -246,6 +343,11 @@ export type LearningProgressNode =
 
 // ─── Tree node icons ───
 
+const iconCourse = new vscode.ThemeIcon("mortar-board");
+const iconPython = new vscode.ThemeIcon(
+  "notebook",
+  new vscode.ThemeColor("charts.blue"),
+);
 const iconContinue = new vscode.ThemeIcon(
   "sparkle",
   new vscode.ThemeColor("charts.blue"),

--- a/source/vscode/src/learning/python/environment.ts
+++ b/source/vscode/src/learning/python/environment.ts
@@ -1,0 +1,491 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { log } from "qsharp-lang";
+import * as vscode from "vscode";
+import { LEARNING_VENV_DIR } from "../constants.js";
+
+/**
+ * Manages per-course Python environments for `python-notebook` courses.
+ *
+ * Every operating-system interaction (creating a venv, installing
+ * packages, registering a Jupyter kernel) is encapsulated behind a method
+ * here and routed through {@link runShell} so the underlying mechanism can
+ * later be swapped for the Python extension's API without touching callers.
+ *
+ * All file access uses `vscode.workspace.fs` and shell work uses the
+ * `vscode.tasks` API, keeping this module free of Node built-ins so the
+ * extension still bundles for VS Code for the Web (where these desktop-only
+ * operations are short-circuited).
+ */
+export class EnvironmentManager {
+  private readonly controllers = new Map<string, vscode.NotebookController>();
+  /** Cached result of probing for `uv` on the PATH. */
+  private _uvAvailable: boolean | undefined;
+
+  dispose(): void {
+    for (const controller of this.controllers.values()) {
+      controller.dispose();
+    }
+    this.controllers.clear();
+  }
+
+  /** The course's virtual environment folder. */
+  venvUri(courseRoot: vscode.Uri): vscode.Uri {
+    return vscode.Uri.joinPath(courseRoot, LEARNING_VENV_DIR);
+  }
+
+  /** True on a host where environment management can run (desktop only). */
+  get supported(): boolean {
+    return vscode.env.uiKind !== vscode.UIKind.Web;
+  }
+
+  /**
+   * Locate a Python interpreter to bootstrap a venv. Prefers the Python
+   * extension's active interpreter, falling back to `python3`/`python`.
+   * Returns `undefined` when none can be determined.
+   */
+  async ensureInterpreter(): Promise<string | undefined> {
+    if (!this.supported) {
+      return undefined;
+    }
+    const fromExtension = await this.activeInterpreterPath();
+    return fromExtension ?? "python3";
+  }
+
+  /** Whether the venv already exists on disk. */
+  async venvExists(courseRoot: vscode.Uri): Promise<boolean> {
+    return uriExists(this.venvUri(courseRoot));
+  }
+
+  /**
+   * Create the course venv if it does not yet exist.
+   *
+   * @param pythonSpec Optional Python version specifier from `course.json`
+   *   (e.g. `">=3.11"`, `"3.12"`). When `uv` is available this is passed
+   *   directly to `uv venv --python <spec>` which lets `uv` discover or
+   *   download a matching interpreter. When `uv` is unavailable, the spec
+   *   is ignored and the system interpreter is used.
+   */
+  async createVenv(courseRoot: vscode.Uri, pythonSpec?: string): Promise<void> {
+    if (!this.supported || (await this.venvExists(courseRoot))) {
+      return;
+    }
+    const cwd = courseRoot;
+    const venvPath = this.venvUri(courseRoot).fsPath;
+
+    // Prefer `uv` when it's available — it's faster and is the modern
+    // default tooling. Fall back to the standard library `venv` module.
+    if (await this.uvAvailable()) {
+      // With `uv`, pass the version spec (e.g. ">=3.11") or fall back to
+      // the system default. `uv` will discover or download a matching
+      // interpreter automatically.
+      const args = ["venv"];
+      if (pythonSpec) {
+        args.push("--python", pythonSpec);
+      }
+      args.push(venvPath);
+
+      const code = await this.runShell(
+        "Create course environment",
+        "uv",
+        args,
+        cwd,
+      );
+      if (code === 0) {
+        return;
+      }
+      log.warn(`\`uv venv\` failed (exit ${code}); falling back to venv.`);
+    }
+
+    // For the stdlib fallback we need an actual interpreter path.
+    const python = await this.ensureInterpreter();
+    if (!python) {
+      throw new Error("No Python interpreter was found.");
+    }
+
+    // Preflight: on some distros the `venv`/`ensurepip` modules are a
+    // separate OS package (e.g. Debian's `python3-venv`). Detect that here
+    // so we can surface an actionable message instead of an opaque failure.
+    const preflight = await this.runShell(
+      "Check Python venv support",
+      python,
+      ["-c", "import venv, ensurepip"],
+      cwd,
+    );
+    if (preflight !== 0) {
+      throw new Error(
+        "This Python installation can't create virtual environments " +
+          "(the `venv`/`ensurepip` modules are missing). On Debian/Ubuntu " +
+          "install them with `sudo apt install python3-venv` (matching your " +
+          "Python version, e.g. `python3.12-venv`), then try again.",
+      );
+    }
+
+    const code = await this.runShell(
+      "Create course environment",
+      python,
+      ["-m", "venv", venvPath],
+      cwd,
+    );
+    if (code !== 0) {
+      throw new Error(
+        `Creating the virtual environment failed (exit ${code}).`,
+      );
+    }
+  }
+
+  /**
+   * Sync the course environment using `uv sync`. This is the preferred
+   * method for courses that ship a `pyproject.toml`. It creates the `.venv`
+   * in the course's root and installs all declared dependencies
+   * in a single command.
+   *
+   * @param courseRoot The course's source folder (where `pyproject.toml`
+   *   lives and where the `.venv` is created).
+   */
+  async syncEnvironment(courseRoot: vscode.Uri): Promise<void> {
+    if (!this.supported) {
+      return;
+    }
+
+    if (!(await this.uvAvailable())) {
+      throw new Error(
+        "`uv` is required to set up this course's Python environment but " +
+          "was not found on your PATH. Install it from https://docs.astral.sh/uv/",
+      );
+    }
+
+    const code = await this.runShell(
+      "Sync course environment",
+      "uv",
+      ["sync", "--project", courseRoot.fsPath],
+      courseRoot,
+    );
+    if (code !== 0) {
+      throw new Error(
+        `\`uv sync\` failed (exit ${code}). Check the terminal output for details.`,
+      );
+    }
+  }
+
+  /**
+   * Install the course's pinned requirements into its venv. Always installs
+   * `ipykernel` as well so the Jupyter extension can discover and run the
+   * venv as a notebook kernel without a globally-registered kernelspec.
+   */
+  async installRequirements(
+    courseRoot: vscode.Uri,
+    requirements: string[],
+  ): Promise<void> {
+    if (!this.supported) {
+      return;
+    }
+    const python = await this.venvPython(courseRoot);
+    if (!python) {
+      throw new Error("The course environment is missing its interpreter.");
+    }
+    // De-duplicate while preserving order; ipykernel is required for the
+    // venv to act as a Jupyter kernel.
+    const packages = [...new Set(["ipykernel", ...requirements])];
+    const cwd = courseRoot;
+
+    if (await this.uvAvailable()) {
+      const code = await this.runShell(
+        "Install course requirements",
+        "uv",
+        ["pip", "install", "--python", python, ...packages],
+        cwd,
+      );
+      if (code === 0) {
+        return;
+      }
+      log.warn(
+        `\`uv pip install\` failed (exit ${code}); falling back to pip.`,
+      );
+    }
+
+    const code = await this.runShell(
+      "Install course requirements",
+      python,
+      ["-m", "pip", "install", "--disable-pip-version-check", ...packages],
+      cwd,
+    );
+    if (code !== 0) {
+      throw new Error(`Installing requirements failed (exit ${code}).`);
+    }
+  }
+
+  /**
+   * Select this course's venv as the kernel/interpreter for a notebook.
+   *
+   * Uses the **stable** `ms-python.python` `environments` API
+   * (`updateActiveEnvironmentPath`) to set the interpreter for the notebook
+   * resource — the mechanism the Jupyter extension honors when picking a
+   * kernel — and additionally nudges the picker with a core
+   * {@link vscode.NotebookController} affinity hint.
+   *
+   * We deliberately do NOT register a global kernelspec
+   * (`ipykernel install --user`): that pollutes the user's kernel list and
+   * competes with the Jupyter extension's own environment discovery.
+   * Instead {@link installRequirements} puts `ipykernel` in the venv so
+   * Jupyter can discover and run it directly.
+   */
+  async selectKernelForNotebook(
+    notebook: vscode.NotebookDocument,
+    courseRoot: vscode.Uri,
+    courseId: string,
+    displayName: string,
+  ): Promise<void> {
+    if (!this.supported) {
+      return;
+    }
+
+    // Primary, stable path: point the Python extension at the venv
+    // interpreter for this notebook resource.
+    const python = await this.venvPython(courseRoot);
+    if (python) {
+      await this.setActiveInterpreter(notebook.uri, python);
+    }
+
+    // Secondary nudge: a notebook controller affinity hint. This is a core
+    // VS Code API (not Python-specific) and is safe to keep as a fallback.
+    let controller = this.controllers.get(courseId);
+    if (!controller) {
+      controller = vscode.notebooks.createNotebookController(
+        `qdk-learning-${courseId}`,
+        "jupyter-notebook",
+        `QDK: ${displayName}`,
+      );
+      controller.supportedLanguages = ["python"];
+      controller.description = "QDK course environment";
+      this.controllers.set(courseId, controller);
+    }
+    controller.updateNotebookAffinity(
+      notebook,
+      vscode.NotebookControllerAffinity.Preferred,
+    );
+  }
+
+  /** Path to the venv's Python interpreter, or `undefined` if not present. */
+  async venvPython(courseRoot: vscode.Uri): Promise<string | undefined> {
+    const venv = this.venvUri(courseRoot);
+    const candidates = [
+      vscode.Uri.joinPath(venv, "bin", "python"),
+      vscode.Uri.joinPath(venv, "bin", "python3"),
+      vscode.Uri.joinPath(venv, "Scripts", "python.exe"),
+    ];
+    for (const candidate of candidates) {
+      if (await uriExists(candidate)) {
+        return candidate.fsPath;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Verify the given modules import in the course venv (e.g. `qdk`,
+   * `qsharp_widgets`). Returns `false` if the venv or interpreter is
+   * missing or the import fails.
+   */
+  async checkImports(
+    courseRoot: vscode.Uri,
+    modules: string[],
+  ): Promise<boolean> {
+    if (!this.supported || modules.length === 0) {
+      return false;
+    }
+    const python = await this.venvPython(courseRoot);
+    if (!python) {
+      return false;
+    }
+    const code = await this.runShell(
+      "Verify course packages",
+      python,
+      ["-c", `import ${modules.join(", ")}`],
+      courseRoot,
+    );
+    return code === 0;
+  }
+
+  /**
+   * Per-module import report for the course venv. Each entry is `true` when
+   * that module imports successfully. Missing venv/interpreter yields all
+   * `false`. Used by the environment check to pinpoint which package is
+   * missing.
+   */
+  async importsReport(
+    courseRoot: vscode.Uri,
+    modules: string[],
+  ): Promise<{ module: string; ok: boolean }[]> {
+    if (!this.supported || modules.length === 0) {
+      return modules.map((module) => ({ module, ok: false }));
+    }
+    const python = await this.venvPython(courseRoot);
+    if (!python) {
+      return modules.map((module) => ({ module, ok: false }));
+    }
+    const results: { module: string; ok: boolean }[] = [];
+    for (const module of modules) {
+      const code = await this.runShell(
+        `Check import: ${module}`,
+        python,
+        ["-c", `import ${module}`],
+        courseRoot,
+      );
+      results.push({ module, ok: code === 0 });
+    }
+    return results;
+  }
+
+  /** Whether `uv` is available on the PATH (public diagnostics accessor). */
+  async hasUv(): Promise<boolean> {
+    return this.uvAvailable();
+  }
+
+  /**
+   * Whether the given interpreter can create virtual environments (the
+   * `venv` and `ensurepip` modules are importable). On some Linux distros
+   * these are a separate OS package. Defaults to the bootstrap interpreter.
+   */
+  async venvModuleSupported(python?: string): Promise<boolean> {
+    if (!this.supported) {
+      return false;
+    }
+    const interpreter = python ?? (await this.ensureInterpreter());
+    if (!interpreter) {
+      return false;
+    }
+    const code = await this.runShell("Check Python venv support", interpreter, [
+      "-c",
+      "import venv, ensurepip",
+    ]);
+    return code === 0;
+  }
+
+  // ─── Private: swappable OS interaction ───
+
+  /**
+   * The Python extension's stable `environments` API, or `undefined` when
+   * the extension is unavailable. Only the documented, non-proposed members
+   * are typed here.
+   */
+  private async pythonEnvironmentsApi(): Promise<
+    | {
+        getActiveEnvironmentPath?: (resource?: vscode.Uri) => {
+          path?: string;
+        };
+        updateActiveEnvironmentPath?: (
+          environment: string,
+          resource?: vscode.Uri,
+        ) => Thenable<void>;
+      }
+    | undefined
+  > {
+    const ext = vscode.extensions.getExtension("ms-python.python");
+    if (!ext) {
+      return undefined;
+    }
+    try {
+      const api = (await ext.activate()) as {
+        environments?: {
+          getActiveEnvironmentPath?: (resource?: vscode.Uri) => {
+            path?: string;
+          };
+          updateActiveEnvironmentPath?: (
+            environment: string,
+            resource?: vscode.Uri,
+          ) => Thenable<void>;
+        };
+      };
+      return api.environments;
+    } catch (e) {
+      log.warn(`Could not query the Python extension: ${String(e)}`);
+      return undefined;
+    }
+  }
+
+  /** The Python extension's active interpreter path, if available. */
+  private async activeInterpreterPath(): Promise<string | undefined> {
+    const environments = await this.pythonEnvironmentsApi();
+    return environments?.getActiveEnvironmentPath?.()?.path;
+  }
+
+  /**
+   * Set the active interpreter for a resource via the stable Python
+   * extension API. The Jupyter extension uses this association to pick the
+   * kernel for the notebook.
+   */
+  private async setActiveInterpreter(
+    resource: vscode.Uri,
+    pythonPath: string,
+  ): Promise<void> {
+    const environments = await this.pythonEnvironmentsApi();
+    if (!environments?.updateActiveEnvironmentPath) {
+      return;
+    }
+    try {
+      await environments.updateActiveEnvironmentPath(pythonPath, resource);
+    } catch (e) {
+      log.warn(`Could not set the active interpreter: ${String(e)}`);
+    }
+  }
+
+  /** Whether `uv` is available on the PATH. Cached after the first probe. */
+  private async uvAvailable(): Promise<boolean> {
+    if (this._uvAvailable === undefined) {
+      const code = await this.runShell("Check for uv", "uv", ["--version"]);
+      this._uvAvailable = code === 0;
+    }
+    return this._uvAvailable;
+  }
+
+  /**
+   * Run a shell command as a one-shot task and resolve with its exit code.
+   * Centralized so the execution mechanism stays swappable.
+   */
+  private runShell(
+    name: string,
+    command: string,
+    args: string[],
+    cwd?: vscode.Uri,
+  ): Promise<number> {
+    // Course commands pass the course root; course-independent probes
+    // (`uv --version`, `python -c "import venv"`) don't depend on the cwd,
+    // so they fall back to the workspace folder, which is guaranteed to exist.
+    const cwdPath = (cwd ?? vscode.workspace.workspaceFolders?.[0]?.uri)
+      ?.fsPath;
+    const task = new vscode.Task(
+      { type: "qdk-learning" },
+      vscode.TaskScope.Workspace,
+      name,
+      "qdk-learning",
+      new vscode.ShellExecution(command, args, { cwd: cwdPath }),
+    );
+    task.presentationOptions = {
+      reveal: vscode.TaskRevealKind.Silent,
+      focus: false,
+      clear: false,
+    };
+    return new Promise<number>((resolve) => {
+      const sub = vscode.tasks.onDidEndTaskProcess((e) => {
+        if (e.execution.task === task) {
+          sub.dispose();
+          resolve(e.exitCode ?? -1);
+        }
+      });
+      void vscode.tasks.executeTask(task);
+    });
+  }
+}
+
+// ─── Helpers ───
+
+async function uriExists(uri: vscode.Uri): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(uri);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/source/vscode/src/learning/python/pythonRunner.ts
+++ b/source/vscode/src/learning/python/pythonRunner.ts
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { log } from "qsharp-lang";
+import * as vscode from "vscode";
+import type { CatalogCourse } from "../types.js";
+
+/**
+ * Manages `python-notebook` course files. All Jupyter/notebook execution
+ * is handled by VS Code's native notebook UI — this class only handles
+ * materialization (copying course source to a working copy) and extension
+ * readiness checks.
+ */
+export class PythonCourseRunner {
+  /**
+   * Soft-check that the Python and Jupyter extensions are available. On
+   * VS Code for the Web (where they can't run) returns a desktop-only
+   * message. Returns `undefined` when everything required is present.
+   */
+  async ensureExtensions(): Promise<string | undefined> {
+    if (vscode.env.uiKind === vscode.UIKind.Web) {
+      return (
+        "Python notebook courses require the desktop version of VS Code " +
+        "with the Python and Jupyter extensions."
+      );
+    }
+    const missing: { id: string; name: string }[] = [];
+    if (!vscode.extensions.getExtension("ms-python.python")) {
+      missing.push({ id: "ms-python.python", name: "Python" });
+    }
+    if (!vscode.extensions.getExtension("ms-toolsai.jupyter")) {
+      missing.push({ id: "ms-toolsai.jupyter", name: "Jupyter" });
+    }
+    if (missing.length === 0) {
+      return undefined;
+    }
+    return `This course needs the ${missing
+      .map((m) => m.name)
+      .join(" and ")} extension${missing.length > 1 ? "s" : ""}.`;
+  }
+
+  /**
+   * Prompt the user to install any missing required extensions. Safe to
+   * call when nothing is missing (it no-ops).
+   */
+  async promptInstallExtensions(): Promise<void> {
+    if (vscode.env.uiKind === vscode.UIKind.Web) {
+      return;
+    }
+    const required: { id: string; name: string }[] = [
+      { id: "ms-python.python", name: "Python" },
+      { id: "ms-toolsai.jupyter", name: "Jupyter" },
+    ].filter((e) => !vscode.extensions.getExtension(e.id));
+    if (required.length === 0) {
+      return;
+    }
+    const choice = await vscode.window.showInformationMessage(
+      `This course needs the ${required
+        .map((r) => r.name)
+        .join(" and ")} extension${required.length > 1 ? "s" : ""}.`,
+      "Install",
+    );
+    if (choice !== "Install") {
+      return;
+    }
+    for (const ext of required) {
+      await vscode.commands.executeCommand(
+        "workbench.extensions.installExtension",
+        ext.id,
+      );
+    }
+  }
+
+  /**
+   * Working-copy URI of a unit's notebook: a `*.workbook.ipynb` file that
+   * sits beside the authored source notebook in the same unit folder.
+   *
+   * Keeping the working copy as a sibling means the learner's notebook
+   * resolves the same relative imports (`_course_lib.py`, `_unit.py`, etc.) as the
+   * source.
+   */
+  workbookFileUri(course: CatalogCourse, notebookRel: string): vscode.Uri {
+    if (!course.sourceDir) {
+      throw new Error(`Course "${course.id}" has no source folder.`);
+    }
+    const sourceRoot = vscode.Uri.parse(course.sourceDir);
+    return vscode.Uri.joinPath(sourceRoot, toWorkbookRel(notebookRel));
+  }
+
+  /**
+   * Materialize the working copy for every unit in the course: copy each
+   * authored notebook to its `*.workbook.ipynb` sibling. Existing workbooks
+   * are never overwritten, preserving learner edits.
+   */
+  async materializeCourse(course: CatalogCourse): Promise<void> {
+    if (!course.sourceDir) {
+      throw new Error(`Course "${course.id}" has no source folder.`);
+    }
+    const sourceRoot = vscode.Uri.parse(course.sourceDir);
+
+    for (const unit of course.units) {
+      if (!unit.notebookRel) {
+        continue;
+      }
+      await this.copyIfMissing(
+        vscode.Uri.joinPath(sourceRoot, unit.notebookRel),
+        vscode.Uri.joinPath(sourceRoot, toWorkbookRel(unit.notebookRel)),
+      );
+    }
+  }
+
+  /**
+   * Re-materialize a single unit: overwrite its `*.workbook.ipynb`
+   * with a fresh copy of the authored notebook.
+   */
+  async rematerializeUnit(
+    course: CatalogCourse,
+    unitId: string,
+  ): Promise<void> {
+    if (!course.sourceDir) {
+      throw new Error(`Course "${course.id}" has no source folder.`);
+    }
+    const unit = course.units.find((u) => u.id === unitId);
+    if (!unit?.notebookRel) {
+      throw new Error(`Unit "${unitId}" not found in course "${course.id}".`);
+    }
+
+    const sourceRoot = vscode.Uri.parse(course.sourceDir);
+    const src = vscode.Uri.joinPath(sourceRoot, unit.notebookRel);
+    const dest = vscode.Uri.joinPath(
+      sourceRoot,
+      toWorkbookRel(unit.notebookRel),
+    );
+    await ensureParentDir(dest);
+    await vscode.workspace.fs.copy(src, dest, { overwrite: true });
+  }
+
+  /** Copy a file only if the destination doesn't already exist. */
+  private async copyIfMissing(
+    src: vscode.Uri,
+    dest: vscode.Uri,
+  ): Promise<void> {
+    if (await uriExists(dest)) {
+      return;
+    }
+    try {
+      await ensureParentDir(dest);
+      await vscode.workspace.fs.copy(src, dest, { overwrite: false });
+    } catch (e) {
+      log.warn(`Failed to copy ${src.fsPath} → ${dest.fsPath}: ${String(e)}`);
+    }
+  }
+}
+
+// ─── Helpers ───
+
+/**
+ * Map a source notebook's relative path to its working-copy sibling by
+ * swapping the `.ipynb` extension for `.workbook.ipynb`
+ * (e.g. `01-intro/intro.ipynb` → `01-intro/intro.workbook.ipynb`).
+ */
+function toWorkbookRel(notebookRel: string): string {
+  return notebookRel.replace(/\.ipynb$/i, ".workbook.ipynb");
+}
+
+async function uriExists(uri: vscode.Uri): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(uri);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureParentDir(fileUri: vscode.Uri): Promise<void> {
+  const parentUri = vscode.Uri.joinPath(fileUri, "..");
+  try {
+    await vscode.workspace.fs.createDirectory(parentUri);
+  } catch {
+    // already exists
+  }
+}

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -6,8 +6,12 @@ import * as vscode from "vscode";
 import { FullProgramConfig, getProgramForDocument } from "../programConfig.js";
 import { ProgramRunStatus, runProgram } from "../run.js";
 import { EventType, sendTelemetryEvent } from "../telemetry.js";
-import { loadKatasCourse } from "./catalog.js";
+import { createCourseRegistry } from "./catalog.js";
+import { CourseRegistry } from "./courseProvider.js";
+import { EnvironmentManager } from "./python/environment.js";
+import { PythonCourseRunner } from "./python/pythonRunner.js";
 import {
+  KATAS_COURSE_ID,
   LEARNING_FILE,
   LEARNING_WORKSPACE_DETECTED_CONTEXT,
   LEARNING_WORKSPACE_FOLDER,
@@ -22,7 +26,13 @@ import type {
   CatalogExercise,
   CatalogActivity,
   CatalogUnit,
+  CourseDescriptor,
+  CourseKind,
   CurrentActivity,
+  EnvironmentCheckFix,
+  EnvironmentCheckItem,
+  EnvironmentCheckReport,
+  EnvironmentStatus,
   ExerciseContent,
   HintContext,
   LearningState,
@@ -38,6 +48,24 @@ import type {
   UnitProgress,
   UnitSummary,
 } from "./types.js";
+import type { EnvironmentCheckStatus } from "./types.js";
+
+/** Build an {@link EnvironmentCheckItem}. */
+function check(
+  id: string,
+  label: string,
+  status: EnvironmentCheckStatus,
+  extras?: Pick<EnvironmentCheckItem, "detail" | "hint" | "fixes">,
+): EnvironmentCheckItem {
+  return {
+    id,
+    label,
+    status,
+    detail: extras?.detail,
+    hint: extras?.hint,
+    fixes: extras?.fixes,
+  };
+}
 
 /** Returns the first open workspace folder URI, or `undefined`. */
 export function resolveNewWorkspaceRoot(): vscode.Uri | undefined {
@@ -90,8 +118,10 @@ interface LearningWorkspaceInfo {
 
 /** All state that exists only while a learning workspace is loaded. */
 interface WorkspaceState extends LearningWorkspaceInfo {
-  /** Currently, only a single course is supported. */
-  catalog: CatalogCourse;
+  /** Loaded courses, keyed by course id. May contain more than one. */
+  courses: Map<string, CatalogCourse>;
+  /** Registry used to enumerate and lazily load additional courses. */
+  registry: CourseRegistry;
   progressData: ProgressFileData;
 }
 
@@ -108,8 +138,12 @@ export class LearningService {
 
   private _lastSnapshot: OverallProgress | undefined;
   private _progressFileWatcher: vscode.FileSystemWatcher | undefined;
+  private _sentinelWatcher: vscode.FileSystemWatcher | undefined;
   private _writingProgress = false;
   private _initPromise: Promise<boolean> | undefined;
+  private readonly _disposables: vscode.Disposable[] = [];
+  private _pythonRunner: PythonCourseRunner | undefined;
+  private _environment: EnvironmentManager | undefined;
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -119,6 +153,40 @@ export class LearningService {
 
   get learningContentRoot(): vscode.Uri {
     return this.requireWorkspace().learningContentRoot;
+  }
+
+  /** The workspace folder that owns the learning content. */
+  get workspaceFolder(): vscode.Uri {
+    return this.requireWorkspace().workspaceRoot;
+  }
+
+  /** Lazily-created runner for `python-notebook` courses. */
+  private get pythonRunner(): PythonCourseRunner {
+    if (!this._pythonRunner) {
+      this._pythonRunner = new PythonCourseRunner();
+    }
+    return this._pythonRunner;
+  }
+
+  /** Lazily-created per-course Python environment manager. */
+  private get environment(): EnvironmentManager {
+    if (!this._environment) {
+      this._environment = new EnvironmentManager();
+    }
+    return this._environment;
+  }
+
+  /**
+   * Re-scan available courses (e.g. after a new drop-in course is added).
+   * Drop-in courses are enumerated lazily by the registry, so this just
+   * refreshes the UI to pick up newly-added folders.
+   */
+  async reloadCourses(): Promise<void> {
+    if (!this.workspace) {
+      return;
+    }
+    this.emitProgress();
+    this._onDidChangeState.fire(this.getState());
   }
 
   /**
@@ -165,6 +233,11 @@ export class LearningService {
     this._onDidChangeState.dispose();
     this._onDidChangeProgress.dispose();
     this._progressFileWatcher?.dispose();
+    this.stopSentinelWatcher();
+    this._environment?.dispose();
+    for (const d of this._disposables) {
+      d.dispose();
+    }
   }
 
   /** Force a fresh progress reload from disk. */
@@ -197,8 +270,46 @@ export class LearningService {
    * The payload sent to the webview. */
   getState(): LearningState {
     return {
+      course: this.getActiveCourseInfo(),
       position: this.getCurrentActivity(),
       actions: this.getAvailableActions(),
+      progress: this.getProgress(),
+    };
+  }
+
+  /**
+   * State snapshot tailored for the lesson webview panel.
+   *
+   * For python-notebook courses the panel always shows the unit-level
+   * summary (intro lesson) rather than drilling into a specific exercise.
+   * Other course kinds fall through to {@link getState}.
+   */
+  getStateForPanel(): LearningState {
+    if (this.activeCourse.kind !== "python-notebook") {
+      return this.getState();
+    }
+
+    const pos = this.position;
+    const unit = this.findUnit(pos.unitId);
+    const intro = unit.activities.find((a) => a.id === "intro")!;
+
+    const introLocation: ActivityLocation = {
+      courseId: pos.courseId,
+      unitId: pos.unitId,
+      activityId: intro.id,
+    };
+
+    const position: CurrentActivity = {
+      location: introLocation,
+      unitTitle: unit.title,
+      activityTitle: unit.title,
+      content: this.resolveActivityContent(introLocation, unit, intro),
+    };
+
+    return {
+      course: this.getActiveCourseInfo(),
+      position,
+      actions: this.getAvailableActionsForPanel(unit),
       progress: this.getProgress(),
     };
   }
@@ -244,12 +355,81 @@ export class LearningService {
     return { moved: true };
   }
 
+  /**
+   * Navigate to the intro of the next unit. Used by the panel for
+   * python-notebook courses where navigation is unit-scoped.
+   */
+  async nextUnit(source: TelemetrySource): Promise<NavigationResult> {
+    const ws = this.requireWorkspace();
+    const course = this.activeCourse;
+    const currentUnitId = ws.progressData.position.unitId;
+    const idx = course.units.findIndex((u) => u.id === currentUnitId);
+    if (idx < 0 || idx >= course.units.length - 1) {
+      return { moved: false };
+    }
+    const nextU = course.units[idx + 1];
+    const firstActivity = nextU.activities[0];
+    if (!firstActivity) {
+      return { moved: false };
+    }
+
+    // Auto-mark the intro lesson of the current unit complete.
+    const introLocation: ActivityLocation = {
+      courseId: course.id,
+      unitId: currentUnitId,
+      activityId: "intro",
+    };
+    if (!this.isComplete(introLocation)) {
+      this.markComplete(introLocation);
+    }
+
+    ws.progressData.position = {
+      courseId: course.id,
+      unitId: nextU.id,
+      activityId: firstActivity.id,
+    };
+    await this.saveProgress();
+    this._onDidChangeState.fire(this.getState());
+    this.sendActivityActionTelemetry("navigate", source);
+    return { moved: true };
+  }
+
+  /**
+   * Navigate to the intro of the previous unit. Used by the panel for
+   * python-notebook courses where navigation is unit-scoped.
+   */
+  async previousUnit(source: TelemetrySource): Promise<NavigationResult> {
+    const ws = this.requireWorkspace();
+    const course = this.activeCourse;
+    const currentUnitId = ws.progressData.position.unitId;
+    const idx = course.units.findIndex((u) => u.id === currentUnitId);
+    if (idx <= 0) {
+      return { moved: false };
+    }
+    const prevU = course.units[idx - 1];
+    const firstActivity = prevU.activities[0];
+    if (!firstActivity) {
+      return { moved: false };
+    }
+
+    ws.progressData.position = {
+      courseId: course.id,
+      unitId: prevU.id,
+      activityId: firstActivity.id,
+    };
+    await this.saveProgress();
+    this._onDidChangeState.fire(this.getState());
+    this.sendActivityActionTelemetry("navigate", source);
+    return { moved: true };
+  }
+
   async goTo(
     location: { unitId: string; activityId?: string },
     source?: TelemetrySource,
   ): Promise<LearningState> {
     const ws = this.requireWorkspace();
-    const unit = ws.catalog.units.find((u) => u.id === location.unitId);
+    const course = this.activeCourse;
+    const unit = course.units.find((u) => u.id === location.unitId);
     if (!unit || unit.activities.length === 0) {
       throw new Error(`Position not found: ${location.unitId}`);
     }
@@ -262,7 +442,7 @@ export class LearningService {
       );
     }
     ws.progressData.position = {
-      courseId: ws.catalog.id,
+      courseId: course.id,
       unitId: location.unitId,
       activityId: activity.id,
     };
@@ -275,17 +455,471 @@ export class LearningService {
     return state;
   }
 
-  listUnits(): UnitSummary[] {
+  /**
+   * Navigate to the exercise activity whose `cellIndex` matches the given
+   * 1-based cell number. Returns `true` if the position was updated.
+   * Only meaningful for python-notebook courses.
+   *
+   * Updates the position silently — does **not** fire the state-change
+   * event, so the lesson panel won't pop up or rearrange the editor layout.
+   */
+  async goToExerciseByCellIndex(
+    cellIndex: number,
+    source?: TelemetrySource,
+  ): Promise<boolean> {
+    if (this.activeCourse.kind !== "python-notebook") {
+      return false;
+    }
+    const unit = this.findUnit(this.position.unitId);
+    const exercise = unit.notebookExercises?.find(
+      (e) => e.cellIndex === cellIndex,
+    );
+    if (!exercise) {
+      return false;
+    }
+    // Only move if we're not already on this exercise.
+    if (this.position.activityId === exercise.id) {
+      return true;
+    }
+
     const ws = this.requireWorkspace();
+    ws.progressData.position = {
+      courseId: this.activeCourse.id,
+      unitId: unit.id,
+      activityId: exercise.id,
+    };
+    await this.saveProgress();
+    if (source) {
+      this.sendActivityActionTelemetry("navigate", source);
+    }
+    return true;
+  }
+
+  /**
+   * Mark the exercise activity at the given 1-based cell index as complete.
+   * Returns `true` if the exercise was found and marked (or already complete).
+   * Fires the state-change event so the treeview updates.
+   */
+  async markExerciseCompleteByCellIndex(cellIndex: number): Promise<boolean> {
+    if (this.activeCourse.kind !== "python-notebook") {
+      return false;
+    }
+    const unit = this.findUnit(this.position.unitId);
+    const exercise = unit.notebookExercises?.find(
+      (e) => e.cellIndex === cellIndex,
+    );
+    if (!exercise) {
+      return false;
+    }
+    const location: ActivityLocation = {
+      courseId: this.activeCourse.id,
+      unitId: unit.id,
+      activityId: exercise.id,
+    };
+    if (this.isComplete(location)) {
+      return true;
+    }
+    this.markComplete(location);
+    await this.saveProgress();
+    this._onDidChangeState.fire(this.getState());
+    return true;
+  }
+
+  /** Enumerate all available courses (loaded or not). */
+  async getCourses(): Promise<CourseDescriptor[]> {
+    return this.requireWorkspace().registry.listCourses();
+  }
+
+  /** The id of the currently-active course. */
+  getActiveCourseId(): string {
+    return this.requireWorkspace().progressData.position.courseId;
+  }
+
+  /** Compact info about the active course for serialization to chat tools. */
+  getActiveCourseInfo(): { id: string; title: string; kind: CourseKind } {
+    const course = this.activeCourse;
+    return { id: course.id, title: course.title, kind: course.kind };
+  }
+
+  /**
+   * Ensure a python-notebook course's per-course environment exists:
+   * create the venv and install pinned requirements. No-ops for Q# courses,
+   * on the Web, or when the venv already exists (unless `force` is set).
+   *
+   * When the course ships a `pyproject.toml`, the preferred path is
+   * `uv sync` which handles venv creation, Python version selection, and
+   * dependency installation in one shot. Courses without `pyproject.toml`
+   * fall back to the manual `createVenv` + `installRequirements` flow.
+   */
+  async ensureEnvironment(
+    course: CatalogCourse,
+    options?: { force?: boolean },
+  ): Promise<void> {
+    if (course.kind !== "python-notebook") {
+      return;
+    }
+    const env = this.environment;
+    if (!env.supported) {
+      return;
+    }
+    if (!course.sourceDir) {
+      return;
+    }
+    const courseRoot = vscode.Uri.parse(course.sourceDir);
+    if (!options?.force && (await env.venvExists(courseRoot))) {
+      return;
+    }
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Setting up the environment for "${course.title}"…`,
+      },
+      async () => {
+        const hasPyproject = await this.uriExists(
+          vscode.Uri.joinPath(courseRoot, "pyproject.toml"),
+        );
+        if (hasPyproject) {
+          // Preferred: `uv sync` resolves and installs from pyproject.toml.
+          await env.syncEnvironment(courseRoot);
+        } else {
+          // Fallback: manual venv creation + pip install.
+          await env.createVenv(courseRoot, course.environment?.python);
+          await env.installRequirements(
+            courseRoot,
+            course.environment?.requirements ?? [],
+          );
+        }
+      },
+    );
+  }
+
+  /** Set up the environment for the currently-active course. */
+  async setupActiveEnvironment(): Promise<void> {
+    await this.ensureEnvironment(this.activeCourse, { force: true });
+  }
+
+  /**
+   * Apply a fix surfaced by {@link runEnvironmentCheck}. Centralizes the
+   * mapping from an {@link EnvironmentCheckFix.kind} to a concrete action so
+   * the command and chat tool can offer fixes without duplicating the logic.
+   */
+  async applyEnvironmentCheckFix(fix: EnvironmentCheckFix): Promise<void> {
+    switch (fix.kind) {
+      case "setup":
+        await this.setupActiveEnvironment();
+        return;
+      case "install-extensions":
+        await this.pythonRunner.promptInstallExtensions();
+        return;
+      case "select-kernel":
+        await vscode.commands.executeCommand("notebook.selectKernel");
+        return;
+      case "docs":
+        return;
+    }
+  }
+
+  /**
+   * Run environment diagnostics for the active course and return a rich,
+   * structured report: an ordered list of checks (each `ok`/`warn`/`fail`/
+   * `skip` with detail, a fix hint, and fixes), an overall status, a
+   * one-line summary, and the aggregated fixes the UI can offer.
+   *
+   * Q# courses need no environment and pass trivially.
+   */
+  async runEnvironmentCheck(): Promise<EnvironmentCheckReport> {
+    const course = this.activeCourse;
+
+    if (course.kind !== "python-notebook") {
+      const checks: EnvironmentCheckItem[] = [
+        check("course-kind", "Course type", "ok", {
+          detail: "Q# course — runs on the built-in simulator.",
+        }),
+        check("environment", "Python environment", "skip", {
+          detail: "Not required for Q# courses.",
+        }),
+      ];
+      return this.assembleReport(course, checks);
+    }
+
+    const env = this.environment;
+
+    // Hard stop: environment management can't run on the Web.
+    if (!env.supported) {
+      const checks: EnvironmentCheckItem[] = [
+        check("host", "Desktop VS Code", "fail", {
+          detail: "Python courses require the desktop version of VS Code.",
+          hint: "Open this workspace in desktop VS Code to run Python courses.",
+        }),
+      ];
+      return this.assembleReport(course, checks);
+    }
+
+    // Resolve the course's working root (its source folder); the venv
+    // lives here, beside the authored notebooks.
+    if (!course.sourceDir) {
+      return this.assembleReport(course, [
+        check("course-folder", "Course folder", "fail", {
+          detail: "This course has no source folder on disk.",
+        }),
+      ]);
+    }
+    const courseRoot = vscode.Uri.parse(course.sourceDir);
+
+    const checks: EnvironmentCheckItem[] = [];
+
+    // 1. Required extensions (Python + Jupyter).
+    const extMessage = await this.pythonRunner.ensureExtensions();
+    checks.push(
+      check(
+        "extensions",
+        "Python & Jupyter extensions",
+        extMessage ? "fail" : "ok",
+        {
+          detail: extMessage ?? "Installed.",
+          hint: extMessage
+            ? "Install the Python and Jupyter extensions to run notebook courses."
+            : undefined,
+          fixes: extMessage
+            ? [{ label: "Install extensions", kind: "install-extensions" }]
+            : undefined,
+        },
+      ),
+    );
+
+    // 2. Base Python interpreter (for bootstrapping the venv).
+    const interpreter = await env.ensureInterpreter();
+    checks.push(
+      check("interpreter", "Python interpreter", interpreter ? "ok" : "fail", {
+        detail: interpreter ?? "No interpreter found.",
+        hint: interpreter
+          ? undefined
+          : "Install Python (3.9+) and select an interpreter via the Python extension.",
+      }),
+    );
+
+    // 3. Tooling: uv (preferred) vs stdlib venv. Informational unless the
+    //    venv is missing AND the stdlib module is unavailable.
+    const hasUv = await env.hasUv();
+    const venvOk = await env.venvExists(courseRoot);
+    if (hasUv) {
+      checks.push(
+        check("tooling", "Environment tooling", "ok", {
+          detail: "uv detected — fast environment creation.",
+        }),
+      );
+    } else if (interpreter) {
+      // Only probe the stdlib venv module when we'd actually need it.
+      const venvModuleOk = venvOk
+        ? true
+        : await env.venvModuleSupported(interpreter);
+      checks.push(
+        check(
+          "tooling",
+          "Environment tooling",
+          venvModuleOk ? "warn" : "fail",
+          {
+            detail: venvModuleOk
+              ? "Using the standard-library `venv` (install `uv` for faster setup)."
+              : "The `venv`/`ensurepip` modules are missing from this Python.",
+            hint: venvModuleOk
+              ? undefined
+              : "On Debian/Ubuntu install them with `sudo apt install python3-venv` " +
+                "(matching your Python version, e.g. `python3.12-venv`).",
+          },
+        ),
+      );
+    }
+
+    // 4. The per-course virtual environment.
+    checks.push(
+      check("venv", "Course virtual environment", venvOk ? "ok" : "fail", {
+        detail: env.venvUri(courseRoot).fsPath,
+        hint: venvOk
+          ? undefined
+          : "Run environment setup to create the course virtual environment.",
+        fixes: venvOk
+          ? undefined
+          : [{ label: "Set up environment", kind: "setup" }],
+      }),
+    );
+
+    const venvPython = venvOk ? await env.venvPython(courseRoot) : undefined;
+    checks.push(
+      check(
+        "venv-interpreter",
+        "Environment interpreter",
+        !venvOk ? "skip" : venvPython ? "ok" : "fail",
+        {
+          detail: !venvOk
+            ? "No environment yet."
+            : (venvPython ?? "The venv exists but has no interpreter."),
+          hint:
+            venvOk && !venvPython
+              ? "The environment looks corrupt; re-run setup to recreate it."
+              : undefined,
+          fixes:
+            venvOk && !venvPython
+              ? [{ label: "Set up environment", kind: "setup" }]
+              : undefined,
+        },
+      ),
+    );
+
+    // 5. Required packages import in the venv.
+    if (venvPython) {
+      const report = await env.importsReport(courseRoot, [
+        "qdk",
+        "qsharp_widgets",
+      ]);
+      const missing = report.filter((r) => !r.ok).map((r) => r.module);
+      checks.push(
+        check(
+          "packages",
+          "Required packages",
+          missing.length === 0 ? "ok" : "fail",
+          {
+            detail:
+              missing.length === 0
+                ? report.map((r) => r.module).join(", ")
+                : `Missing or broken: ${missing.join(", ")}`,
+            hint:
+              missing.length === 0
+                ? undefined
+                : "Re-run environment setup to (re)install the course's pinned packages.",
+            fixes:
+              missing.length === 0
+                ? undefined
+                : [{ label: "Set up environment", kind: "setup" }],
+          },
+        ),
+      );
+    } else {
+      checks.push(
+        check("packages", "Required packages", "skip", {
+          detail: "No environment yet.",
+        }),
+      );
+    }
+
+    return this.assembleReport(course, checks);
+  }
+
+  /**
+   * Fold a list of diagnostic checks into an {@link EnvironmentCheckReport}:
+   * compute the overall status, a human summary, and the de-duplicated fix
+   * list.
+   */
+  private assembleReport(
+    course: CatalogCourse,
+    checks: EnvironmentCheckItem[],
+  ): EnvironmentCheckReport {
+    const hasFail = checks.some((c) => c.status === "fail");
+    const hasWarn = checks.some((c) => c.status === "warn");
+    const overallStatus: EnvironmentStatus = hasFail
+      ? "error"
+      : hasWarn
+        ? "warning"
+        : "ok";
+
+    // De-duplicate fixes by kind+label, preserving first-seen order.
+    const fixes: EnvironmentCheckFix[] = [];
+    const seen = new Set<string>();
+    for (const c of checks) {
+      for (const r of c.fixes ?? []) {
+        const key = `${r.kind}:${r.label}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          fixes.push(r);
+        }
+      }
+    }
+
+    const failed = checks.filter((c) => c.status === "fail").length;
+    const warned = checks.filter((c) => c.status === "warn").length;
+    const summary =
+      overallStatus === "ok"
+        ? `"${course.title}" is ready to go.`
+        : overallStatus === "warning"
+          ? `"${course.title}" works, but ${warned} thing${warned === 1 ? "" : "s"} could be improved.`
+          : `"${course.title}" has ${failed} problem${failed === 1 ? "" : "s"} to fix before it will run.`;
+
+    return {
+      courseId: course.id,
+      overallStatus,
+      summary,
+      checks,
+      fixes,
+    };
+  }
+
+  /**
+   * Switch the active course. Lazily loads the course (and scaffolds its
+   * files) if it isn't loaded yet, moves the position to the first
+   * incomplete activity, persists, and fires change events.
+   */
+  async switchCourse(
+    courseId: string,
+    source?: TelemetrySource,
+  ): Promise<LearningState> {
+    const ws = this.requireWorkspace();
+    let course = ws.courses.get(courseId);
+    if (!course) {
+      course = await ws.registry.loadCourse(courseId);
+      ws.courses.set(course.id, course);
+      await this.scaffoldCourse(ws, course);
+    }
+    if (course.kind === "python-notebook") {
+      void this.pythonRunner.promptInstallExtensions();
+      void this.ensureEnvironment(course);
+    }
+    ws.progressData.position = this.firstIncompletePosition(course);
+    await this.saveProgress();
+    this.startSentinelWatcher();
+    const state = this.getState();
+    this._onDidChangeState.fire(state);
+    if (source) {
+      this.sendActivityActionTelemetry("navigate", source);
+    }
+    return state;
+  }
+
+  /**
+   * The first activity in a course that has not been completed, or the
+   * course's first activity when everything is already complete.
+   */
+  private firstIncompletePosition(course: CatalogCourse): ActivityLocation {
+    for (const unit of course.units) {
+      for (const activity of unit.activities) {
+        const location: ActivityLocation = {
+          courseId: course.id,
+          unitId: unit.id,
+          activityId: activity.id,
+        };
+        if (!this.isComplete(location)) {
+          return location;
+        }
+      }
+    }
+    const first = course.units[0];
+    return {
+      courseId: course.id,
+      unitId: first?.id ?? "",
+      activityId: first?.activities[0]?.id ?? "",
+    };
+  }
+
+  listUnits(): UnitSummary[] {
+    const course = this.activeCourse;
     let foundFirstIncomplete = false;
 
-    return ws.catalog.units.map((kata) => {
+    return course.units.map((kata) => {
       const activityCount = kata.activities.length;
       let completedCount = 0;
       for (const activity of kata.activities) {
         if (
           this.findCompletion({
-            courseId: ws.catalog.id,
+            courseId: course.id,
             unitId: kata.id,
             activityId: activity.id,
           })
@@ -311,14 +945,33 @@ export class LearningService {
   }
 
   getProgress(): OverallProgress {
+    return this.computeProgress(this.activeCourse);
+  }
+
+  /**
+   * Compute progress for an arbitrary course, lazily loading it if needed.
+   * Does **not** change the active course or position. Used to populate
+   * per-course progress badges in the tree view.
+   */
+  async getCourseProgress(courseId: string): Promise<OverallProgress> {
+    const ws = this.requireWorkspace();
+    let course = ws.courses.get(courseId);
+    if (!course) {
+      course = await ws.registry.loadCourse(courseId);
+      ws.courses.set(course.id, course);
+    }
+    return this.computeProgress(course);
+  }
+
+  private computeProgress(course: CatalogCourse): OverallProgress {
     const ws = this.requireWorkspace();
     let totalActivities = 0;
     let completedActivities = 0;
 
-    const units: UnitProgress[] = ws.catalog.units.map((k) => {
+    const units: UnitProgress[] = course.units.map((k) => {
       const activities: ActivityProgress[] = k.activities.map((s) => {
         const completion = this.findCompletion({
-          courseId: ws.catalog.id,
+          courseId: course.id,
           unitId: k.id,
           activityId: s.id,
         });
@@ -354,17 +1007,16 @@ export class LearningService {
     result: HintContext | null;
     state: LearningState;
   } {
-    const exercise = this.resolveExercise();
+    if (source) {
+      this.sendActivityActionTelemetry("hint", source);
+    }
 
+    const exercise = this.resolveExercise();
     const hints = exercise.hints;
     const solutionExplanation = exercise.solutionExplanation;
 
     if (hints.length === 0 && solutionExplanation.length === 0) {
       return { result: null, state: this.getState() };
-    }
-
-    if (source) {
-      this.sendActivityActionTelemetry("hint", source);
     }
 
     return {
@@ -374,11 +1026,11 @@ export class LearningService {
   }
 
   getAllSolutions(source?: TelemetrySource): string[] {
-    const exercise = this.resolveExercise();
     if (source) {
       this.sendActivityActionTelemetry("solution", source);
     }
-    return exercise.solutionCodes;
+
+    return this.resolveExercise().solutionCodes;
   }
 
   getExerciseFileUri(): vscode.Uri {
@@ -432,6 +1084,14 @@ export class LearningService {
   }
 
   getCurrentCodeFileUri(): vscode.Uri | undefined {
+    // Python-notebook courses: the "code" is the notebook itself.
+    if (this.activeCourse.kind === "python-notebook") {
+      const { unit } = this.findCurrentActivity();
+      if (unit.notebookRel) {
+        return this.notebookFileUri(unit.notebookRel);
+      }
+      return undefined;
+    }
     const { activity } = this.findCurrentActivity();
     if (activity.type === "exercise") {
       return this.getExerciseFileUri();
@@ -443,10 +1103,44 @@ export class LearningService {
   }
 
   /**
-   * Reset the current exercise file to the original placeholder code
-   * and clear its completion status.
+   * Reset the current exercise/unit to its original state and clear
+   * completion status.
    */
   async resetExercise(source?: TelemetrySource): Promise<void> {
+    // Python-notebook courses: close the notebook, re-copy the entire unit
+    // from source, and clear completion.
+    if (this.activeCourse.kind === "python-notebook") {
+      const { unit } = this.findCurrentActivity();
+      // Close any open notebook tabs for this unit.
+      if (unit.notebookRel) {
+        const notebookUri = this.notebookFileUri(unit.notebookRel);
+        await this.closeNotebookTab(notebookUri);
+      }
+      // Re-materialize the unit from source.
+      await this.pythonRunner.rematerializeUnit(this.activeCourse, unit.id);
+      // Delete the sentinel file if present.
+      if (unit.notebookRel) {
+        const unitDir = this.notebookFileUri(unit.notebookRel);
+        const sentinelUri = vscode.Uri.joinPath(
+          unitDir,
+          "..",
+          ".qdk-unit-complete",
+        );
+        try {
+          await vscode.workspace.fs.delete(sentinelUri);
+        } catch {
+          // may not exist
+        }
+      }
+      this.markIncomplete(this.requireWorkspace().progressData.position);
+      await this.saveProgress();
+      this._onDidChangeState.fire(this.getState());
+      if (source) {
+        this.sendActivityActionTelemetry("reset", source);
+      }
+      return;
+    }
+
     const exercise = this.resolveExercise();
     const uri = this.getExerciseFileUri();
     // Save any unsaved edits first so the editor is clean, then overwrite
@@ -473,10 +1167,6 @@ export class LearningService {
     if (activity.type === "exercise") {
       throw new Error("Exercises cannot be run. Use checkSolution() instead.");
     }
-    const fileUri = this.getCurrentCodeFileUri();
-    if (!fileUri) {
-      throw new Error("Current activity cannot be run.");
-    }
 
     if (activity.type === "lesson" && activity.example) {
       await this.markExampleRun();
@@ -484,6 +1174,25 @@ export class LearningService {
 
     if (source) {
       this.sendActivityActionTelemetry("run", source);
+    }
+
+    // Python-notebook courses use native VS Code notebook execution.
+    if (this.activeCourse.kind === "python-notebook") {
+      return {
+        result: {
+          success: false,
+          messages: [],
+          error:
+            "This course uses native notebook execution. " +
+            "Run cells directly in the notebook.",
+        },
+        state: this.getState(),
+      };
+    }
+
+    const fileUri = this.getCurrentCodeFileUri();
+    if (!fileUri) {
+      throw new Error("Current activity cannot be run.");
     }
 
     const doc = await vscode.workspace.openTextDocument(fileUri);
@@ -514,8 +1223,27 @@ export class LearningService {
       this.sendActivityActionTelemetry("check", source);
     }
 
+    // Python-notebook courses use in-notebook verification via
+    // complete_unit(). The extension detects completion via the sentinel
+    // file watcher, not through this method.
+    if (this.activeCourse.kind === "python-notebook") {
+      return {
+        result: {
+          passed: false,
+          messages: [],
+          error:
+            "This course uses native notebook execution. " +
+            "Run all cells in the notebook, including the final " +
+            "complete_unit() cell, to mark the unit complete.",
+        },
+        state: this.getState(),
+      };
+    }
+
     const exercise = this.resolveExercise();
     const userCode = await this.readUserCode();
+    // Drop-in courses carry their own verification sources inline; the
+    // built-in katas resolve them from the bundled content by `sourceIds`.
     const exerciseSources = await getExerciseSources(
       // CatalogExercise is structurally incompatible with Exercise (different
       // description/solution shapes), but getExerciseSources only reads sourceIds.
@@ -663,6 +1391,7 @@ export class LearningService {
         detected.learningContentRoot,
       );
       this.startWatcher();
+      this.startSentinelWatcher();
       sendTelemetryEvent(
         EventType.LearningSessionStarted,
         { isFirstTime: "false" },
@@ -693,6 +1422,7 @@ export class LearningService {
       this._writingProgress = false;
     }
     this.startWatcher();
+    this.startSentinelWatcher();
     sendTelemetryEvent(
       EventType.LearningSessionStarted,
       { isFirstTime: "true" },
@@ -707,7 +1437,23 @@ export class LearningService {
   ): Promise<void> {
     const learningFile = vscode.Uri.joinPath(workspaceRoot, LEARNING_FILE);
 
-    const course = await loadKatasCourse();
+    const registry = createCourseRegistry(workspaceRoot);
+
+    // Eagerly load all available courses so that the saved position
+    // (which may reference a drop-in course) resolves correctly.
+    const courses = new Map<string, CatalogCourse>();
+    const descriptors = await registry.listCourses();
+    for (const descriptor of descriptors) {
+      try {
+        const course = await registry.loadCourse(descriptor.id);
+        courses.set(course.id, course);
+      } catch {
+        // Skip courses that fail to load.
+      }
+    }
+
+    const defaultCourse =
+      courses.get(KATAS_COURSE_ID) ?? courses.values().next().value;
 
     // Build workspace state; assigned to this.workspace only after all
     // async setup succeeds so that `initialized` stays false on failure.
@@ -715,26 +1461,34 @@ export class LearningService {
       workspaceRoot,
       learningContentRoot: katasRoot,
       learningFile,
-      catalog: course,
+      courses,
+      registry,
       progressData: {
         version: 1,
         position: {
-          courseId: course.id,
-          unitId: course.units[0]?.id ?? "",
-          activityId: course.units[0]?.activities[0]?.id ?? "",
+          courseId: defaultCourse?.id ?? "",
+          unitId: defaultCourse?.units[0]?.id ?? "",
+          activityId: defaultCourse?.units[0]?.activities[0]?.id ?? "",
         },
         completions: {},
         startedAt: new Date().toISOString(),
       },
     };
 
-    await this.scaffoldExercises(ws);
-    await this.scaffoldExamples(ws);
     await this.loadProgress(ws);
 
-    // All async setup succeeded — publish the workspace.
+    // Publish the workspace before scaffolding so that methods relying on
+    // `requireWorkspace()` can resolve.
     this.workspace = ws;
     this.syncContextKey();
+
+    for (const course of courses.values()) {
+      try {
+        await this.scaffoldCourse(ws, course);
+      } catch {
+        // A failing scaffold should not block workspace initialization.
+      }
+    }
   }
 
   private requireWorkspace(): WorkspaceState {
@@ -744,6 +1498,20 @@ export class LearningService {
       );
     }
     return this.workspace;
+  }
+
+  /** The currently-active course, resolved from the progress position. */
+  private get activeCourse(): CatalogCourse {
+    const ws = this.requireWorkspace();
+    return this.requireCourse(ws, ws.progressData.position.courseId);
+  }
+
+  private requireCourse(ws: WorkspaceState, courseId: string): CatalogCourse {
+    const course = ws.courses.get(courseId);
+    if (!course) {
+      throw new Error(`Course not loaded: ${courseId}`);
+    }
+    return course;
   }
 
   private syncContextKey(): void {
@@ -768,7 +1536,54 @@ export class LearningService {
 
   /** Builds the button groups shown in the webview toolbar for the current activity. */
   private getAvailableActions(): ActionGroup[] {
-    const { activity } = this.findCurrentActivity();
+    const { activity, unit } = this.findCurrentActivity();
+
+    // Python-notebook courses: primary action is "Open Notebook" (or
+    // "Next" if the unit is already complete).
+    if (this.activeCourse.kind === "python-notebook" && unit.notebookRel) {
+      const isComplete = this.isComplete(this.position);
+      const primaryGroup: ActionGroup = isComplete
+        ? [{ key: "space", label: "Next", action: "next", primary: true }]
+        : [
+            {
+              key: "space",
+              label: "Open Notebook",
+              action: "open-notebook",
+              primary: true,
+              codicon: "notebook",
+            },
+          ];
+      const extraGroups: ActionGroup[] = isComplete
+        ? [
+            [
+              {
+                key: "o",
+                label: "Open Notebook",
+                action: "open-notebook",
+                codicon: "notebook",
+              },
+              { key: "r", label: "Reset", action: "reset" },
+            ],
+          ]
+        : [
+            [
+              {
+                key: "h",
+                label: "Hint",
+                action: "hint-chat",
+                codicon: "sparkle",
+              },
+              { key: "r", label: "Reset", action: "reset" },
+            ],
+          ];
+      const navGroup: ActionGroup = [
+        { key: "b", label: "Back", action: "back" },
+      ];
+      return [primaryGroup, ...extraGroups, navGroup].filter(
+        (g) => g.length > 0,
+      );
+    }
+
     const primary = this.getPrimaryAction();
 
     const primaryLabel: Record<PrimaryAction, string> = {
@@ -833,6 +1648,54 @@ export class LearningService {
     );
   }
 
+  /**
+   * Actions for the panel in python-notebook courses. Checks whether
+   * the entire unit is complete (all exercises done) rather than a
+   * single activity.
+   */
+  private getAvailableActionsForPanel(unit: CatalogUnit): ActionGroup[] {
+    const course = this.activeCourse;
+    const unitComplete = unit.activities
+      .filter((a) => a.type === "exercise")
+      .every((a) =>
+        this.isComplete({
+          courseId: course.id,
+          unitId: unit.id,
+          activityId: a.id,
+        }),
+      );
+
+    const primaryGroup: ActionGroup = unitComplete
+      ? [{ key: "space", label: "Next", action: "next", primary: true }]
+      : [
+          {
+            key: "space",
+            label: "Open Notebook",
+            action: "open-notebook",
+            primary: true,
+            codicon: "notebook",
+          },
+        ];
+
+    const extraGroups: ActionGroup[] = unitComplete
+      ? [
+          [
+            {
+              key: "o",
+              label: "Open Notebook",
+              action: "open-notebook",
+              codicon: "notebook",
+            },
+            { key: "r", label: "Reset", action: "reset" },
+          ],
+        ]
+      : [[{ key: "r", label: "Reset", action: "reset" }]];
+
+    const navGroup: ActionGroup = [{ key: "b", label: "Back", action: "back" }];
+
+    return [primaryGroup, ...extraGroups, navGroup].filter((g) => g.length > 0);
+  }
+
   /** Turns a catalog activity into the typed content payload (exercise, lesson-example, or lesson-text). */
   private resolveActivityContent(
     location: ActivityLocation,
@@ -842,6 +1705,15 @@ export class LearningService {
     const ws = this.requireWorkspace();
 
     if (activity.type === "exercise") {
+      // Python-notebook exercises live in the notebook — show their
+      // description as lesson text so the panel renders something useful.
+      if (this.activeCourse.kind === "python-notebook") {
+        return {
+          type: "lesson-text",
+          content: activity.description,
+        } satisfies LessonTextContent;
+      }
+
       const fileUri = vscode.Uri.joinPath(
         ws.learningContentRoot,
         "exercises",
@@ -884,6 +1756,11 @@ export class LearningService {
     } satisfies LessonTextContent;
   }
 
+  /** Working-copy (`*.workbook.ipynb`) URI of a notebook for the active python-notebook course. */
+  private notebookFileUri(notebookRel: string): vscode.Uri {
+    return this.pythonRunner.workbookFileUri(this.activeCourse, notebookRel);
+  }
+
   private findCurrentActivity(): {
     unit: CatalogUnit;
     activity: CatalogActivity;
@@ -909,13 +1786,13 @@ export class LearningService {
   private nextActivity(
     location: ActivityLocation,
   ): ActivityLocation | undefined {
-    const ws = this.requireWorkspace();
+    const course = this.activeCourse;
     let found = false;
-    for (const unit of ws.catalog.units) {
+    for (const unit of course.units) {
       for (const a of unit.activities) {
         if (found) {
           return {
-            courseId: ws.catalog.id,
+            courseId: course.id,
             unitId: unit.id,
             activityId: a.id,
           };
@@ -932,15 +1809,15 @@ export class LearningService {
   private previousActivity(
     location: ActivityLocation,
   ): ActivityLocation | undefined {
-    const ws = this.requireWorkspace();
+    const course = this.activeCourse;
     let prev: ActivityLocation | undefined;
-    for (const unit of ws.catalog.units) {
+    for (const unit of course.units) {
       for (const a of unit.activities) {
         if (unit.id === location.unitId && a.id === location.activityId) {
           return prev;
         }
         prev = {
-          courseId: ws.catalog.id,
+          courseId: course.id,
           unitId: unit.id,
           activityId: a.id,
         };
@@ -950,9 +1827,7 @@ export class LearningService {
   }
 
   private findUnit(unitId: string): CatalogUnit {
-    const kata = this.requireWorkspace().catalog.units.find(
-      (k) => k.id === unitId,
-    );
+    const kata = this.activeCourse.units.find((k) => k.id === unitId);
     if (!kata) {
       throw new Error(`Unit not found: ${unitId}`);
     }
@@ -966,9 +1841,7 @@ export class LearningService {
     await this.saveProgress();
     this._onDidChangeState.fire(this.getState());
 
-    const unit = this.requireWorkspace().catalog.units.find(
-      (u) => u.id === location.unitId,
-    );
+    const unit = this.activeCourse.units.find((u) => u.id === location.unitId);
     const exercises =
       unit?.activities.filter((s) => s.type === "exercise") ?? [];
     const exerciseIndex = exercises.findIndex(
@@ -998,11 +1871,19 @@ export class LearningService {
         parsed.position !== null
       ) {
         ws.progressData = parsed as ProgressFileData;
+        // Resolve the course the saved position points at, falling back to
+        // the default loaded course if it references one not yet loaded.
+        const course =
+          ws.courses.get(ws.progressData.position.courseId) ??
+          this.defaultCourseOf(ws);
         // Validate saved position references a known unit and activity
-        if (ws.catalog.units.length > 0) {
-          const unit = ws.catalog.units.find(
-            (k) => k.id === ws.progressData.position.unitId,
-          );
+        if (course && course.units.length > 0) {
+          const unit =
+            ws.progressData.position.courseId === course.id
+              ? course.units.find(
+                  (k) => k.id === ws.progressData.position.unitId,
+                )
+              : undefined;
           const activityValid =
             unit &&
             unit.activities.some(
@@ -1010,9 +1891,9 @@ export class LearningService {
             );
           if (!activityValid) {
             ws.progressData.position = {
-              courseId: ws.catalog.id,
-              unitId: ws.catalog.units[0].id,
-              activityId: ws.catalog.units[0].activities[0]?.id ?? "",
+              courseId: course.id,
+              unitId: course.units[0].id,
+              activityId: course.units[0].activities[0]?.id ?? "",
             };
           }
         }
@@ -1021,16 +1902,22 @@ export class LearningService {
     } catch {
       // expected when file is missing or corrupt
     }
+    const course = this.defaultCourseOf(ws);
     ws.progressData = {
       version: 1,
       position: {
-        courseId: ws.catalog.id,
-        unitId: ws.catalog.units[0]?.id ?? "",
-        activityId: ws.catalog.units[0]?.activities[0]?.id ?? "",
+        courseId: course?.id ?? "",
+        unitId: course?.units[0]?.id ?? "",
+        activityId: course?.units[0]?.activities[0]?.id ?? "",
       },
       completions: {},
       startedAt: new Date().toISOString(),
     };
+  }
+
+  /** The default course for a workspace (built-in katas, else the first loaded). */
+  private defaultCourseOf(ws: WorkspaceState): CatalogCourse | undefined {
+    return ws.courses.get(KATAS_COURSE_ID) ?? ws.courses.values().next().value;
   }
 
   private async saveProgress(): Promise<void> {
@@ -1127,47 +2014,135 @@ export class LearningService {
     this._onDidChangeProgress.fire(this._lastSnapshot);
   }
 
-  private async scaffoldExercises(ws: WorkspaceState): Promise<void> {
-    for (const kata of ws.catalog.units) {
-      for (const activity of kata.activities) {
-        if (activity.type !== "exercise") {
-          continue;
+  /**
+   * Start watching for `.qdk-unit-complete` sentinel files in the active
+   * python-notebook course folder. When the notebook's `complete_unit()` writes this
+   * file, we mark the unit complete.
+   */
+  private startSentinelWatcher(): void {
+    this.stopSentinelWatcher();
+    const course = this.activeCourse;
+    if (course.kind !== "python-notebook" || !course.sourceDir) {
+      return;
+    }
+    const coursesDir = vscode.Uri.parse(course.sourceDir);
+    const pattern = new vscode.RelativePattern(
+      coursesDir,
+      "**/.qdk-unit-complete",
+    );
+    this._sentinelWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+
+    const onSentinel = async (uri: vscode.Uri) => {
+      try {
+        const bytes = await vscode.workspace.fs.readFile(uri);
+        const unitId = new TextDecoder().decode(bytes).trim();
+        if (!unitId) {
+          return;
         }
-        const fileUri = vscode.Uri.joinPath(
-          ws.learningContentRoot,
-          "exercises",
-          kata.id,
-          `${activity.id}.qs`,
-        );
-        if (await this.uriExists(fileUri)) {
-          continue;
+        // Find the unit and mark all its activities complete.
+        const unit = course.units.find((u) => u.id === unitId);
+        if (!unit || unit.activities.length === 0) {
+          return;
         }
-        await this.ensureParentDir(fileUri);
-        await vscode.workspace.fs.writeFile(
-          fileUri,
-          new TextEncoder().encode(activity.placeholderCode),
-        );
+        let changed = false;
+        for (const activity of unit.activities) {
+          const location: ActivityLocation = {
+            courseId: course.id,
+            unitId: unit.id,
+            activityId: activity.id,
+          };
+          if (!this.isComplete(location)) {
+            this.markComplete(location);
+            changed = true;
+          }
+        }
+        if (changed) {
+          await this.saveProgress();
+          this._onDidChangeState.fire(this.getState());
+        }
+      } catch {
+        // sentinel may be transient or corrupt; ignore
       }
+    };
+
+    this._sentinelWatcher.onDidCreate(onSentinel);
+    this._sentinelWatcher.onDidChange(onSentinel);
+  }
+
+  private stopSentinelWatcher(): void {
+    this._sentinelWatcher?.dispose();
+    this._sentinelWatcher = undefined;
+  }
+
+  /**
+   * Close any open editor tabs whose URI matches the given notebook URI.
+   */
+  private async closeNotebookTab(uri: vscode.Uri): Promise<void> {
+    const uriStr = uri.toString();
+    const tabs: vscode.Tab[] = [];
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        if (
+          tab.input instanceof vscode.TabInputNotebook &&
+          tab.input.uri.toString() === uriStr
+        ) {
+          tabs.push(tab);
+        }
+      }
+    }
+    if (tabs.length > 0) {
+      await vscode.window.tabGroups.close(tabs);
     }
   }
 
-  private async scaffoldExamples(ws: WorkspaceState): Promise<void> {
-    for (const kata of ws.catalog.units) {
+  /**
+   * Materialize the editable files (exercise placeholders and example code)
+   * for a Q# course into the learning content folder. No-op for non-qsharp
+   * courses (those are scaffolded by their own runtime).
+   */
+  private async scaffoldCourse(
+    ws: WorkspaceState,
+    course: CatalogCourse,
+  ): Promise<void> {
+    if (course.kind === "python-notebook") {
+      // Copy the course's notebooks into the workspace working copy so the
+      // learner edits a stable location, then surface any missing tooling.
+      await this.pythonRunner.materializeCourse(course);
+      return;
+    }
+    if (course.kind !== "qsharp") {
+      return;
+    }
+    for (const kata of course.units) {
       for (const activity of kata.activities) {
-        if (activity.type !== "lesson" || !activity.example) {
-          continue;
+        if (activity.type === "exercise") {
+          const fileUri = vscode.Uri.joinPath(
+            ws.learningContentRoot,
+            "exercises",
+            kata.id,
+            `${activity.id}.qs`,
+          );
+          if (await this.uriExists(fileUri)) {
+            continue;
+          }
+          await this.ensureParentDir(fileUri);
+          await vscode.workspace.fs.writeFile(
+            fileUri,
+            new TextEncoder().encode(activity.placeholderCode),
+          );
+        } else if (activity.type === "lesson" && activity.example) {
+          const fileUri = vscode.Uri.joinPath(
+            ws.learningContentRoot,
+            "examples",
+            kata.id,
+            `${activity.example.id}.qs`,
+          );
+          await this.ensureParentDir(fileUri);
+          await vscode.workspace.fs.writeFile(
+            fileUri,
+            new TextEncoder().encode(activity.example.code),
+          );
         }
-        const fileUri = vscode.Uri.joinPath(
-          ws.learningContentRoot,
-          "examples",
-          kata.id,
-          `${activity.example.id}.qs`,
-        );
-        await this.ensureParentDir(fileUri);
-        await vscode.workspace.fs.writeFile(
-          fileUri,
-          new TextEncoder().encode(activity.example.code),
-        );
       }
     }
   }

--- a/source/vscode/src/learning/types.d.ts
+++ b/source/vscode/src/learning/types.d.ts
@@ -75,7 +75,8 @@ export type Action =
   | "check"
   | "reset"
   | "hint-chat"
-  | "explain-chat";
+  | "explain-chat"
+  | "open-notebook";
 
 export interface ActionBinding {
   /** Keyboard shortcut key (single character like "b", or "space"). */
@@ -136,6 +137,8 @@ export interface HintContext {
 }
 
 export interface LearningState {
+  /** The currently-active course. */
+  course: { id: string; title: string; kind: CourseKind };
   position: CurrentActivity;
   actions: ActionGroup[];
   progress: OverallProgress;
@@ -215,7 +218,13 @@ export type WebviewToHostMessage =
   /** Open Copilot Chat with a learning-context query. */
   | { command: "openChat"; text: string }
   /** Focus the learning progress tree view in the sidebar. */
-  | { command: "focusProgress" };
+  | { command: "focusProgress" }
+  /** Switch to a different course. */
+  | { command: "switchCourse"; courseId: string }
+  /** Show README/info for a course (defaults to the active course). */
+  | { command: "courseInfo"; courseId?: string }
+  /** Open the course picker to browse and switch courses. */
+  | { command: "browseCourses" };
 
 // ─── Catalog ───
 //
@@ -256,16 +265,98 @@ export interface CatalogLesson {
 
 export type CatalogActivity = CatalogExercise | CatalogLesson;
 
+/**
+ * Exercise metadata loaded from a per-unit `_exercises.json` sidecar
+ * (python-notebook courses). Provides hints, solutions, and descriptions
+ * for the chat LM tools without requiring cell parsing or execution.
+ */
+export interface NotebookExerciseInfo {
+  id: string;
+  title: string;
+  description: string;
+  hints: string[];
+  solution: string;
+  solutionExplanation: string;
+  /** 1-based cell index in the notebook where this exercise lives. */
+  cellIndex?: number;
+}
+
 export interface CatalogUnit {
   id: string;
   title: string;
   activities: CatalogActivity[];
+  /**
+   * Exercise metadata for python-notebook courses, loaded from
+   * `_exercises.json`. Used by chat LM tools for hints/solutions.
+   */
+  notebookExercises?: NotebookExerciseInfo[];
+  /**
+   * Path (relative to the course source dir) of the notebook for this
+   * unit. Set for python-notebook courses.
+   */
+  notebookRel?: string;
 }
+
+/** The execution model for a course's activities. */
+export type CourseKind = "qsharp" | "python-notebook";
 
 export interface CatalogCourse {
   id: string;
   title: string;
+  /** Execution model for this course. Defaults to `"qsharp"`. */
+  kind: CourseKind;
   units: CatalogUnit[];
+  /**
+   * URI string of the folder the course was loaded from (drop-in courses
+   * only). Used to locate notebooks and other assets for materialization.
+   */
+  sourceDir?: string;
+  /** Environment requirements (python-notebook courses). */
+  environment?: CourseEnvironment;
+}
+
+/**
+ * Lightweight metadata describing a course that can be loaded by the
+ * {@link CourseRegistry}. Used to populate course pickers and the tree
+ * view without forcing a full course load.
+ */
+export interface CourseDescriptor {
+  id: string;
+  title: string;
+  shortDescription?: string;
+  kind: CourseKind;
+  /** Optional path (URI string) to a README rendered for "Course info". */
+  readmePath?: string;
+  /** Optional environment requirements (used by python-notebook courses). */
+  environment?: CourseEnvironment;
+}
+
+/**
+ * Environment requirements for a course (python-notebook courses).
+ *
+ * Courses that ship a `pyproject.toml` use `uv sync` for environment setup;
+ * the `python` and `requirements` fields are only used as a legacy fallback
+ * when no `pyproject.toml` is present.
+ */
+export interface CourseEnvironment {
+  /**
+   * Python version specifier for the course venv (e.g. `">=3.11"`, `"3.12"`).
+   * Legacy: used only when no `pyproject.toml` is present. Prefer declaring
+   * `requires-python` in `pyproject.toml` instead.
+   */
+  python?: string;
+  /**
+   * Python package requirements (e.g. `["qdk[jupyter]>=1.0", "ipympl"]`).
+   * Legacy: used only when no `pyproject.toml` is present. Prefer declaring
+   * `dependencies` in `pyproject.toml` instead.
+   */
+  requirements?: string[];
+  /**
+   * Module names to probe with `importlib.util.find_spec` in the notebook's
+   * environment check cell (e.g. `["qdk", "qdk.widgets"]`). These are
+   * importable module names, not pip package names.
+   */
+  importChecks?: string[];
 }
 
 export interface UnitSummary {
@@ -275,4 +366,54 @@ export interface UnitSummary {
   completedCount: number;
   /** True if this is the first unit that hasn't been fully completed. */
   firstIncomplete: boolean;
+}
+
+// ─── Environment check (environment diagnostics) ───
+
+/** Severity of a single {@link EnvironmentCheckItem}. */
+export type EnvironmentCheckStatus = "ok" | "warn" | "fail" | "skip";
+
+/** A suggested fix attached to a failing {@link EnvironmentCheckItem}. */
+export interface EnvironmentCheckFix {
+  /** Short label for the action (e.g. "Set up environment"). */
+  label: string;
+  /**
+   * What the fix does when chosen:
+   * - `setup`: run the per-course environment setup.
+   * - `install-extensions`: prompt to install Python/Jupyter.
+   * - `select-kernel`: re-select the course kernel for the notebook.
+   * - `docs`: informational only; no action.
+   */
+  kind: "setup" | "install-extensions" | "select-kernel" | "docs";
+}
+
+/** One diagnostic in an {@link EnvironmentCheckReport}. */
+export interface EnvironmentCheckItem {
+  /** Stable identifier for the check (e.g. `"venv"`). */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  /** Pass/warn/fail/skip. */
+  status: EnvironmentCheckStatus;
+  /** Extra detail (a path, version, or error message). */
+  detail?: string;
+  /** Guidance on how to fix a non-ok check. */
+  hint?: string;
+  /** Optional fixes the UI can offer for this check. */
+  fixes?: EnvironmentCheckFix[];
+}
+
+/** Overall status for an {@link EnvironmentCheckReport}. */
+export type EnvironmentStatus = "ok" | "warning" | "error";
+
+/** Structured result of running environment diagnostics for a course. */
+export interface EnvironmentCheckReport {
+  courseId: string;
+  /** Overall status across all checks. */
+  overallStatus: EnvironmentStatus;
+  /** One-line human summary of the overall status. */
+  summary: string;
+  checks: EnvironmentCheckItem[];
+  /** Distinct fixes aggregated from all failing checks, in priority order. */
+  fixes: EnvironmentCheckFix[];
 }

--- a/source/vscode/src/learning/webview/webview-client.tsx
+++ b/source/vscode/src/learning/webview/webview-client.tsx
@@ -225,7 +225,7 @@ function App() {
 
   return (
     <>
-      <Branding />
+      <Branding course={learning.course} />
       <Header current={learning.position} />
       <ContentBody
         content={learning.position.content}
@@ -247,8 +247,11 @@ function App() {
   );
 }
 
-function Branding() {
+function Branding({ course }: { course: LearningState["course"] }) {
   const mobiusUri = document.body.dataset.mobiusUri ?? "";
+  const onInfo = () =>
+    vscodeApi.postMessage({ command: "courseInfo", courseId: course.id });
+  const onBrowse = () => vscodeApi.postMessage({ command: "browseCourses" });
   return (
     <div class="branding" style={`--mobius-url: url('${mobiusUri}')`}>
       <div
@@ -256,7 +259,19 @@ function Branding() {
         role="img"
         aria-label="Microsoft Quantum logo"
       />
-      <span class="branding-text">Microsoft Quantum Katas</span>
+      <span class="branding-text">{course.title}</span>
+      <span class="branding-actions">
+        <button class="link-button" title="Course info" onClick={onInfo}>
+          Course info
+        </button>
+        <button
+          class="link-button"
+          title="Browse and switch courses"
+          onClick={onBrowse}
+        >
+          Browse courses
+        </button>
+      </span>
     </div>
   );
 }

--- a/source/vscode/src/learning/webview/webview.css
+++ b/source/vscode/src/learning/webview/webview.css
@@ -130,6 +130,29 @@ body {
   color: var(--muted);
 }
 
+/* Course actions (info / browse) pushed to the right of the branding bar. */
+.branding-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: var(--vscode-textLink-foreground, #3794ff);
+  font-size: var(--font-xs);
+  font-family: inherit;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
 /* Breadcrumb bar showing "Unit › Activity" and a type badge. */
 .header {
   display: flex;

--- a/source/vscode/test/buildTests.mjs
+++ b/source/vscode/test/buildTests.mjs
@@ -27,6 +27,7 @@ const platformBuildOptions = {
       join(thisDir, "suites", "empty", "index.browser.ts"),
       join(thisDir, "suites", "language-service", "index.browser.ts"),
       join(thisDir, "suites", "debugger", "index.browser.ts"),
+      join(thisDir, "suites", "learning", "index.browser.ts"),
     ],
     platform: "browser",
     outdir: join(thisDir, "out", "browser"),
@@ -37,6 +38,7 @@ const platformBuildOptions = {
     entryPoints: [
       join(thisDir, "suites", "language-service", "index.node.ts"),
       join(thisDir, "suites", "debugger", "index.node.ts"),
+      join(thisDir, "suites", "learning", "index.node.ts"),
     ],
     platform: "node",
     outdir: join(thisDir, "out", "node"),

--- a/source/vscode/test/runTests.mjs
+++ b/source/vscode/test/runTests.mjs
@@ -11,7 +11,7 @@
 // it in a headless instance of Chromium to run the integration test suite.
 //
 // Command-line arguments:
-// --suite=<name>           Run only the specified test suite (language-service or debugger)
+// --suite=<name>           Run only the specified test suite (language-service, debugger, or learning)
 // --waitForDebugger=<port> Wait for debugger to attach on the specified port before running tests
 // --verbose                Enable verbose logging for VS Code and test web server
 //                          Note: This controls the VS Code and test web server logging level.
@@ -72,7 +72,7 @@ try {
   }
   console.log("Empty suite succeeded.");
 
-  const suites = ["language-service", "debugger"];
+  const suites = ["language-service", "debugger", "learning"];
   const toRun =
     selectedSuite && suites.includes(selectedSuite) ? [selectedSuite] : suites;
 

--- a/source/vscode/test/suites/extensionUtils.ts
+++ b/source/vscode/test/suites/extensionUtils.ts
@@ -32,7 +32,7 @@ export function setTestGithubEndpoint(url: string) {
   testGithubEndpoint = url;
 }
 
-export async function activateExtension() {
+export async function activateExtension(): Promise<ExtensionApi> {
   // Check for pre-release or stable builds of the extension, as could be in release pipeline
   const ext =
     vscode.extensions.getExtension("quantum.qsharp-lang-vscode-dev") ??
@@ -43,7 +43,7 @@ export async function activateExtension() {
   }
 
   if (ext.isActive) {
-    return;
+    return ext.exports as ExtensionApi;
   }
 
   const start = performance.now();
@@ -73,6 +73,8 @@ export async function activateExtension() {
   console.log(
     `qsharp-tests: activate() completed in ${performance.now() - start}ms`,
   );
+
+  return extensionApi;
 }
 
 /**

--- a/source/vscode/test/suites/learning/index.browser.ts
+++ b/source/vscode/test/suites/learning/index.browser.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { runMochaTests } from "../runBrowser";
+
+export function run(): Promise<void> {
+  return runMochaTests(() => {
+    // We can't use any wildcards or dynamically discovered
+    // paths here since ESBuild needs these modules to be
+    // real paths on disk at bundling time.
+    require("./learning.test"); // eslint-disable-line @typescript-eslint/no-require-imports
+  });
+}

--- a/source/vscode/test/suites/learning/index.node.ts
+++ b/source/vscode/test/suites/learning/index.node.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { runMochaTests } from "../runNode";
+
+export async function run(): Promise<void> {
+  await runMochaTests(() => {
+    // We can't use any wildcards or dynamically discovered
+    // paths here since ESBuild needs these modules to be
+    // real paths on disk at bundling time.
+    require("./learning.test"); // eslint-disable-line @typescript-eslint/no-require-imports
+  });
+}

--- a/source/vscode/test/suites/learning/learning.test.ts
+++ b/source/vscode/test/suites/learning/learning.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert } from "chai";
+import { type ExtensionApi } from "../../src/extension";
+import { activateExtension } from "../extensionUtils";
+
+type LearningService = NonNullable<ExtensionApi["learning"]>;
+
+suite("QDK Learning multi-course", function suite() {
+  let service: LearningService;
+
+  this.beforeAll(async function beforeAll() {
+    const api = await activateExtension();
+    // The learning feature is desktop-only, so this suite is skipped in the
+    // web (browser) test host where no learning service is exposed.
+    if (!api.learning) {
+      this.skip();
+    }
+    service = api.learning!;
+    await service.tryInitialize({ createIfMissing: true });
+  });
+
+  test("Katas is the default course", async () => {
+    const courses = await service.getCourses();
+    assert.isTrue(
+      courses.some((c) => c.id === "katas"),
+      "the built-in Katas course should always be available",
+    );
+    assert.equal(service.getActiveCourseId(), "katas");
+  });
+
+  test("Drop-in python-notebook course is discovered", async function test() {
+    const courses = await service.getCourses();
+    const descriptor = courses.find((c) => c.id === "circuit-diagrams");
+    assert.ok(descriptor, "the fixture course should be discovered");
+    assert.equal(descriptor!.kind, "python-notebook");
+  });
+
+  test("Notebook unit parses into a lesson, example, and two tasks", async function test() {
+    await service.switchCourse("circuit-diagrams", "tree");
+    try {
+      assert.equal(service.getActiveCourseId(), "circuit-diagrams");
+      const units = service.listUnits();
+      assert.equal(units.length, 1, "course should have a single unit");
+
+      const progress = service.getProgress();
+      const activities = progress.units[0].activities;
+      const ids = activities.map((a) => a.id);
+      assert.include(ids, "build-bell");
+      assert.include(ids, "display-circuit");
+
+      const exercises = activities.filter((a) => a.type === "exercise");
+      assert.equal(exercises.length, 2, "both tasks should become exercises");
+    } finally {
+      await service.switchCourse("katas", "tree");
+    }
+  });
+
+  test("Environment check returns a structured report", async function test() {
+    await service.switchCourse("circuit-diagrams", "tree");
+    try {
+      const report = await service.runEnvironmentCheck();
+      assert.equal(report.courseId, "circuit-diagrams");
+      assert.isAbove(
+        report.checks.length,
+        0,
+        "the report should contain checks",
+      );
+      // Until the per-course environment is set up (or on a host without the
+      // tooling), the report should flag problems and offer a fix.
+      if (report.overallStatus !== "ok") {
+        assert.isTrue(
+          report.fixes.length > 0 ||
+            report.checks.some((c) => c.status !== "ok"),
+          "a failing report should be actionable",
+        );
+      }
+    } finally {
+      await service.switchCourse("katas", "tree");
+    }
+  });
+
+  test("Katas course needs no environment (check passes)", async () => {
+    await service.switchCourse("katas", "tree");
+    const report = await service.runEnvironmentCheck();
+    assert.equal(report.courseId, "katas");
+    assert.equal(
+      report.overallStatus,
+      "ok",
+      "Q# courses should pass diagnostics trivially",
+    );
+    assert.isFalse(report.fixes.some((r) => r.kind === "setup"));
+  });
+});


### PR DESCRIPTION
This change generalizes the QDK Learning feature to support multiple courses of different kinds, including author-provided Python Jupyter notebook courses, while keeping the Quantum Katas as the default.