### PR TITLE
Add Adaptive target profile completions and OpenQASM pragma/annotation completions

### DIFF
--- a/source/compiler/qsc_data_structures/src/target.rs
+++ b/source/compiler/qsc_data_structures/src/target.rs
@@ -63,8 +63,6 @@ use std::str::FromStr;
 /// Most user-facing APIs work in terms of profiles.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Profile {
-    /// Corresponds to a target with no limitations on supported language features.
-    Unrestricted,
     /// Corresponds to a target with support only for gate operations on qubits with all measurements at the end of the program..
     Base,
     /// Corresponds to a target with support for forward branching, qubit reuse, and integer computations.
@@ -73,17 +71,19 @@ pub enum Profile {
     AdaptiveRIF,
     /// Corresponds to a target with support for full adaptive profile, including any extensions.
     Adaptive,
+    /// Corresponds to a target with no limitations on supported language features.
+    Unrestricted,
 }
 
 impl Profile {
     #[must_use]
     pub fn to_str(&self) -> &'static str {
         match self {
-            Self::Unrestricted => "Unrestricted",
             Self::Base => "Base",
             Self::AdaptiveRI => "Adaptive_RI",
             Self::AdaptiveRIF => "Adaptive_RIF",
             Self::Adaptive => "Adaptive",
+            Self::Unrestricted => "Unrestricted",
         }
     }
 }
@@ -114,10 +114,10 @@ impl FromStr for Profile {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "base" => Ok(Self::Base),
             "adaptive_ri" => Ok(Self::AdaptiveRI),
             "adaptive_rif" => Ok(Self::AdaptiveRIF),
             "adaptive" => Ok(Self::Adaptive),
-            "base" => Ok(Self::Base),
             "unrestricted" => Ok(Self::Unrestricted),
             _ => Err(()),
         }

--- a/source/compiler/qsc_data_structures/src/target.rs
+++ b/source/compiler/qsc_data_structures/src/target.rs
@@ -76,6 +76,18 @@ pub enum Profile {
 }
 
 impl Profile {
+    /// Returns all supported profiles, ordered from least to most capable.
+    #[must_use]
+    pub fn all() -> [Profile; 5] {
+        [
+            Self::Base,
+            Self::AdaptiveRI,
+            Self::AdaptiveRIF,
+            Self::Adaptive,
+            Self::Unrestricted,
+        ]
+    }
+
     #[must_use]
     pub fn to_str(&self) -> &'static str {
         match self {

--- a/source/compiler/qsc_openqasm_compiler/src/compiler.rs
+++ b/source/compiler/qsc_openqasm_compiler/src/compiler.rs
@@ -64,6 +64,20 @@ const QDK_QIR_NOISE_INTRINSIC_ANNOTATION: &str = "qdk.qir.noise_intrinsic";
 const QSHARP_CONFIG_ANNOTATION: &str = "Config";
 const QDK_CONFIG_ANNOTATION: &str = "qdk.qir.profile";
 
+/// The QDK-namespaced annotation names recognized by the compiler.
+pub const SUPPORTED_QDK_ANNOTATIONS: [&str; 3] = [
+    QDK_QIR_INTRINSIC_ANNOTATION,
+    QDK_QIR_NOISE_INTRINSIC_ANNOTATION,
+    QDK_CONFIG_ANNOTATION,
+];
+
+/// Returns `true` if the given annotation name configures the QIR target profile,
+/// accepting either the QDK-namespaced or bare Q#-style spelling.
+#[must_use]
+pub fn annotation_configures_profile(name: &str) -> bool {
+    name == QSHARP_CONFIG_ANNOTATION || name == QDK_CONFIG_ANNOTATION
+}
+
 /// Helper to create an error expression. Used when we fail to
 /// compile an expression. It is assumed that an error was
 /// already reported.
@@ -132,17 +146,62 @@ pub enum PragmaKind {
     QdkQirProfile,
 }
 
+impl PragmaKind {
+    /// Returns the canonical source spelling of the pragma name.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PragmaKind::QdkBoxOpen => "qdk.box.open",
+            PragmaKind::QdkBoxClose => "qdk.box.close",
+            PragmaKind::QdkQirProfile => "qdk.qir.profile",
+        }
+    }
+
+    /// Returns all supported pragma kinds.
+    #[must_use]
+    pub fn all() -> [PragmaKind; 3] {
+        [
+            PragmaKind::QdkBoxOpen,
+            PragmaKind::QdkBoxClose,
+            PragmaKind::QdkQirProfile,
+        ]
+    }
+}
+
 impl FromStr for PragmaKind {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "qdk.box.open" => Ok(PragmaKind::QdkBoxOpen),
-            "qdk.box.close" => Ok(PragmaKind::QdkBoxClose),
-            "qdk.qir.profile" => Ok(PragmaKind::QdkQirProfile),
-            _ => Err(()),
-        }
+        let lowered = s.to_lowercase();
+        PragmaKind::all()
+            .into_iter()
+            .find(|kind| kind.as_str() == lowered)
+            .ok_or(())
     }
