### PR TITLE
Run FIR transforms before RCA at interpreter construction

### DIFF
--- a/source/compiler/qsc/src/interpret.rs
+++ b/source/compiler/qsc/src/interpret.rs
@@ -352,28 +352,65 @@ impl Interpreter {
 
         let package = map_hir_package_to_fir(package_id);
 
-        // Run RCA early to surface capability violations at interpreter construction
-        // time rather than deferring to qirgen()/circuit(). The computed properties
-        // are intentionally discarded — only the `?` error propagation is used.
-        // Caching would not help because later backend paths clone the FIR store,
-        // run the transform pipeline, and re-run RCA on the transformed store.
+        // Validate capabilities at interpreter construction time rather than
+        // deferring to qirgen()/circuit(). To match what codegen actually emits,
+        // run the FIR transform pipeline on a throwaway clone of the FIR store, then
+        // run RCA on that transformed clone.
+        //
+        // The original `fir_store` is left un-transformed and remains the artifact used
+        // for execution and debugging.
+        //
+        // The transformed clone (and its computed properties) are discarded after
+        // validation.
         if capabilities != TargetCapabilityFlags::all() {
-            let _compute_properties = PassContext::run_fir_passes_on_fir(
-                &fir_store,
-                map_hir_package_to_fir(source_package_id),
-                capabilities,
-            )
-            .map_err(|caps_errors| {
-                let source_package = compiler
-                    .package_store()
-                    .get(source_package_id)
-                    .expect("package should exist in the package store");
+            let fir_package_id = map_hir_package_to_fir(source_package_id);
+            let source_package = compiler
+                .package_store()
+                .get(source_package_id)
+                .expect("package should exist in the package store");
 
-                caps_errors
-                    .into_iter()
-                    .map(|error| Error::Pass(WithSource::from_map(&source_package.sources, error)))
-                    .collect::<Vec<_>>()
-            })?;
+            // The transform pipeline requires a package with an entry expression, and
+            // entry-less library packages and eval calls via the Python interop layer can
+            // arrive here. Guard the transform branch on the presence of an entry expression
+            // exactly like the language service does; when absent, fall back to
+            // running RCA on the original store.
+            let transformed_store = if fir_store.get(fir_package_id).entry.is_some() {
+                let mut transformed_store = fir_store.clone();
+                let transform_result = crate::fir_transforms::run_pipeline_with_diagnostics(
+                    &mut transformed_store,
+                    fir_package_id,
+                );
+                if !transform_result.errors.is_empty() {
+                    // Fatal transform errors reuse the existing FirTransform variant,
+                    // mapped exactly as codegen.rs does. They are not capability
+                    // failures, so they are not routed through Error::Pass.
+                    return Err(transform_result
+                        .errors
+                        .into_iter()
+                        .map(|e| {
+                            Error::FirTransform(WithSource::from_map(&source_package.sources, e))
+                        })
+                        .collect());
+                }
+                Some(transformed_store)
+            } else {
+                None
+            };
+
+            let store_for_rca = transformed_store.as_ref().unwrap_or(&fir_store);
+
+            // The computed properties are intentionally discarded — only the `?`
+            // error propagation is used to surface capability violations.
+            let _compute_properties =
+                PassContext::run_fir_passes_on_fir(store_for_rca, fir_package_id, capabilities)
+                    .map_err(|caps_errors| {
+                        caps_errors
+                            .into_iter()
+                            .map(|error| {
+                                Error::Pass(WithSource::from_map(&source_package.sources, error))
+                            })
+                            .collect::<Vec<_>>()
+                    })?;
         }
 
         Ok(Self {

--- a/source/compiler/qsc/src/interpret/tests.rs
+++ b/source/compiler/qsc/src/interpret/tests.rs
@@ -2314,6 +2314,7 @@ mod given_interpreter {
         };
         use qsc_data_structures::source::SourceMap;
         use qsc_data_structures::span::Span;
+        use qsc_data_structures::target::Profile;
         use qsc_passes::PackageType;
 
         #[test]
@@ -2396,6 +2397,245 @@ mod given_interpreter {
                            [test] [x]
                     "#]],
                 ),
+            }
+        }
+
+        #[test]
+        fn restricted_profile_struct_output_runs_after_fir_transforms() {
+            // A struct/UDT output is only a valid restricted-profile output after
+            // the FIR transform pipeline erases the UDT and decomposes it into a
+            // tuple. The construction-time gate now validates the transformed
+            // program (as codegen does), so this program must construct and run
+            // without a false-positive `UseOfAdvancedOutput` rejection.
+            let source = indoc! { r#"
+            namespace Test {
+                import Std.Intrinsic.*;
+                import Std.Measurement.*;
+
+                struct Data {
+                    a : Result,
+                    b : Int,
+                }
+
+                @EntryPoint()
+                operation Main() : Data {
+                    use q = Qubit();
+                    H(q);
+                    new Data { a = MResetZ(q), b = 3 }
+                }
+            }"#};
+
+            let sources = SourceMap::new([("test".into(), source.into())], None);
+            let (std_id, store) =
+                crate::compile::package_store_with_stdlib(TargetCapabilityFlags::all());
+            let mut interpreter = Interpreter::new(
+                sources,
+                PackageType::Exe,
+                Profile::AdaptiveRI.into(),
+                LanguageFeatures::default(),
+                store,
+                &[(std_id, None)],
+            )
+            .expect("interpreter should be created without a false-positive capability rejection");
+
+            let (result, _output) = entry(&mut interpreter);
+            match result {
+                Ok(_) => {}
+                Err(errors) => {
+                    panic!("expected entry to run without a capability error, got {errors:?}")
+                }
+            }
+        }
+
+        #[test]
+        fn restricted_profile_string_output_still_rejected() {
+            // A String output is genuinely advanced and remains so after the FIR
+            // transforms, so the construction-time gate must still reject it.
+            let source = indoc! { r#"
+            namespace Test {
+                @EntryPoint()
+                operation Main() : String {
+                    "hello"
+                }
+            }"#};
+
+            let sources = SourceMap::new([("test".into(), source.into())], None);
+            let (std_id, store) =
+                crate::compile::package_store_with_stdlib(TargetCapabilityFlags::all());
+            let result = Interpreter::new(
+                sources,
+                PackageType::Exe,
+                Profile::AdaptiveRI.into(),
+                LanguageFeatures::default(),
+                store,
+                &[(std_id, None)],
+            );
+
+            match result {
+                Ok(_) => panic!("expected a capability rejection for advanced String output"),
+                Err(errors) => {
+                    assert!(
+                        errors
+                            .iter()
+                            .all(|error| matches!(error, crate::interpret::Error::Pass(_))),
+                        "expected capability-check pass errors, got {errors:?}"
+                    );
+                    assert!(
+                        errors
+                            .iter()
+                            .any(|error| format!("{error:?}").contains("UseOfAdvancedOutput")),
+                        "expected an advanced-output capability diagnostic, got {errors:?}"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn restricted_profile_fatal_transform_error_reported_as_fir_transform() {
+            // A local callable forced to `Dynamic` by a loop reassignment cannot be
+            // resolved statically, so the defunctionalize stage of the FIR transform
+            // pipeline emits a fatal diagnostic. The construction-time gate must
+            // surface this as `Error::FirTransform` (mirroring codegen), not as a
+            // capability `Error::Pass`.
+            let source = indoc! { r#"
+            namespace Test {
+                operation Foo(q : Qubit) : Unit {}
+                operation Bar(q : Qubit) : Unit {}
+
+                @EntryPoint()
+                operation Main() : Unit {
+                    use q = Qubit();
+                    mutable f = Foo;
+                    for _ in 0..2 {
+                        f = Bar;
+                    }
+                    f(q);
+                }
+            }"#};
+
+            let sources = SourceMap::new([("test".into(), source.into())], None);
+            let (std_id, store) =
+                crate::compile::package_store_with_stdlib(TargetCapabilityFlags::all());
+            let result = Interpreter::new(
+                sources,
+                PackageType::Exe,
+                Profile::AdaptiveRI.into(),
+                LanguageFeatures::default(),
+                store,
+                &[(std_id, None)],
+            );
+
+            match result {
+                Ok(_) => panic!("expected a fatal FIR transform error for a dynamic callable"),
+                Err(errors) => {
+                    assert!(
+                        errors
+                            .iter()
+                            .all(|error| matches!(error, crate::interpret::Error::FirTransform(_))),
+                        "expected FIR transform errors, got {errors:?}"
+                    );
+                    assert!(
+                        errors
+                            .iter()
+                            .any(|error| format!("{error:?}").contains("DynamicCallable")),
+                        "expected a dynamic-callable transform diagnostic, got {errors:?}"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn restricted_profile_entryless_library_does_not_panic() {
+            // A PackageType::Lib package with no @EntryPoint/Main has no entry
+            // expression. The FIR transform pipeline asserts (panics) on a missing
+            // entry, so the construction-time gate must skip transforms and run RCA
+            // on the original store. This path is reachable via the Python interop
+            // layer, which constructs library interpreters under restricted targets.
+            let source = indoc! { r#"
+            namespace Test {
+                import Std.Intrinsic.*;
+
+                operation DoNothing() : Unit {
+                    use q = Qubit();
+                    H(q);
+                }
+            }"#};
+
+            let sources = SourceMap::new([("test".into(), source.into())], None);
+            let (std_id, store) =
+                crate::compile::package_store_with_stdlib(TargetCapabilityFlags::all());
+            let interpreter = Interpreter::new(
+                sources,
+                PackageType::Lib,
+                Profile::AdaptiveRI.into(),
+                LanguageFeatures::default(),
+                store,
+                &[(std_id, None)],
+            );
+
+            assert!(
+                interpreter.is_ok(),
+                "entry-less library construction should not panic and should pass RCA, got {:?}",
+                interpreter.err()
+            );
+        }
+
+        #[test]
+        fn restricted_profile_entryless_library_reports_transform_removable_violation() {
+            // Documents a known limitation of the entry-less path. An early `return`
+            // inside a measurement-conditioned scope is a profile violation
+            // (`ReturnWithinDynamicScope`) only before return-unification runs; once
+            // an entry expression reaches this operation, the FIR transform pipeline
+            // removes the violation and codegen accepts it. But an entry-less library
+            // has no entry expression, so the construction-time gate cannot run the
+            // transforms and instead runs RCA on the original store. The violation is
+            // therefore reported as `Error::Pass` even though it would be removed once
+            // the code is actually reachable.
+            let source = indoc! { r#"
+            namespace Test {
+                import Std.Intrinsic.*;
+                import Std.Measurement.*;
+
+                operation DynBranch(q : Qubit) : Int {
+                    use a = Qubit();
+                    H(a);
+                    if MResetZ(a) == One {
+                        return 1;
+                    }
+                    return 2;
+                }
+            }"#};
+
+            let sources = SourceMap::new([("test".into(), source.into())], None);
+            let (std_id, store) =
+                crate::compile::package_store_with_stdlib(TargetCapabilityFlags::all());
+            let result = Interpreter::new(
+                sources,
+                PackageType::Lib,
+                Profile::AdaptiveRI.into(),
+                LanguageFeatures::default(),
+                store,
+                &[(std_id, None)],
+            );
+
+            match result {
+                Ok(_) => panic!(
+                    "expected the entry-less library to report the untransformed RCA violation"
+                ),
+                Err(errors) => {
+                    assert!(
+                        errors
+                            .iter()
+                            .all(|error| matches!(error, crate::interpret::Error::Pass(_))),
+                        "expected capability-check pass errors, got {errors:?}"
+                    );
+                    assert!(
+                        errors
+                            .iter()
+                            .any(|error| format!("{error:?}").contains("ReturnWithinDynamicScope")),
+                        "expected a return-within-dynamic-scope diagnostic, got {errors:?}"
+                    );
+                }
             }
         }
 

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -187,9 +187,9 @@ pub const SIMPLEVQE_EXPECT_DEBUG: Expect = expect![[r#"
    0.3216"#]];
 // VQE sample is not expected to produce a circuit as it is too large and complex.
 pub const SIMPLEVQE_EXPECT_CIRCUIT: Expect =
-    expect!["circuit error: cannot use a dynamically-sized array"];
+    expect!["compilation error: cannot use a dynamically-sized array"];
 pub const SIMPLEVQE_EXPECT_QIR: Expect =
-    expect!["QIR generation error for `SimpleVQE.Main()`: cannot use a dynamically-sized array"];
+    expect!["compilation error: cannot use a dynamically-sized array"];
 pub const SUPERDENSECODING_EXPECT: Expect = expect!["((false, true), (false, true))"];
 pub const SUPERDENSECODING_EXPECT_DEBUG: Expect = expect!["((false, true), (false, true))"];
 pub const SUPERDENSECODING_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4891"];


### PR DESCRIPTION
Fixes #3328

Clones the FIR store and run the transform pipeline before RCA so capability checks match codegen surface fatal transform errors as Error::FirTransform; skip transforms for entry-less packages.