### PR TITLE
Fix pauli noise on qubit registers

### DIFF
--- a/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
@@ -2114,7 +2114,7 @@ def test_pauli_noise_with_qubit_immediates():
     )
     noise = NoiseConfig()
     noise.z.x = 1.0
-    results = run_qir(qir, SHOTS, noise, seed=42, type="gpu")
+    results = run_qir(qir, SHOTS, noise, seed=42, type="cpu")
     counts = Counter(map_result_list_to_str(r) for r in results)
     assert counts == {"1": SHOTS}, f"Expected all {SHOTS} shots to be '1', got {counts}"
 
@@ -2128,6 +2128,6 @@ def test_pauli_noise_with_qubit_registers():
     )
     noise = NoiseConfig()
     noise.z.x = 1.0
-    results = run_qir(qir, SHOTS, noise, seed=42, type="gpu")
+    results = run_qir(qir, SHOTS, noise, seed=42, type="cpu")
     counts = Counter(map_result_list_to_str(r) for r in results)
     assert counts == {"1": SHOTS}, f"Expected all {SHOTS} shots to be '1', got {counts}"

--- a/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
@@ -2082,3 +2082,52 @@ bit[4] result = measure q;
     assert all(
         len(r) >= 4 and all(c in "01" for c in r) for r in results
     ), f"Unexpected result format: {results[:5]}"