+}
+
+/// Returns true when the function type takes no parameters and returns void.
+/// This is the requirement for a `qdk.box.open`/`qdk.box.close` pragma target.
+fn is_parameterless_and_returns_void(args: &Arc<[Type]>, return_ty: &Arc<Type>) -> bool {
+    args.is_empty() && matches!(&**return_ty, Type::Void)
+}
+
+/// Returns the names of all symbols that are valid targets for the
+/// `qdk.box.open` and `qdk.box.close` pragmas. A valid target is a function
+/// that takes no parameters and returns void.
+#[must_use]
+pub fn valid_box_pragma_targets(symbols: &SymbolTable) -> Vec<String> {
+    symbols
+        .symbols()
+        .filter_map(|symbol| match &symbol.ty {
+            Type::Function(args, return_ty)
+                if is_parameterless_and_returns_void(args, return_ty) =>
+            {
+                Some(symbol.name.clone())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 #[derive(Eq, PartialEq, Default)]
@@ -1315,14 +1374,6 @@ impl QasmCompiler {
     }
 
     fn compile_pragma_stmt(&mut self, stmt: &semast::Pragma) {
-        fn is_parameterless_and_returns_void(args: &Arc<[Type]>, return_ty: &Arc<Type>) -> bool {
-            args.is_empty()
-                && matches!(
-                    &**return_ty,
-                    qsc_openqasm_parser::semantic::types::Type::Void
-                )
-        }
-
         let name_str = stmt
             .identifier
             .as_ref()

--- a/source/compiler/qsc_openqasm_parser/src/semantic/symbols.rs
+++ b/source/compiler/qsc_openqasm_parser/src/semantic/symbols.rs
@@ -423,6 +423,11 @@ impl SymbolTable {
         self.scopes.pop();
     }
 
+    /// Returns an iterator over all symbols defined in the table, across all scopes.
+    pub fn symbols(&self) -> impl Iterator<Item = &Rc<Symbol>> {
+        self.symbols.values()
+    }
+
     pub fn insert_symbol(&mut self, symbol: Symbol) -> Result<SymbolId, SymbolInsertError> {
         let symbol = Rc::new(symbol);
         let id = self.current_id;

--- a/source/language_service/src/completion/openqasm.rs
+++ b/source/language_service/src/completion/openqasm.rs
@@ -2,6 +2,15 @@
 // Licensed under the MIT License.
 
 use std::iter::once;
+use std::str::FromStr;
+
+use qsc::openqasm::compiler::{
+    PragmaKind, SUPPORTED_QDK_ANNOTATIONS, annotation_configures_profile, valid_box_pragma_targets,
+};
+use qsc::openqasm::parser::ast::PathKind;
+use qsc::openqasm::semantic::ast::{Annotation, Pragma};
+use qsc::openqasm::semantic::symbols::SymbolTable;
+use qsc::target::Profile;
 
 use crate::{
     Compilation,
@@ -16,6 +25,20 @@ pub(super) fn completions(
     source_contents: &str,
     cursor_offset: u32,
 ) -> CompletionList {
+    // Pragmas and annotations are lexed as single whole-line tokens, so the generic word-kind
+    // collector cannot distinguish the name position from the value position within them.
+    // When the cursor is inside such a line, re-parse the source and use the resulting AST
+    // to offer precisely scoped completions. Pragma names are only offered inside a pragma, and
+    // annotation names are only offered after the `@` that begins an annotation.
+    //
+    // We should update the lexer to produce separate tokens for the directive keyword,
+    // name, and value, so that the generic word-kind collector can handle them without
+    // needing to re-parse the source in a follow-up.
+    if let Some(line_kind) = classify_pragma_or_annotation_line(source_contents, cursor_offset) {
+        let scoped = pragma_or_annotation_completions(source_contents, cursor_offset, line_kind);
+        return into_completion_list(once(scoped));
+    }
+
     let expected_words_at_cursor = qsc::openqasm::completion::possible_words_at_offset_in_source(
         source_contents,
         cursor_offset,
@@ -34,6 +57,165 @@ pub(super) fn completions(
     into_completion_list(once(hardcoded_completions).chain(name_completions))
 }
 
+/// The kind of directive line the cursor is on, used to scope completions to
+/// pragma names / annotation names / profile values.
+#[derive(Clone, Copy)]
+enum DirectiveLine {
+    Pragma,
+    Annotation,
+}
+
+/// Classifies the line the cursor is on as a pragma line, an annotation line,
+/// or neither. Pragma names are only relevant inside a `#pragma`/`pragma` line,
+/// and annotation names only after the `@` that begins an annotation, so this
+/// keeps those completions out of ordinary statement positions.
+fn classify_pragma_or_annotation_line(
+    source_contents: &str,
+    cursor_offset: u32,
+) -> Option<DirectiveLine> {
+    let offset = (cursor_offset as usize).min(source_contents.len());
+    let line_start = source_contents[..offset]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    let line = source_contents[line_start..].trim_start();
+
+    if line.starts_with('@') {
+        return Some(DirectiveLine::Annotation);
+    }
+
+    // Require a word boundary after the keyword so identifiers such as
+    // `pragmatic` are not mistaken for a pragma directive.
+    for keyword in ["#pragma", "pragma"] {
+        if let Some(rest) = line.strip_prefix(keyword)
+            && (rest.is_empty() || rest.starts_with(char::is_whitespace))
+        {
+            return Some(DirectiveLine::Pragma);
+        }
+    }
+
+    None
+}
+
+/// Returns the completions scoped to the cursor's position inside a `#pragma`
+/// or `@annotation` line. Re-parses the source so the pragma/annotation AST
+/// node spans can be used to tell the name position from the value position.
+/// Falls back to offering names when no node is available yet.
+fn pragma_or_annotation_completions(
+    source_contents: &str,
+    cursor_offset: u32,
+    line_kind: DirectiveLine,
+) -> Vec<Completion> {
+    let res = qsc::openqasm::semantic::parse(source_contents, "<completions>");
+    let program = &res.program;
+
+    match line_kind {
+        DirectiveLine::Pragma => {
+            for pragma in &program.pragmas {
+                if span_contains(pragma.span, cursor_offset) {
+                    return pragma_completions(pragma, cursor_offset, &res.symbols);
+                }
+            }
+            pragma_name_completions()
+        }
+        DirectiveLine::Annotation => {
+            for stmt in &program.statements {
+                for annotation in &stmt.annotations {
+                    if span_contains(annotation.span, cursor_offset) {
+                        return annotation_completions(annotation, cursor_offset);
+                    }
+                }
+            }
+            annotation_name_completions()
+        }
+    }
+}
+
+fn span_contains(span: qsc::Span, offset: u32) -> bool {
+    span.lo <= offset && offset <= span.hi
+}
+
+/// Completions for a position inside a `#pragma` line: the supported pragma
+/// names while the cursor is on the name, or value completions once the cursor
+/// is in the value position. The value completions are target profiles for a
+/// `qdk.qir.profile` pragma, or valid target function names for a
+/// `qdk.box.open`/`qdk.box.close` pragma.
+fn pragma_completions(
+    pragma: &Pragma,
+    cursor_offset: u32,
+    symbols: &SymbolTable,
+) -> Vec<Completion> {
+    let in_name_position = match pragma.identifier.as_ref().and_then(PathKind::span) {
+        Some(span) => cursor_offset <= span.hi,
+        None => true,
+    };
+
+    if in_name_position {
+        return pragma_name_completions();
+    }
+
+    let name = pragma
+        .identifier
+        .as_ref()
+        .map(PathKind::as_string)
+        .unwrap_or_default();
+    match PragmaKind::from_str(&name) {
+        Ok(PragmaKind::QdkQirProfile) => profile_completions(),
+        Ok(PragmaKind::QdkBoxOpen | PragmaKind::QdkBoxClose) => box_target_completions(symbols),
+        _ => Vec::new(),
+    }
+}
+
+/// Completions for a position inside an `@annotation` line: the supported QDK
+/// annotation names while the cursor is on the name, or target profile values
+/// once the cursor is in the value position of a profile annotation.
+fn annotation_completions(annotation: &Annotation, cursor_offset: u32) -> Vec<Completion> {
+    let in_name_position = match annotation.identifier.span() {
+        Some(span) => cursor_offset <= span.hi,
+        None => true,
+    };
+
+    if in_name_position {
+        return annotation_name_completions();
+    }
+
+    if annotation_configures_profile(&annotation.identifier.as_string()) {
+        profile_completions()
+    } else {
+        Vec::new()
+    }
+}
+
+fn pragma_name_completions() -> Vec<Completion> {
+    PragmaKind::all()
+        .into_iter()
+        .map(|kind| Completion::new(kind.as_str().to_string(), CompletionItemKind::Keyword))
+        .collect()
+}
+
+fn annotation_name_completions() -> Vec<Completion> {
+    SUPPORTED_QDK_ANNOTATIONS
+        .into_iter()
+        .map(|name| Completion::new(name.to_string(), CompletionItemKind::Interface))
+        .collect()
+}
+
+fn profile_completions() -> Vec<Completion> {
+    Profile::all()
+        .into_iter()
+        .map(|profile| Completion::new(profile.to_str().to_string(), CompletionItemKind::Keyword))
+        .collect()
+}
+
+/// Completions for the value of a `qdk.box.open`/`qdk.box.close` pragma: the
+/// names of functions that are valid box targets (parameterless and returning
+/// void), as defined by the compiler.
+fn box_target_completions(symbols: &SymbolTable) -> Vec<Completion> {
+    valid_box_pragma_targets(symbols)
+        .into_iter()
+        .map(|name| Completion::new(name, CompletionItemKind::Function))
+        .collect()
+}
+
 #[allow(clippy::items_after_statements)]
 fn collect_hardcoded_words(
     expected: qsc::openqasm::completion::word_kinds::WordKinds,
@@ -42,10 +224,9 @@ fn collect_hardcoded_words(
     for word_kind in expected.iter_hardcoded_ident_kinds() {
         match word_kind {
             qsc::openqasm::completion::word_kinds::HardcodedIdentKind::Annotation => {
-                completions.extend([Completion::new(
-                    "SimulatableIntrinsic".to_string(),
-                    CompletionItemKind::Interface,
-                )]);
+                // Annotation names are offered only after the `@` that begins an
+                // annotation (handled by the directive-line path), not at every
+                // statement-start position where an annotation would be valid.
             }
         }
     }

--- a/source/language_service/src/completion/qsharp.rs
+++ b/source/language_service/src/completion/qsharp.rs
@@ -37,10 +37,11 @@ pub(super) fn completions(
         if name.as_ref() == "EntryPoint" {
             return CompletionList {
                 items: vec![
-                    CompletionItem::new("Unrestricted".to_string(), CompletionItemKind::Keyword),
                     CompletionItem::new("Base".to_string(), CompletionItemKind::Keyword),
                     CompletionItem::new("Adaptive_RI".to_string(), CompletionItemKind::Keyword),
                     CompletionItem::new("Adaptive_RIF".to_string(), CompletionItemKind::Keyword),
+                    CompletionItem::new("Adaptive".to_string(), CompletionItemKind::Keyword),
+                    CompletionItem::new("Unrestricted".to_string(), CompletionItemKind::Keyword),
                 ],
             };
         }

--- a/source/language_service/src/completion/tests.rs
+++ b/source/language_service/src/completion/tests.rs
@@ -2351,6 +2351,31 @@ fn no_completion_inside_attr() {
 }
 
 #[test]
+fn target_profile_completions_in_entry_point_attr() {
+    check_single_file(
+        "namespace Test {
+            @EntryPoint(↘)
+            operation Main() : Unit {}
+        }",
+        &[
+            "Base",
+            "Adaptive_RI",
+            "Adaptive_RIF",
+            "Adaptive",
+            "Unrestricted",
+        ],
+        &expect![[r#"
+            found, sorted:
+              "Base" (Keyword)
+              "Adaptive_RI" (Keyword)
+              "Adaptive_RIF" (Keyword)
+              "Adaptive" (Keyword)
+              "Unrestricted" (Keyword)
+        "#]],
+    );
+}
+
+#[test]
 fn in_comment() {
     check_no_completions(
         "namespace Test {

--- a/source/language_service/src/completion/tests/openqasm.rs
+++ b/source/language_service/src/completion/tests/openqasm.rs
@@ -50,16 +50,158 @@ fn in_file_after_openqasm_contains_keywords_containing_i() {
 }
 
 #[test]
-fn in_file_after_openqasm_contains_annotations_containing_i() {
+fn annotation_names_not_offered_at_statement_start() {
     check_single_file(
         indoc! {r#"
         OPENQASM 3.0;
-        i↘
+        ↘
     }"#},
-        &["SimulatableIntrinsic"],
+        &[
+            "qdk.qir.intrinsic",
+            "qdk.qir.noise_intrinsic",
+            "qdk.qir.profile",
+        ],
+        &expect![[r#"
+            not found:
+              "qdk.qir.intrinsic"
+              "qdk.qir.noise_intrinsic"
+              "qdk.qir.profile"
+        "#]],
+    );
+}
+
+#[test]
+fn annotation_after_at_offers_qdk_annotations() {
+    check_single_file(
+        indoc! {r#"
+        OPENQASM 3.0;
+        @↘
+    }"#},
+        &[
+            "qdk.qir.intrinsic",
+            "qdk.qir.noise_intrinsic",
+            "qdk.qir.profile",
+        ],
         &expect![[r#"
             found, sorted:
-              "SimulatableIntrinsic" (Interface)
+              "qdk.qir.intrinsic" (Interface)
+              "qdk.qir.noise_intrinsic" (Interface)
+              "qdk.qir.profile" (Interface)
+        "#]],
+    );
+}
+
+#[test]
+fn pragma_name_position_offers_supported_pragmas() {
+    check_single_file(
+        indoc! {r#"
+        OPENQASM 3.0;
+        #pragma ↘
+    }"#},
+        &["qdk.box.open", "qdk.box.close", "qdk.qir.profile"],
+        &expect![[r#"
+            found, sorted:
+              "qdk.box.close" (Keyword)
+              "qdk.box.open" (Keyword)
+              "qdk.qir.profile" (Keyword)
+        "#]],
+    );
+}
+
+#[test]
+fn pragma_partial_name_offers_supported_pragmas() {
+    check_single_file(
+        indoc! {r#"
+        OPENQASM 3.0;
+        #pragma qdk↘
+    }"#},
+        &["qdk.box.open", "qdk.box.close", "qdk.qir.profile"],
+        &expect![[r#"
+            found, sorted:
+              "qdk.box.close" (Keyword)
+              "qdk.box.open" (Keyword)
+              "qdk.qir.profile" (Keyword)
+        "#]],
+    );
+}
+
+#[test]
+fn pragma_profile_value_offers_profiles() {
+    check_single_file(
+        indoc! {r#"
+        OPENQASM 3.0;
+        #pragma qdk.qir.profile ↘
+    }"#},
+        &[
+            "Base",
+            "Adaptive_RI",
+            "Adaptive_RIF",
+            "Adaptive",
+            "Unrestricted",
+        ],
+        &expect![[r#"
+            found, sorted:
+              "Adaptive" (Keyword)
+              "Adaptive_RI" (Keyword)
+              "Adaptive_RIF" (Keyword)
+              "Base" (Keyword)
+              "Unrestricted" (Keyword)
+        "#]],
+    );
+}
+
+#[test]
+fn pragma_box_value_offers_target_functions() {
+    check_single_file(
+        indoc! {r#"
+        OPENQASM 3.0;
+        def box_begin() {}
+        def box_end() {}
+        def with_param(int x) {}
+        #pragma qdk.box.open ↘
+    }"#},
+        &[
+            "box_begin",
+            "box_end",
+            "with_param",
+            "Base",
+            "qdk.qir.profile",
+        ],
+        &expect![[r#"
+            found, sorted:
+              "box_begin" (Function)
+              "box_end" (Function)
+
+            not found:
+              "with_param"
+              "Base"
+              "qdk.qir.profile"
+        "#]],
+    );
+}
+
+#[test]
+fn annotation_profile_value_offers_profiles() {
+    check_single_file(
+        indoc! {r#"
+        OPENQASM 3.0;
+        @qdk.qir.profile ↘
+        def foo() {}
+    }"#},
+        &[
+            "Base",
+            "Adaptive_RI",
+            "Adaptive_RIF",
+            "Adaptive",
+            "Unrestricted",
+        ],
+        &expect![[r#"
+            found, sorted:
+              "Adaptive" (Keyword)
+              "Adaptive_RI" (Keyword)
+              "Adaptive_RIF" (Keyword)
+              "Base" (Keyword)
+              "Unrestricted" (Keyword)
         "#]],
     );
 }

--- a/source/qdk_package/src/interpreter.rs
+++ b/source/qdk_package/src/interpreter.rs
@@ -186,7 +186,7 @@ pub(crate) enum TargetProfile {
     /// capabilities, as well as the optional floating-point computation
     /// extension defined by the QIR specification.
     Adaptive_RIF,
-    /// Target supports the Adaptive profile with all optional extensions.
+    /// Target supports the QIR Adaptive Profile with all QDK-supported extensions.
     Adaptive,
     /// Target supports the full set of capabilities required to run any Q# program.
     ///

--- a/source/qdk_package/tests/test_enums.py
+++ b/source/qdk_package/tests/test_enums.py
@@ -28,6 +28,7 @@ def test_target_profile_serialization() -> None:
         TargetProfile.Base,
         TargetProfile.Adaptive_RI,
         TargetProfile.Adaptive_RIF,
+        TargetProfile.Adaptive,
         TargetProfile.Unrestricted,
     ]
     import pickle

--- a/source/vscode/qsharp.schema.json
+++ b/source/vscode/qsharp.schema.json
@@ -25,7 +25,13 @@
     "targetProfile": {
       "title": "Target QIR Profile",
       "type": "string",
-      "enum": ["unrestricted", "adaptive_ri", "adaptive_rif", "base"]
+      "enum": [
+        "base",
+        "adaptive_ri",
+        "adaptive_rif",
+        "adaptive",
+        "unrestricted"
+      ]
     },
     "lints": {
       "title": "Lints",

--- a/source/vscode/skills/qdk-programming/python.md
+++ b/source/vscode/skills/qdk-programming/python.md
@@ -88,12 +88,13 @@ qsharp.init(project_root="./my_project")
 
 ### Target Profiles
 
-| Profile                      | Use Case                                                              |
-| ---------------------------- | --------------------------------------------------------------------- |
-| `TargetProfile.Unrestricted` | Full simulation (default)                                             |
-| `TargetProfile.Adaptive_RIF` | Adaptive profile with integer & floating-point computation extensions |
-| `TargetProfile.Adaptive_RI`  | Adaptive profile with integer computation extension                   |
-| `TargetProfile.Base`         | Minimal capabilities required to run a quantum program (Base Profile) |
+| Profile                      | Use Case                                                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `TargetProfile.Unrestricted` | Full simulation (default)                                                                             |
+| `TargetProfile.Adaptive`     | Full adaptive profile: RIF extensions plus backwards branching, static-sized arrays, and call support |
+| `TargetProfile.Adaptive_RIF` | Adaptive profile with integer & floating-point computation extensions                                 |
+| `TargetProfile.Adaptive_RI`  | Adaptive profile with integer computation extension                                                   |
+| `TargetProfile.Base`         | Minimal capabilities required to run a quantum program (Base Profile)                                 |
 
 ## Q#
 

--- a/source/vscode/skills/qdk-programming/python.md
+++ b/source/vscode/skills/qdk-programming/python.md
@@ -91,7 +91,7 @@ qsharp.init(project_root="./my_project")
 | Profile                      | Use Case                                                                                              |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `TargetProfile.Unrestricted` | Full simulation (default)                                                                             |
-| `TargetProfile.Adaptive`     | Full adaptive profile: RIF extensions plus backwards branching, static-sized arrays, and call support |
+| `TargetProfile.Adaptive`     | The QIR Adaptive Profile with all QDK-supported extensions.                                           |
 | `TargetProfile.Adaptive_RIF` | Adaptive profile with integer & floating-point computation extensions                                 |
 | `TargetProfile.Adaptive_RI`  | Adaptive profile with integer computation extension                                                   |
 | `TargetProfile.Base`         | Minimal capabilities required to run a quantum program (Base Profile)                                 |

--- a/source/vscode/skills/qdk-programming/python.md
+++ b/source/vscode/skills/qdk-programming/python.md
@@ -88,13 +88,13 @@ qsharp.init(project_root="./my_project")
 
 ### Target Profiles
 
-| Profile                      | Use Case                                                                                              |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `TargetProfile.Unrestricted` | Full simulation (default)                                                                             |
-| `TargetProfile.Adaptive`     | The QIR Adaptive Profile with all QDK-supported extensions.                                           |
-| `TargetProfile.Adaptive_RIF` | Adaptive profile with integer & floating-point computation extensions                                 |
-| `TargetProfile.Adaptive_RI`  | Adaptive profile with integer computation extension                                                   |
-| `TargetProfile.Base`         | Minimal capabilities required to run a quantum program (Base Profile)                                 |
+| Profile                      | Use Case                                                              |
+| ---------------------------- | --------------------------------------------------------------------- |
+| `TargetProfile.Unrestricted` | Full simulation (default)                                             |
+| `TargetProfile.Adaptive`     | The QIR Adaptive Profile with all QDK-supported extensions.           |
+| `TargetProfile.Adaptive_RIF` | Adaptive profile with integer & floating-point computation extensions |
+| `TargetProfile.Adaptive_RI`  | Adaptive profile with integer computation extension                   |
+| `TargetProfile.Base`         | Minimal capabilities required to run a quantum program (Base Profile) |
 
 ## Q#
 

--- a/source/vscode/skills/qdk-programming/qsharp.md
+++ b/source/vscode/skills/qdk-programming/qsharp.md
@@ -311,7 +311,7 @@ operation Main() : Result { ... }
 | Profile / Attribute             | Description                                                                                                          |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `unrestricted`                  | Full simulation (default)                                                                                            |
-| `adaptive` / `Adaptive`         | Full adaptive profile: RIF extensions plus backwards branching, static-sized arrays, and call support                |
+| `adaptive` / `Adaptive`         | The QIR Adaptive Profile with all QDK-supported extensions.                                                          |
 | `adaptive_rif` / `Adaptive_RIF` | Adaptive profile with integer & floating-point computation extensions; required for `CircuitGenerationMethod.Static` |
 | `adaptive_ri` / `Adaptive_RI`   | Adaptive profile with integer computation extension                                                                  |
 | `base` / `Base`                 | Minimal capabilities required to run a quantum program (Base Profile per QIR spec)                                   |

--- a/source/vscode/skills/qdk-programming/qsharp.md
+++ b/source/vscode/skills/qdk-programming/qsharp.md
@@ -311,6 +311,7 @@ operation Main() : Result { ... }
 | Profile / Attribute             | Description                                                                                                          |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `unrestricted`                  | Full simulation (default)                                                                                            |
+| `adaptive` / `Adaptive`         | Full adaptive profile: RIF extensions plus backwards branching, static-sized arrays, and call support                |
 | `adaptive_rif` / `Adaptive_RIF` | Adaptive profile with integer & floating-point computation extensions; required for `CircuitGenerationMethod.Static` |
 | `adaptive_ri` / `Adaptive_RI`   | Adaptive profile with integer computation extension                                                                  |
 | `base` / `Base`                 | Minimal capabilities required to run a quantum program (Base Profile per QIR spec)                                   |

--- a/source/vscode/src/config.ts
+++ b/source/vscode/src/config.ts
@@ -12,6 +12,8 @@ export function getTargetFriendlyName(targetProfile?: string) {
       return "QIR Adaptive RI";
     case "adaptive_rif":
       return "QIR Adaptive RIF";
+    case "adaptive":
+      return "QIR Adaptive";
     case "unrestricted":
       return "QIR Unrestricted";
     default:

--- a/source/vscode/src/qirGeneration.ts
+++ b/source/vscode/src/qirGeneration.ts
@@ -62,6 +62,7 @@ function checkCompatibility(
     "base",
     "adaptive_ri",
     "adaptive_rif",
+    "adaptive",
     "unrestricted",
   ];
 

--- a/source/wasm/src/language_service.rs
+++ b/source/wasm/src/language_service.rs
@@ -628,7 +628,7 @@ serializable_type! {
         pub projectRoot: Option<String>,
     },
     r#"export interface INotebookMetadata {
-        targetProfile?: "base" | "adaptive_ri" | "adaptive_rif" | "unrestricted";
+        targetProfile?: "base" | "adaptive_ri" | "adaptive_rif" | "adaptive" | "unrestricted";
         languageFeatures?: "v2-preview-syntax"[];
         manifest?: string;
         projectRoot?: string;


### PR DESCRIPTION
Fixes #3084

## Summary
This branch delivers two related improvements to the QDK language service:

- First-class Adaptive target profile exposed consistently across the compiler, language service, VS Code config, schema, and Python bindings, with a unified least-to-most-capable profile ordering everywhere.
- OpenQASM completion support for pragma and annotation directives, including dynamic completion of valid box-target function names.