### PR TITLE
Have RCA reject unsafe qubit release from dynamic context

### DIFF
--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -530,6 +530,12 @@ fn return_within_dynamic_scope_yields_errors() {
         RETURN_WITHIN_DYNAMIC_SCOPE,
         &expect![[r#"
             [
+                UseOfDynamicQubitRelease(
+                    Span {
+                        lo: 66,
+                        hi: 82,
+                    },
+                ),
                 ReturnWithinDynamicScope(
                     Span {
                         lo: 128,

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -420,6 +420,12 @@ fn return_within_dynamic_scope_yields_errors() {
         RETURN_WITHIN_DYNAMIC_SCOPE,
         &expect![[r#"
             [
+                UseOfDynamicQubitRelease(
+                    Span {
+                        lo: 66,
+                        hi: 82,
+                    },
+                ),
                 ReturnWithinDynamicScope(
                     Span {
                         lo: 128,

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats.rs
@@ -405,6 +405,12 @@ fn return_within_dynamic_scope_yields_errors() {
         RETURN_WITHIN_DYNAMIC_SCOPE,
         &expect![[r#"
             [
+                UseOfDynamicQubitRelease(
+                    Span {
+                        lo: 66,
+                        hi: 82,
+                    },
+                ),
                 ReturnWithinDynamicScope(
                     Span {
                         lo: 128,

--- a/source/compiler/qsc_rca/src/common.rs
+++ b/source/compiler/qsc_rca/src/common.rs
@@ -28,8 +28,9 @@ pub enum LocalKind {
     InputParam(InputParamIndex),
     /// A specialization input (i.e. control qubits).
     SpecInput,
-    /// An immutable binding with the expression associated to it.
-    Immutable(ExprId),
+    /// An immutable binding with the expression associated to it and the optional
+    /// expression for the containing dynamic scope, if any.
+    Immutable(ExprId, Option<ExprId>),
     /// A mutable binding with the optional expression for the containing dynamic scope,
     /// if any.
     Mutable(Option<ExprId>),
@@ -172,7 +173,7 @@ fn try_resolve_local_callee(
     // This is a best effort attempt to resolve a callee.
     match locals_map.find(local_var_id) {
         Some(local) => match local.kind {
-            LocalKind::Immutable(expr_id) => {
+            LocalKind::Immutable(expr_id, _) => {
                 try_resolve_callee(expr_id, package_id, package, locals_map)
             }
             _ => (None, None),

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -469,6 +469,43 @@ impl<'a> Analyzer<'a> {
             compute_kind.aggregate_value_kind(value_kind);
         }
 
+        if !self.target_capabilities.is_empty()
+            && callable_decl.name.name.as_ref() == "__quantum__rt__qubit_release"
+        {
+            // If the analysis is for a target non-empty capabilities, we need to check if this is
+            // a non-deterministic qubit release, which requires the dynamic qubit allocation feature.
+            // (We ignore this check for Base Profile as other dynamism will already be flagged and this
+            // specific case does not come up in isolation).
+            // We know that only one intrinsic callable named "__quantum__rt__qubit_release" is allowed by the compiler
+            // and that the argument is a local variable of type "Qubit" so we unwrap to it and check its scoping.
+            // It is valid to release a qubit from a dynamic scope as long as it is the same scope the qubit was allocated in.
+            // If it is not the same scope, that means we will not be able to unconditional perform a single release during
+            // partial evaluation and would need to emit a dynamic call to a release function. Without the dynamic qubit release
+            // feature, this manifests as a double release during codegen, which we want to avoid. Adding the dynamic qubit release
+            // feature to the compute kind will flag this as requiring the dynamic qubit release feature.
+            let args_expr = self.get_expr(args_expr_id);
+            let ExprKind::Var(res, _) = args_expr.kind else {
+                panic!("expected a variable expression for qubit release arguments");
+            };
+            let Res::Local(local_var_id) = res else {
+                panic!("expected a local variable for qubit release arguments");
+            };
+            let local_var_compute_kind = application_instance
+                .locals_map
+                .find_local_compute_kind(local_var_id)
+                .expect("local compute kind should be defined before update");
+            let in_matching_dynamic_scope = matches!(
+                local_var_compute_kind.local.kind,
+                LocalKind::Immutable(_, dynamic_scope) | LocalKind::Mutable(dynamic_scope) if dynamic_scope.as_ref() == application_instance.active_dynamic_scopes.last()
+            );
+            if !in_matching_dynamic_scope {
+                compute_kind = compute_kind.aggregate(ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::UseOfDynamicQubitRelease,
+                    value_kind: ValueKind::Constant,
+                });
+            }
+        }
+
         compute_kind
     }
 
@@ -1362,7 +1399,9 @@ impl<'a> Analyzer<'a> {
         match &pat.kind {
             PatKind::Bind(ident) => {
                 let local_kind = match mutability {
-                    Mutability::Immutable => LocalKind::Immutable(expr_id),
+                    Mutability::Immutable => {
+                        LocalKind::Immutable(expr_id, self.get_current_dynamic_scope())
+                    }
                     Mutability::Mutable => LocalKind::Mutable(self.get_current_dynamic_scope()),
                 };
                 let application_instance = self.get_current_application_instance();
@@ -1395,7 +1434,9 @@ impl<'a> Analyzer<'a> {
         match &pat.kind {
             PatKind::Bind(ident) => {
                 let local_kind = match mutability {
-                    Mutability::Immutable => LocalKind::Immutable(expr_id),
+                    Mutability::Immutable => {
+                        LocalKind::Immutable(expr_id, self.get_current_dynamic_scope())
+                    }
                     Mutability::Mutable => LocalKind::Mutable(self.get_current_dynamic_scope()),
                 };
                 let application_instance = self.get_current_application_instance();

--- a/source/compiler/qsc_rca/src/errors.rs
+++ b/source/compiler/qsc_rca/src/errors.rs
@@ -228,6 +228,14 @@ pub enum Error {
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-generic"))]
     #[diagnostic(code("Qsc.CapabilitiesCk.UseOfDynamicGeneric"))]
     UseOfDynamicGeneric(#[label] Span),
+
+    #[error("cannot use a dynamic qubit release")]
+    #[diagnostic(help(
+        "non-deterministic qubit release, often from patterns like dynamic early returns, requires the dynamic qubit allocation feature and is not supported by the configured target profile"
+    ))]
+    #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-qubit-release"))]
+    #[diagnostic(code("Qsc.CapabilitiesCk.UseOfDynamicQubitRelease"))]
+    UseOfDynamicQubitRelease(#[label] Span),
 }
 
 #[must_use]
@@ -322,6 +330,9 @@ pub fn generate_errors_from_runtime_features(
     }
     if runtime_features.contains(RuntimeFeatureFlags::UseOfDynamicGeneric) {
         errors.push(Error::UseOfDynamicGeneric(span));
+    }
+    if runtime_features.contains(RuntimeFeatureFlags::UseOfDynamicQubitRelease) {
+        errors.push(Error::UseOfDynamicQubitRelease(span));
     }
     errors
 }

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -696,6 +696,8 @@ bitflags! {
         const UseOfDynamicGeneric = 1 << 28;
         /// A callable allocates qubits (directly or transitively).
         const QubitAllocation = 1 << 29;
+        /// A dynamic release of a qubit.
+        const UseOfDynamicQubitRelease = 1 << 30;
     }
 }
 
@@ -808,6 +810,9 @@ impl RuntimeFeatureFlags {
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicGeneric) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
+        }
+        if self.contains(RuntimeFeatureFlags::UseOfDynamicQubitRelease) {
+            capabilities |= TargetCapabilityFlags::DynamicQubitAllocation;
         }
         capabilities
     }

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -148,7 +148,7 @@ fn check_rca_for_operation_with_one_classical_return_and_one_dynamic_return() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | QubitAllocation | UseOfDynamicQubitRelease)
                         value_kind: Variable
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -205,7 +205,7 @@ fn check_rca_for_callable_block_with_dynamic_unreachable_binding() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | QubitAllocation | UseOfDynamicQubitRelease)
                         value_kind: Variable
                     dynamic_param_applications: <empty>
                 adj: <none>

--- a/source/compiler/qsc_rca/src/tests/calls.rs
+++ b/source/compiler/qsc_rca/src/tests/calls.rs
@@ -222,7 +222,7 @@ fn check_rca_for_call_to_operation_with_one_classical_return_and_one_dynamic_ret
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | ReturnWithinDynamicScope | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | ReturnWithinDynamicScope | QubitAllocation | UseOfDynamicQubitRelease)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );


### PR DESCRIPTION
This change updates the analysis performed to check if a given call expression is a call to qubit release in a dynamic scope with an argument that comes from a different dynamic scope. Without dynamic qubit allocation, this would result in a double release during codegen, so we tag this pattern as requiring dynamic qubit allocation and provide design-time feedback. Fixes #3310

The error is flagged on the qubit allocation itself, since that is the corresponding span for the compiler generated release. The error message specifically calls out dynamic early returns, since that is the most common cause of these errors:
<img width="737" height="341" alt="image" src="https://github.com/user-attachments/assets/3ded6256-34fb-4292-96b1-c8a3ee9e94f9" />