+
+
+GATE_CALL_WITH_QUBIT_IMMEDIATE = """
+entry:
+  call void @__quantum__qis__z__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+GATE_CALL_WITH_QUBIT_REGISTER = """
+entry:
+  call void @z(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+"""
+
+GATE_WRAPPED_IN_FUNCTION_DECL = """
+define void @z(ptr %var_2) {
+block_2:
+  call void @__quantum__qis__z__body(ptr %var_2)
+  ret void
+}
+"""
+
+
+def test_pauli_noise_with_qubit_immediates():
+    qir = format_qir(
+        GATE_CALL_WITH_QUBIT_IMMEDIATE,
+        num_qubits=1,
+        num_results=1,
+    )
+    noise = NoiseConfig()
+    noise.z.x = 1.0
+    results = run_qir(qir, SHOTS, noise, seed=42, type="gpu")
+    counts = Counter(map_result_list_to_str(r) for r in results)
+    assert counts == {"1": SHOTS}, f"Expected all {SHOTS} shots to be '1', got {counts}"
+
+
+def test_pauli_noise_with_qubit_registers():
+    qir = format_qir(
+        GATE_CALL_WITH_QUBIT_REGISTER,
+        extra_decls=GATE_WRAPPED_IN_FUNCTION_DECL,
+        num_qubits=1,
+        num_results=1,
+    )
+    noise = NoiseConfig()
+    noise.z.x = 1.0
+    results = run_qir(qir, SHOTS, noise, seed=42, type="gpu")
+    counts = Counter(map_result_list_to_str(r) for r in results)
+    assert counts == {"1": SHOTS}, f"Expected all {SHOTS} shots to be '1', got {counts}"

--- a/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
@@ -2361,3 +2361,54 @@ bit[4] result = measure q;
     assert all(
         c == 0 for c in results["shot_result_codes"]
     ), f"Some shots failed: {results['shot_result_codes']}"
+
+
+GATE_CALL_WITH_QUBIT_IMMEDIATE = """
+entry:
+  call void @__quantum__qis__z__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+GATE_CALL_WITH_QUBIT_REGISTER = """
+entry:
+  call void @z(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+"""
+
+GATE_WRAPPED_IN_FUNCTION_DECL = """
+define void @z(ptr %var_2) {
+block_2:
+  call void @__quantum__qis__z__body(ptr %var_2)
+  ret void
+}
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_pauli_noise_with_qubit_immediates():
+    qir = format_qir(
+        GATE_CALL_WITH_QUBIT_IMMEDIATE,
+        num_qubits=1,
+        num_results=1,
+    )
+    noise = NoiseConfig()
+    noise.z.x = 1.0
+    results = run_qir(qir, SHOTS, noise, seed=42, type="gpu")
+    counts = Counter(map_result_list_to_str(r) for r in results)
+    assert counts == {"1": SHOTS}, f"Expected all {SHOTS} shots to be '1', got {counts}"
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_pauli_noise_with_qubit_registers():
+    qir = format_qir(
+        GATE_CALL_WITH_QUBIT_REGISTER,
+        extra_decls=GATE_WRAPPED_IN_FUNCTION_DECL,
+        num_qubits=1,
+        num_results=1,
+    )
+    noise = NoiseConfig()
+    noise.z.x = 1.0
+    results = run_qir(qir, SHOTS, noise, seed=42, type="gpu")
+    counts = Counter(map_result_list_to_str(r) for r in results)
+    assert counts == {"1": SHOTS}, f"Expected all {SHOTS} shots to be '1', got {counts}"

--- a/source/simulators/src/gpu_full_state_simulator/common.wgsl
+++ b/source/simulators/src/gpu_full_state_simulator/common.wgsl
@@ -332,9 +332,10 @@ fn get_pauli_noise_idx(op_idx: u32) -> u32 {
 }
 
 
-fn apply_1q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32) {
+fn apply_1q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32, q1: u32) {
     // NOTE: Assumes that whatever prepared the program ensured that noise_op.q1 matches op.q1 and
-    // that op is a 1-qubit gate
+    // that op is a 1-qubit gate. `q1` is the resolved target qubit (may be
+    // dynamic for the adaptive interpreter, where op.q1 is only a placeholder).
     let shot = &shots[shot_idx];
     let op = &ops[op_idx];
     let noise_op = &ops[noise_idx];
@@ -373,7 +374,7 @@ fn apply_1q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32) {
         // sampled, schedule a loss commit for this qubit; a following
         // loss-commit op performs the measure + reset.
         if (rand < (p_x + p_z + p_y + p_loss)) {
-            shot.pending_loss_mask |= (1u << op.q1);
+            shot.pending_loss_mask |= (1u << q1);
         }
         // No noise. Set the op_type back to the op.id value if it's Id, MResetZ, MZ, or ResetZ, as they get handled specially in execute_op
         if (op.id == OPID_ID || op.id == OPID_MRESETZ || op.id == OPID_MZ || op.id == OPID_RESETZ) {
@@ -389,11 +390,11 @@ fn apply_1q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32) {
     if (shot.op_type == OPID_ID || shot.op_type == OPID_RZ) {
         shot.qubits_updated_last_op_mask = 0u;
     } else {
-        shot.qubits_updated_last_op_mask = 1u << op.q1;
+        shot.qubits_updated_last_op_mask = 1u << q1;
     };
 }
 
-fn apply_2q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32) {
+fn apply_2q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32, q1: u32, q2: u32) {
     let shot = &shots[shot_idx];
     let op = &ops[op_idx];
     let noise_op = &ops[noise_idx];
@@ -427,8 +428,8 @@ fn apply_2q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32) {
 
     // Schedule loss commits for any qubit whose sampled term is loss (L = 4).
     // A following loss-commit op performs the measure + reset.
-    if (q1_term == 4) { shot.pending_loss_mask |= (1u << op.q1); }
-    if (q2_term == 4) { shot.pending_loss_mask |= (1u << op.q2); }
+    if (q1_term == 4) { shot.pending_loss_mask |= (1u << q1); }
+    if (q2_term == 4) { shot.pending_loss_mask |= (1u << q2); }
 
     // A Pauli fault (X, Z, Y = 1, 2, 3) is fused into the gate by permuting its
     // rows. Loss (4) and identity (0) leave the gate unmodified for that qubit.
@@ -510,7 +511,7 @@ fn apply_2q_pauli_noise(shot_idx: u32, op_idx: u32, noise_idx: u32) {
     if (shot.op_type == OPID_CZ || shot.op_type == OPID_RZZ) {
         shot.qubits_updated_last_op_mask = 0u;
     } else  {
-        shot.qubits_updated_last_op_mask = (1u << op.q1 ) | (1u << op.q2);
+        shot.qubits_updated_last_op_mask = (1u << q1 ) | (1u << q2);
     }
 }
 

--- a/source/simulators/src/gpu_full_state_simulator/simulator_adaptive.wgsl
+++ b/source/simulators/src/gpu_full_state_simulator/simulator_adaptive.wgsl
@@ -1623,9 +1623,9 @@ fn prepare_op(@builtin(global_invocation_id) globalId: vec3<u32>) {
             // Handle Pauli noise (loss, if sampled, is recorded in pending_loss_mask)
             if pauli_op_idx != 0u {
                 if ops[pauli_op_idx].id == OPID_PAULI_NOISE_1Q {
-                    apply_1q_pauli_noise(shot_idx, op_idx, pauli_op_idx);
+                    apply_1q_pauli_noise(shot_idx, op_idx, pauli_op_idx, q1);
                 } else {
-                    apply_2q_pauli_noise(shot_idx, op_idx, pauli_op_idx);
+                    apply_2q_pauli_noise(shot_idx, op_idx, pauli_op_idx, q1, q2);
                 }
                 shots[shot_idx].interp.status = STATUS_RUNNING;
                 return;
@@ -1672,9 +1672,9 @@ fn prepare_op(@builtin(global_invocation_id) globalId: vec3<u32>) {
                 // The non-adaptive path inserts Id+noise before measure; here the Id
                 // is at op_idx and the original measure op follows after noise ops
                 if ops[pauli_op_idx].id == OPID_PAULI_NOISE_1Q {
-                    apply_1q_pauli_noise(shot_idx, op_idx, pauli_op_idx);
+                    apply_1q_pauli_noise(shot_idx, op_idx, pauli_op_idx, q1);
                 } else {
-                    apply_2q_pauli_noise(shot_idx, op_idx, pauli_op_idx);
+                    apply_2q_pauli_noise(shot_idx, op_idx, pauli_op_idx, q1, q2);
                 }
                 shots[shot_idx].interp.status = STATUS_RUNNING;
                 return;

--- a/source/simulators/src/gpu_full_state_simulator/simulator_base.wgsl
+++ b/source/simulators/src/gpu_full_state_simulator/simulator_base.wgsl
@@ -321,11 +321,11 @@ fn prepare_op(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
     if pauli_op_idx != 0 {
         if ops[pauli_op_idx].id == OPID_PAULI_NOISE_1Q {
-            apply_1q_pauli_noise(shot_idx, op_idx, pauli_op_idx);
+            apply_1q_pauli_noise(shot_idx, op_idx, pauli_op_idx, op.q1);
             // This will have set up all the state we need.
             return;
         } else {
-            apply_2q_pauli_noise(shot_idx, op_idx, pauli_op_idx);
+            apply_2q_pauli_noise(shot_idx, op_idx, pauli_op_idx, op.q1, op.q2);
             return;
         }
     }


### PR DESCRIPTION
The run_qir adaptive GPU shader was resolving the qubits for pauli noise incorrectly when the qubits were passed as registers. This PR fixes that.