### PR TITLE
Include unit number in exercise telemetry

### DIFF
--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -966,9 +966,9 @@ export class LearningService {
     await this.saveProgress();
     this._onDidChangeState.fire(this.getState());
 
-    const unit = this.requireWorkspace().catalog.units.find(
-      (u) => u.id === location.unitId,
-    );
+    const units = this.requireWorkspace().catalog.units;
+    const unitIndex = units.findIndex((u) => u.id === location.unitId);
+    const unit = unitIndex >= 0 ? units[unitIndex] : undefined;
     const exercises =
       unit?.activities.filter((s) => s.type === "exercise") ?? [];
     const exerciseIndex = exercises.findIndex(
@@ -978,6 +978,7 @@ export class LearningService {
       EventType.LearningExerciseCompleted,
       {},
       {
+        unitNumber: unitIndex + 1,
         exerciseNumber: exerciseIndex + 1,
         totalExercises: exercises.length,
       },

--- a/source/vscode/src/telemetry.ts
+++ b/source/vscode/src/telemetry.ts
@@ -350,6 +350,7 @@ type EventTypes = {
   [EventType.LearningExerciseCompleted]: {
     properties: Empty;
     measurements: {
+      unitNumber: number;
       exerciseNumber: number;
       totalExercises: number;
     };


### PR DESCRIPTION
Right now, we get events that say 11/21 or 1/1 exercises were completed but there's no indication of which unit has been completed.

My goal is to figure out where people are getting stuck.