### PR TITLE
Interpreter-level config

### DIFF
--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -480,6 +480,30 @@ operation PostSelectZ(res : Result, qubit : Qubit) : Unit {
     body intrinsic;
 }
 
+/// # Summary
+/// Returns a value from the host-provided configuration map.
+///
+/// # Description
+/// Looks up `name` in a read-only configuration map provided by the host runtime.
+/// If the key does not exist, returns `defaultValue`.
+///
+/// # Input
+/// ## name
+/// The configuration key.
+/// ## defaultValue
+/// The value to return when `name` is not present.
+///
+/// # Output
+/// The configured value for `name`, or `defaultValue` if the key is absent.
+///
+/// # Example
+/// ```qsharp
+/// let experimentName = Std.Diagnostics.GetConfig("experiment_name", "");
+/// ```
+function GetConfig<'T>(name : String, defaultValue : 'T) : 'T {
+    body intrinsic;
+}
+
 export
     DumpMachine,
     DumpRegister,
@@ -501,4 +525,5 @@ export
     PhaseFlipNoise,
     DepolarizingNoise,
     NoNoise,
-    PostSelectZ;
+    PostSelectZ,
+    GetConfig;

--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -500,7 +500,7 @@ operation PostSelectZ(res : Result, qubit : Qubit) : Unit {
 /// ```qsharp
 /// let experimentName = Std.Diagnostics.GetConfig("experiment_name", "");
 /// ```
-function GetConfig<'T>(name : String, defaultValue : 'T) : 'T {
+operation GetConfig<'T>(name : String, defaultValue : 'T) : 'T {
     body intrinsic;
 }
 

--- a/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
@@ -2283,11 +2283,11 @@ fn value_returning_ir_function_rir_reloads_after_same_block_store() {
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-282)
                 1 = SubProgram name=Foo location=(2-29)
-                2 = SubProgram name=MResetZ location=(1-182952)
+                2 = SubProgram name=MResetZ location=(1-182953)
             dbg_locations:
                 [1]: scope=0 location=(2-363)
                 [2]: scope=1 location=(2-112) inlined_at=1
-                [3]: scope=2 location=(1-183001) inlined_at=2
+                [3]: scope=2 location=(1-183002) inlined_at=2
                 [4]: scope=1 location=(2-109) inlined_at=1
             tags:
                 [0]: 0_i

--- a/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
@@ -2283,11 +2283,11 @@ fn value_returning_ir_function_rir_reloads_after_same_block_store() {
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-282)
                 1 = SubProgram name=Foo location=(2-29)
-                2 = SubProgram name=MResetZ location=(1-182278)
+                2 = SubProgram name=MResetZ location=(1-182952)
             dbg_locations:
                 [1]: scope=0 location=(2-363)
                 [2]: scope=1 location=(2-112) inlined_at=1
-                [3]: scope=2 location=(1-182327) inlined_at=2
+                [3]: scope=2 location=(1-183001) inlined_at=2
                 [4]: scope=1 location=(2-109) inlined_at=1
             tags:
                 [0]: 0_i

--- a/source/compiler/qsc/src/interpret.rs
+++ b/source/compiler/qsc/src/interpret.rs
@@ -175,6 +175,8 @@ pub struct Interpreter {
     /// The classical seed, if any. This needs to be passed to the evaluator for use in intrinsic
     /// calls that produce classical random numbers.
     classical_seed: Option<u64>,
+    /// Read-only config values exposed to Q# via Std.Diagnostics.GetConfig.
+    config_map: FxHashMap<Rc<str>, Value>,
     /// The evaluator environment.
     env: Env,
     /// The execution graph configuration to use for evaluation.
@@ -432,6 +434,7 @@ impl Interpreter {
             }),
             quantum_seed: None,
             classical_seed: None,
+            config_map: FxHashMap::default(),
             package,
             source_package: map_hir_package_to_fir(source_package_id),
             eval_config,
@@ -705,6 +708,10 @@ impl Interpreter {
         self.classical_seed = seed;
     }
 
+    pub fn set_config(&mut self, key: &str, value: Value) {
+        self.config_map.insert(Rc::from(key), value);
+    }
+
     pub fn check_source_lints(&self) -> Vec<Lint> {
         if let Some(compile_unit) = self
             .compiler
@@ -737,6 +744,7 @@ impl Interpreter {
         eval(
             self.source_package,
             self.classical_seed,
+            &self.config_map,
             graph,
             self.eval_config,
             self.compiler.package_store(),
@@ -762,6 +770,7 @@ impl Interpreter {
         eval(
             self.source_package,
             self.classical_seed,
+            &self.config_map,
             graph,
             self.eval_config,
             self.compiler.package_store(),
@@ -844,6 +853,7 @@ impl Interpreter {
         eval(
             self.package,
             self.classical_seed,
+            &self.config_map,
             graph,
             self.eval_config,
             self.compiler.package_store(),
@@ -861,7 +871,7 @@ impl Interpreter {
         callable: Value,
         args: Value,
     ) -> InterpretResult {
-        qsc_eval::invoke(
+        qsc_eval::invoke_with_config(
             self.package,
             self.classical_seed,
             &self.fir_store,
@@ -871,6 +881,7 @@ impl Interpreter {
             receiver,
             callable,
             args,
+            &self.config_map,
         )
         .map_err(|(error, call_stack)| {
             eval_error(
@@ -1564,6 +1575,7 @@ impl Interpreter {
         eval(
             self.package,
             classical_seed,
+            &self.config_map,
             graph,
             self.eval_config,
             self.compiler.package_store(),
@@ -1595,6 +1607,7 @@ impl Interpreter {
         eval(
             package_id,
             self.classical_seed,
+            &self.config_map,
             graph,
             config,
             self.compiler.package_store(),
@@ -1638,7 +1651,7 @@ impl Interpreter {
             Some(seed) => Some(seed),
             None => self.classical_seed,
         };
-        qsc_eval::invoke(
+        qsc_eval::invoke_with_config(
             self.package,
             classical_seed,
             &self.fir_store,
@@ -1648,6 +1661,7 @@ impl Interpreter {
             receiver,
             callable,
             args,
+            &self.config_map,
         )
         .map_err(|(error, call_stack)| {
             eval_error(
@@ -1851,6 +1865,7 @@ impl Debugger {
                 entry_exec_graph,
                 ExecGraphConfig::Debug,
                 None,
+                FxHashMap::default(),
                 ErrorBehavior::StopOnError,
             ),
         })
@@ -1868,6 +1883,7 @@ impl Debugger {
                 entry_exec_graph,
                 ExecGraphConfig::Debug,
                 None,
+                FxHashMap::default(),
                 ErrorBehavior::StopOnError,
             ),
         }
@@ -2004,6 +2020,7 @@ impl Debugger {
 fn eval<B: Backend>(
     package: PackageId,
     classical_seed: Option<u64>,
+    config_map: &FxHashMap<Rc<str>, Value>,
     exec_graph: ExecGraph,
     exec_graph_config: ExecGraphConfig,
     package_store: &PackageStore,
@@ -2012,7 +2029,7 @@ fn eval<B: Backend>(
     tracing_backend: &mut TracingBackend<'_, B>,
     receiver: &mut impl Receiver,
 ) -> InterpretResult {
-    qsc_eval::eval(
+    qsc_eval::eval_with_config(
         package,
         classical_seed,
         exec_graph,
@@ -2021,6 +2038,7 @@ fn eval<B: Backend>(
         env,
         tracing_backend,
         receiver,
+        config_map,
     )
     .map_err(|(error, call_stack)| eval_error(package_store, fir_store, call_stack, error))
 }

--- a/source/compiler/qsc/src/interpret/tests.rs
+++ b/source/compiler/qsc/src/interpret/tests.rs
@@ -121,6 +121,46 @@ mod given_interpreter {
         }
 
         #[test]
+        fn config_values_are_available_via_get_config() {
+            let mut interpreter = get_interpreter();
+
+            // Integer config.
+            interpreter.set_config("int_config", Value::Int(123));
+            let (result, output) =
+                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"int_config\", 0)");
+            is_only_value(&result, &output, &Value::Int(123));
+
+            // Boolean config.
+            interpreter.set_config("bool_config", Value::Bool(true));
+            let (result, output) =
+                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"bool_config\", false)");
+            is_only_value(&result, &output, &Value::Bool(true));
+
+            // String config.
+            interpreter.set_config("string_config", Value::String("value".into()));
+            let (result, output) =
+                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"string_config\", \"\")");
+            is_only_value(&result, &output, &Value::String("value".into()));
+
+            // Double config.
+            interpreter.set_config("double_config", Value::Double(124.1));
+            let (result, output) =
+                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"double_config\", 0.0)");
+            is_only_value(&result, &output, &Value::Double(124.1));
+
+            // Default value.
+            let (result, output) =
+                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"unknown\", 15)");
+            is_only_value(&result, &output, &Value::Int(15));
+
+            // Can overwrite an existing value.
+            interpreter.set_config("int_config", Value::Int(100));
+            let (result, output) =
+                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"int_config\", 0)");
+            is_only_value(&result, &output, &Value::Int(100));
+        }
+
+        #[test]
         fn let_bindings_update_interpreter() {
             let mut interpreter = get_interpreter();
             line(&mut interpreter, "let y = 7;")

--- a/source/compiler/qsc/src/interpret/tests.rs
+++ b/source/compiler/qsc/src/interpret/tests.rs
@@ -126,37 +126,49 @@ mod given_interpreter {
 
             // Integer config.
             interpreter.set_config("int_config", Value::Int(123));
-            let (result, output) =
-                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"int_config\", 0)");
+            let (result, output) = line(
+                &mut interpreter,
+                "Std.Diagnostics.GetConfig(\"int_config\", 0)",
+            );
             is_only_value(&result, &output, &Value::Int(123));
 
             // Boolean config.
             interpreter.set_config("bool_config", Value::Bool(true));
-            let (result, output) =
-                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"bool_config\", false)");
+            let (result, output) = line(
+                &mut interpreter,
+                "Std.Diagnostics.GetConfig(\"bool_config\", false)",
+            );
             is_only_value(&result, &output, &Value::Bool(true));
 
             // String config.
             interpreter.set_config("string_config", Value::String("value".into()));
-            let (result, output) =
-                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"string_config\", \"\")");
+            let (result, output) = line(
+                &mut interpreter,
+                "Std.Diagnostics.GetConfig(\"string_config\", \"\")",
+            );
             is_only_value(&result, &output, &Value::String("value".into()));
 
             // Double config.
             interpreter.set_config("double_config", Value::Double(124.1));
-            let (result, output) =
-                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"double_config\", 0.0)");
+            let (result, output) = line(
+                &mut interpreter,
+                "Std.Diagnostics.GetConfig(\"double_config\", 0.0)",
+            );
             is_only_value(&result, &output, &Value::Double(124.1));
 
             // Default value.
-            let (result, output) =
-                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"unknown\", 15)");
+            let (result, output) = line(
+                &mut interpreter,
+                "Std.Diagnostics.GetConfig(\"unknown\", 15)",
+            );
             is_only_value(&result, &output, &Value::Int(15));
 
             // Can overwrite an existing value.
             interpreter.set_config("int_config", Value::Int(100));
-            let (result, output) =
-                line(&mut interpreter, "Std.Diagnostics.GetConfig(\"int_config\", 0)");
+            let (result, output) = line(
+                &mut interpreter,
+                "Std.Diagnostics.GetConfig(\"int_config\", 0)",
+            );
             is_only_value(&result, &output, &Value::Int(100));
         }
 

--- a/source/compiler/qsc_circuit/src/builder/tests/logical_stack_trace.rs
+++ b/source/compiler/qsc_circuit/src/builder/tests/logical_stack_trace.rs
@@ -19,6 +19,7 @@ use qsc_fir::fir::{self, ExecGraphConfig};
 use qsc_frontend::compile::{self, PackageStore, compile};
 use qsc_lowerer::map_hir_package_to_fir;
 use qsc_passes::{PackageType, run_core_passes, run_default_passes};
+use rustc_hash::FxHashMap;
 
 use crate::builder::{LogicalStack, LogicalStackWithSourceLookup};
 
@@ -147,6 +148,7 @@ fn check_trace(file: &str, expr: &str, exec_graph_config: ExecGraphConfig, expec
         entry,
         exec_graph_config,
         None,
+        FxHashMap::default(),
         ErrorBehavior::FailOnError,
     );
 

--- a/source/compiler/qsc_eval/src/intrinsic.rs
+++ b/source/compiler/qsc_eval/src/intrinsic.rs
@@ -29,6 +29,7 @@ pub(crate) fn call<B: Backend>(
     call_stack: &[Frame],
     sim: &mut TracingBackend<'_, B>,
     rng: &mut StdRng,
+    config_map: &FxHashMap<Rc<str>, Value>,
     out: &mut dyn Receiver,
 ) -> Result<Value, Error> {
     match name {
@@ -165,6 +166,14 @@ pub(crate) fn call<B: Backend>(
         "DrawRandomBool" => {
             let p = arg.unwrap_double();
             Ok(Value::Bool(rng.random_bool(p)))
+        }
+        "GetConfig" => {
+            let [name, default_value] = unwrap_tuple(arg);
+            let name = name.unwrap_string();
+            Ok(config_map
+                .get(name.as_ref())
+                .cloned()
+                .unwrap_or(default_value))
         }
         #[allow(clippy::cast_possible_truncation)]
         "Truncate" => Ok(Value::Int(arg.unwrap_double() as i64)),

--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -279,11 +279,40 @@ pub fn eval<B: Backend>(
     sim: &mut TracingBackend<'_, B>,
     receiver: &mut impl Receiver,
 ) -> Result<Value, (Error, Vec<Frame>)> {
+    eval_with_config(
+        package,
+        seed,
+        exec_graph,
+        exec_graph_config,
+        globals,
+        env,
+        sim,
+        receiver,
+        &FxHashMap::default(),
+    )
+}
+
+/// Evaluates the given code with the given context and config map.
+/// # Errors
+/// Returns the first error encountered during execution.
+#[allow(clippy::too_many_arguments)]
+pub fn eval_with_config<B: Backend>(
+    package: PackageId,
+    seed: Option<u64>,
+    exec_graph: ExecGraph,
+    exec_graph_config: ExecGraphConfig,
+    globals: &impl PackageStoreLookup,
+    env: &mut Env,
+    sim: &mut TracingBackend<'_, B>,
+    receiver: &mut impl Receiver,
+    config_map: &FxHashMap<Rc<str>, Value>,
+) -> Result<Value, (Error, Vec<Frame>)> {
     let mut state = State::new(
         package,
         exec_graph,
         exec_graph_config,
         seed,
+        config_map.clone(),
         ErrorBehavior::FailOnError,
     );
     let res = state.eval(globals, env, sim, receiver, &[], StepAction::Continue)?;
@@ -310,11 +339,42 @@ pub fn invoke<B: Backend>(
     callable: Value,
     args: Value,
 ) -> Result<Value, (Error, Vec<Frame>)> {
+    invoke_with_config(
+        package,
+        seed,
+        globals,
+        exec_graph_config,
+        env,
+        sim,
+        receiver,
+        callable,
+        args,
+        &FxHashMap::default(),
+    )
+}
+
+/// Evaluates the given callable with the given context and config map.
+/// # Errors
+/// Returns the first error encountered during execution.
+#[allow(clippy::too_many_arguments)]
+pub fn invoke_with_config<B: Backend>(
+    package: PackageId,
+    seed: Option<u64>,
+    globals: &impl PackageStoreLookup,
+    exec_graph_config: ExecGraphConfig,
+    env: &mut Env,
+    sim: &mut TracingBackend<'_, B>,
+    receiver: &mut impl Receiver,
+    callable: Value,
+    args: Value,
+    config_map: &FxHashMap<Rc<str>, Value>,
+) -> Result<Value, (Error, Vec<Frame>)> {
     let mut state = State::new(
         package,
         ExecGraph::default(),
         exec_graph_config,
         seed,
+        config_map.clone(),
         ErrorBehavior::FailOnError,
     );
     // Push the callable value into the state stack and then the args value so they are ready for evaluation.
@@ -596,6 +656,7 @@ pub struct State {
     call_stack: CallStack,
     current_span: Span,
     rng: RefCell<StdRng>,
+    config_map: FxHashMap<Rc<str>, Value>,
     call_counts: FxHashMap<CallableCountKey, i64>,
     qubit_counter: Option<QubitCounter>,
     dirty_qubits: FxHashSet<usize>,
@@ -611,6 +672,7 @@ impl State {
         exec_graph: ExecGraph,
         exec_graph_config: ExecGraphConfig,
         classical_seed: Option<u64>,
+        config_map: FxHashMap<Rc<str>, Value>,
         error_behavior: ErrorBehavior,
     ) -> Self {
         let rng = match classical_seed {
@@ -628,6 +690,7 @@ impl State {
             call_stack: CallStack::default(),
             current_span: Span::default(),
             rng,
+            config_map,
             call_counts: FxHashMap::default(),
             qubit_counter: None,
             dirty_qubits: FxHashSet::default(),
@@ -1378,6 +1441,7 @@ impl State {
                     &call_stack,
                     sim,
                     &mut self.rng.borrow_mut(),
+                    &self.config_map,
                     out,
                 )?;
                 if val == Value::unit() && callee.output != Ty::UNIT {

--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -295,7 +295,7 @@ pub fn eval<B: Backend>(
 /// Evaluates the given code with the given context and config map.
 /// # Errors
 /// Returns the first error encountered during execution.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::implicit_hasher)]
 pub fn eval_with_config<B: Backend>(
     package: PackageId,
     seed: Option<u64>,
@@ -356,7 +356,7 @@ pub fn invoke<B: Backend>(
 /// Evaluates the given callable with the given context and config map.
 /// # Errors
 /// Returns the first error encountered during execution.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::implicit_hasher)]
 pub fn invoke_with_config<B: Backend>(
     package: PackageId,
     seed: Option<u64>,

--- a/source/compiler/qsc_eval/src/tests.rs
+++ b/source/compiler/qsc_eval/src/tests.rs
@@ -17,6 +17,7 @@ use qsc_fir::fir::{PackageId, PackageStoreLookup};
 use qsc_frontend::compile::{self, PackageStore, compile};
 use qsc_lowerer::map_hir_package_to_fir;
 use qsc_passes::{PackageType, run_core_passes, run_default_passes};
+use rustc_hash::FxHashMap;
 
 /// Evaluates the given control flow graph with the given context.
 /// Creates a new environment and simulator.
@@ -36,6 +37,7 @@ pub(super) fn eval_graph(
         graph,
         exec_graph_config,
         None,
+        FxHashMap::default(),
         ErrorBehavior::FailOnError,
     );
     let StepResult::Return(value) = state.eval(

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
@@ -509,8 +509,8 @@ fn analysis_apply_operation_power_ca_consumer() {
         &expect![[r#"
             callable_params: 3
               param: callable_id=<item 4 in package 2>, path=[0], ty=((Qubit)[] => Unit is Adj + Ctl)
+              param: callable_id=<item 1018 in package 1>, path=[1], ty=((Qubit)[] => Unit is Adj + Ctl)
               param: callable_id=<item 5 in package 2>, path=[0], ty=((Int, (Qubit)[]) => Unit is Adj + Ctl)
-              param: callable_id=<item 1016 in package 1>, path=[1], ty=((Qubit)[] => Unit is Adj + Ctl)
             call_sites: 5
               site: hof=ApplyOperationPowerCA<(Qubit)[], AdjCtl>, arg=Dynamic
               site: hof=ApplyOperationPowerCA<(Qubit)[], AdjCtl>, arg=Dynamic
@@ -638,18 +638,18 @@ fn analysis_apply_operation_power_ca_consumer() {
             operation ApplyOperationPowerCA__Qubit_____AdjCtl__U_(power : Int, target : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _range_id_48030 : Range = 1..AbsI(power);
-                        mutable _index_id_48033 : Int = _range_id_48030::Start;
-                        let _step_id_48038 : Int = _range_id_48030::Step;
-                        let _end_id_48043 : Int = _range_id_48030::End;
-                        while _step_id_48038 > 0 and _index_id_48033 <= _end_id_48043 or _step_id_48038 < 0 and _index_id_48033 >= _end_id_48043 {
-                            let _ : Int = _index_id_48033;
+                        let _range_id_48039 : Range = 1..AbsI(power);
+                        mutable _index_id_48042 : Int = _range_id_48039::Start;
+                        let _step_id_48047 : Int = _range_id_48039::Step;
+                        let _end_id_48052 : Int = _range_id_48039::End;
+                        while _step_id_48047 > 0 and _index_id_48042 <= _end_id_48052 or _step_id_48047 < 0 and _index_id_48042 >= _end_id_48052 {
+                            let _ : Int = _index_id_48042;
                             if power >= 0 {
                                 U(target)
                             } else {
                                 Adjoint U(target)
                             };
-                            _index_id_48033 += _step_id_48038;
+                            _index_id_48042 += _step_id_48047;
                         }
 
                     }
@@ -659,18 +659,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                     {
                         let _range : Range = 1..AbsI(power);
                         {
-                            let _range_id_48073 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                            mutable _index_id_48076 : Int = _range_id_48073::Start;
-                            let _step_id_48081 : Int = _range_id_48073::Step;
-                            let _end_id_48086 : Int = _range_id_48073::End;
-                            while _step_id_48081 > 0 and _index_id_48076 <= _end_id_48086 or _step_id_48081 < 0 and _index_id_48076 >= _end_id_48086 {
-                                let _ : Int = _index_id_48076;
+                            let _range_id_48082 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                            mutable _index_id_48085 : Int = _range_id_48082::Start;
+                            let _step_id_48090 : Int = _range_id_48082::Step;
+                            let _end_id_48095 : Int = _range_id_48082::End;
+                            while _step_id_48090 > 0 and _index_id_48085 <= _end_id_48095 or _step_id_48090 < 0 and _index_id_48085 >= _end_id_48095 {
+                                let _ : Int = _index_id_48085;
                                 if power >= 0 {
                                     Adjoint U(target)
                                 } else {
                                     U(target)
                                 };
-                                _index_id_48076 += _step_id_48081;
+                                _index_id_48085 += _step_id_48090;
                             }
 
                         }
@@ -680,18 +680,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _range_id_48116 : Range = 1..AbsI(power);
-                        mutable _index_id_48119 : Int = _range_id_48116::Start;
-                        let _step_id_48124 : Int = _range_id_48116::Step;
-                        let _end_id_48129 : Int = _range_id_48116::End;
-                        while _step_id_48124 > 0 and _index_id_48119 <= _end_id_48129 or _step_id_48124 < 0 and _index_id_48119 >= _end_id_48129 {
-                            let _ : Int = _index_id_48119;
+                        let _range_id_48125 : Range = 1..AbsI(power);
+                        mutable _index_id_48128 : Int = _range_id_48125::Start;
+                        let _step_id_48133 : Int = _range_id_48125::Step;
+                        let _end_id_48138 : Int = _range_id_48125::End;
+                        while _step_id_48133 > 0 and _index_id_48128 <= _end_id_48138 or _step_id_48133 < 0 and _index_id_48128 >= _end_id_48138 {
+                            let _ : Int = _index_id_48128;
                             if power >= 0 {
                                 Controlled U(ctls, target)
                             } else {
                                 Controlled Adjoint U(ctls, target)
                             };
-                            _index_id_48119 += _step_id_48124;
+                            _index_id_48128 += _step_id_48133;
                         }
 
                     }
@@ -701,18 +701,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                     {
                         let _range : Range = 1..AbsI(power);
                         {
-                            let _range_id_48159 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                            mutable _index_id_48162 : Int = _range_id_48159::Start;
-                            let _step_id_48167 : Int = _range_id_48159::Step;
-                            let _end_id_48172 : Int = _range_id_48159::End;
-                            while _step_id_48167 > 0 and _index_id_48162 <= _end_id_48172 or _step_id_48167 < 0 and _index_id_48162 >= _end_id_48172 {
-                                let _ : Int = _index_id_48162;
+                            let _range_id_48168 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                            mutable _index_id_48171 : Int = _range_id_48168::Start;
+                            let _step_id_48176 : Int = _range_id_48168::Step;
+                            let _end_id_48181 : Int = _range_id_48168::End;
+                            while _step_id_48176 > 0 and _index_id_48171 <= _end_id_48181 or _step_id_48176 < 0 and _index_id_48171 >= _end_id_48181 {
+                                let _ : Int = _index_id_48171;
                                 if power >= 0 {
                                     Controlled Adjoint U(ctls, target)
                                 } else {
                                     Controlled U(ctls, target)
                                 };
-                                _index_id_48162 += _step_id_48167;
+                                _index_id_48171 += _step_id_48176;
                             }
 
                         }
@@ -780,7 +780,7 @@ fn analysis_bernstein_vazirani_sample_shape() {
         adaptive_qirgen_capabilities(),
         &expect![[r#"
             callable_params: 2
-              param: callable_id=<item 1016 in package 1>, path=[0], ty=(Qubit => Unit is Adj + Ctl)
+              param: callable_id=<item 1018 in package 1>, path=[0], ty=(Qubit => Unit is Adj + Ctl)
               param: callable_id=<item 6 in package 2>, path=[0], ty=(((Qubit)[], Qubit) => Unit)
             call_sites: 3
               site: hof=BernsteinVazirani<Empty>, arg=Closure(target=5, Body)
@@ -1030,13 +1030,13 @@ fn analysis_bernstein_vazirani_sample_shape() {
             operation ApplyToEachA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46247 : Qubit[] = register;
-                        let _len_id_46251 : Int = Length(_array_id_46247);
-                        mutable _index_id_46256 : Int = 0;
-                        while _index_id_46256 < _len_id_46251 {
-                            let item : Qubit = _array_id_46247[_index_id_46256];
+                        let _array_id_46256 : Qubit[] = register;
+                        let _len_id_46260 : Int = Length(_array_id_46256);
+                        mutable _index_id_46265 : Int = 0;
+                        while _index_id_46265 < _len_id_46260 {
+                            let item : Qubit = _array_id_46256[_index_id_46265];
                             H(item);
-                            _index_id_46256 += 1;
+                            _index_id_46265 += 1;
                         }
 
                     }
@@ -1046,15 +1046,15 @@ fn analysis_bernstein_vazirani_sample_shape() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46275 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46278 : Int = _range_id_46275::Start;
-                            let _step_id_46283 : Int = _range_id_46275::Step;
-                            let _end_id_46288 : Int = _range_id_46275::End;
-                            while _step_id_46283 > 0 and _index_id_46278 <= _end_id_46288 or _step_id_46283 < 0 and _index_id_46278 >= _end_id_46288 {
-                                let _index : Int = _index_id_46278;
+                            let _range_id_46284 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46287 : Int = _range_id_46284::Start;
+                            let _step_id_46292 : Int = _range_id_46284::Step;
+                            let _end_id_46297 : Int = _range_id_46284::End;
+                            while _step_id_46292 > 0 and _index_id_46287 <= _end_id_46297 or _step_id_46292 < 0 and _index_id_46287 >= _end_id_46297 {
+                                let _index : Int = _index_id_46287;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46278 += _step_id_46283;
+                                _index_id_46287 += _step_id_46292;
                             }
 
                         }
@@ -1066,13 +1066,13 @@ fn analysis_bernstein_vazirani_sample_shape() {
             operation ApplyToEachA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46247 : Qubit[] = register;
-                        let _len_id_46251 : Int = Length(_array_id_46247);
-                        mutable _index_id_46256 : Int = 0;
-                        while _index_id_46256 < _len_id_46251 {
-                            let item : Qubit = _array_id_46247[_index_id_46256];
+                        let _array_id_46256 : Qubit[] = register;
+                        let _len_id_46260 : Int = Length(_array_id_46256);
+                        mutable _index_id_46265 : Int = 0;
+                        while _index_id_46265 < _len_id_46260 {
+                            let item : Qubit = _array_id_46256[_index_id_46265];
                             H(item);
-                            _index_id_46256 += 1;
+                            _index_id_46265 += 1;
                         }
 
                     }
@@ -1082,15 +1082,15 @@ fn analysis_bernstein_vazirani_sample_shape() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46275 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46278 : Int = _range_id_46275::Start;
-                            let _step_id_46283 : Int = _range_id_46275::Step;
-                            let _end_id_46288 : Int = _range_id_46275::End;
-                            while _step_id_46283 > 0 and _index_id_46278 <= _end_id_46288 or _step_id_46283 < 0 and _index_id_46278 >= _end_id_46288 {
-                                let _index : Int = _index_id_46278;
+                            let _range_id_46284 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46287 : Int = _range_id_46284::Start;
+                            let _step_id_46292 : Int = _range_id_46284::Step;
+                            let _end_id_46297 : Int = _range_id_46284::End;
+                            while _step_id_46292 > 0 and _index_id_46287 <= _end_id_46297 or _step_id_46292 < 0 and _index_id_46287 >= _end_id_46297 {
+                                let _index : Int = _index_id_46287;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46278 += _step_id_46283;
+                                _index_id_46287 += _step_id_46292;
                             }
 
                         }
@@ -1166,7 +1166,7 @@ fn analysis_deutsch_jozsa_sample_shape() {
         adaptive_qirgen_capabilities(),
         &expect![[r#"
             callable_params: 2
-              param: callable_id=<item 1016 in package 1>, path=[1], ty=(Qubit => Unit is Adj + Ctl)
+              param: callable_id=<item 1018 in package 1>, path=[1], ty=(Qubit => Unit is Adj + Ctl)
               param: callable_id=<item 7 in package 2>, path=[0], ty=(((Qubit)[], Qubit) => Unit)
             call_sites: 6
               site: hof=ApplyControlledOnInt<Qubit, AdjCtl>, arg=Global(X, Body)
@@ -1965,13 +1965,13 @@ fn full_pipeline_handles_stdlib_apply_to_each() {
             }
             operation ApplyToEach_Qubit__AdjCtl__H_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46209 : Qubit[] = register;
-                    let _len_id_46213 : Int = Length(_array_id_46209);
-                    mutable _index_id_46218 : Int = 0;
-                    while _index_id_46218 < _len_id_46213 {
-                        let item : Qubit = _array_id_46209[_index_id_46218];
+                    let _array_id_46218 : Qubit[] = register;
+                    let _len_id_46222 : Int = Length(_array_id_46218);
+                    mutable _index_id_46227 : Int = 0;
+                    while _index_id_46227 < _len_id_46222 {
+                        let item : Qubit = _array_id_46218[_index_id_46227];
                         H(item);
-                        _index_id_46218 += 1;
+                        _index_id_46227 += 1;
                     }
 
                 }
@@ -2013,13 +2013,13 @@ fn full_pipeline_handles_stdlib_apply_to_each_with_custom_intrinsic() {
             }
             operation ApplyToEach_Qubit__AdjCtl__SX_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46209 : Qubit[] = register;
-                    let _len_id_46213 : Int = Length(_array_id_46209);
-                    mutable _index_id_46218 : Int = 0;
-                    while _index_id_46218 < _len_id_46213 {
-                        let item : Qubit = _array_id_46209[_index_id_46218];
+                    let _array_id_46218 : Qubit[] = register;
+                    let _len_id_46222 : Int = Length(_array_id_46218);
+                    mutable _index_id_46227 : Int = 0;
+                    while _index_id_46227 < _len_id_46222 {
+                        let item : Qubit = _array_id_46218[_index_id_46227];
                         SX(item);
-                        _index_id_46218 += 1;
+                        _index_id_46227 += 1;
                     }
 
                 }
@@ -2061,13 +2061,13 @@ fn apply_to_each_body_callable_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__AdjCtl__H_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46209 : Qubit[] = register;
-                    let _len_id_46213 : Int = Length(_array_id_46209);
-                    mutable _index_id_46218 : Int = 0;
-                    while _index_id_46218 < _len_id_46213 {
-                        let item : Qubit = _array_id_46209[_index_id_46218];
+                    let _array_id_46218 : Qubit[] = register;
+                    let _len_id_46222 : Int = Length(_array_id_46218);
+                    mutable _index_id_46227 : Int = 0;
+                    while _index_id_46227 < _len_id_46222 {
+                        let item : Qubit = _array_id_46218[_index_id_46227];
                         H(item);
-                        _index_id_46218 += 1;
+                        _index_id_46227 += 1;
                     }
 
                 }
@@ -2113,13 +2113,13 @@ fn apply_to_each_a_adjoint_callable_defunctionalizes() {
             operation ApplyToEachA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46237 : Qubit[] = register;
-                        let _len_id_46241 : Int = Length(_array_id_46237);
-                        mutable _index_id_46246 : Int = 0;
-                        while _index_id_46246 < _len_id_46241 {
-                            let item : Qubit = _array_id_46237[_index_id_46246];
+                        let _array_id_46246 : Qubit[] = register;
+                        let _len_id_46250 : Int = Length(_array_id_46246);
+                        mutable _index_id_46255 : Int = 0;
+                        while _index_id_46255 < _len_id_46250 {
+                            let item : Qubit = _array_id_46246[_index_id_46255];
                             S(item);
-                            _index_id_46246 += 1;
+                            _index_id_46255 += 1;
                         }
 
                     }
@@ -2129,15 +2129,15 @@ fn apply_to_each_a_adjoint_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46265 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46268 : Int = _range_id_46265::Start;
-                            let _step_id_46273 : Int = _range_id_46265::Step;
-                            let _end_id_46278 : Int = _range_id_46265::End;
-                            while _step_id_46273 > 0 and _index_id_46268 <= _end_id_46278 or _step_id_46273 < 0 and _index_id_46268 >= _end_id_46278 {
-                                let _index : Int = _index_id_46268;
+                            let _range_id_46274 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46277 : Int = _range_id_46274::Start;
+                            let _step_id_46282 : Int = _range_id_46274::Step;
+                            let _end_id_46287 : Int = _range_id_46274::End;
+                            while _step_id_46282 > 0 and _index_id_46277 <= _end_id_46287 or _step_id_46282 < 0 and _index_id_46277 >= _end_id_46287 {
+                                let _index : Int = _index_id_46277;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46268 += _step_id_46273;
+                                _index_id_46277 += _step_id_46282;
                             }
 
                         }
@@ -2189,13 +2189,13 @@ fn apply_to_each_c_controlled_callable_defunctionalizes() {
             operation ApplyToEachC_Qubit__AdjCtl__X_(register : Qubit[]) : Unit is Ctl {
                 body ... {
                     {
-                        let _array_id_46308 : Qubit[] = register;
-                        let _len_id_46312 : Int = Length(_array_id_46308);
-                        mutable _index_id_46317 : Int = 0;
-                        while _index_id_46317 < _len_id_46312 {
-                            let item : Qubit = _array_id_46308[_index_id_46317];
+                        let _array_id_46317 : Qubit[] = register;
+                        let _len_id_46321 : Int = Length(_array_id_46317);
+                        mutable _index_id_46326 : Int = 0;
+                        while _index_id_46326 < _len_id_46321 {
+                            let item : Qubit = _array_id_46317[_index_id_46326];
                             X(item);
-                            _index_id_46317 += 1;
+                            _index_id_46326 += 1;
                         }
 
                     }
@@ -2203,13 +2203,13 @@ fn apply_to_each_c_controlled_callable_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46336 : Qubit[] = register;
-                        let _len_id_46340 : Int = Length(_array_id_46336);
-                        mutable _index_id_46345 : Int = 0;
-                        while _index_id_46345 < _len_id_46340 {
-                            let item : Qubit = _array_id_46336[_index_id_46345];
+                        let _array_id_46345 : Qubit[] = register;
+                        let _len_id_46349 : Int = Length(_array_id_46345);
+                        mutable _index_id_46354 : Int = 0;
+                        while _index_id_46354 < _len_id_46349 {
+                            let item : Qubit = _array_id_46345[_index_id_46354];
                             Controlled X(ctls, item);
-                            _index_id_46345 += 1;
+                            _index_id_46354 += 1;
                         }
 
                     }
@@ -2253,13 +2253,13 @@ fn apply_to_each_ca_callable_defunctionalizes() {
             operation ApplyToEachCA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46364 : Qubit[] = register;
-                        let _len_id_46368 : Int = Length(_array_id_46364);
-                        mutable _index_id_46373 : Int = 0;
-                        while _index_id_46373 < _len_id_46368 {
-                            let item : Qubit = _array_id_46364[_index_id_46373];
+                        let _array_id_46373 : Qubit[] = register;
+                        let _len_id_46377 : Int = Length(_array_id_46373);
+                        mutable _index_id_46382 : Int = 0;
+                        while _index_id_46382 < _len_id_46377 {
+                            let item : Qubit = _array_id_46373[_index_id_46382];
                             S(item);
-                            _index_id_46373 += 1;
+                            _index_id_46382 += 1;
                         }
 
                     }
@@ -2269,15 +2269,15 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46392 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46395 : Int = _range_id_46392::Start;
-                            let _step_id_46400 : Int = _range_id_46392::Step;
-                            let _end_id_46405 : Int = _range_id_46392::End;
-                            while _step_id_46400 > 0 and _index_id_46395 <= _end_id_46405 or _step_id_46400 < 0 and _index_id_46395 >= _end_id_46405 {
-                                let _index : Int = _index_id_46395;
+                            let _range_id_46401 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46404 : Int = _range_id_46401::Start;
+                            let _step_id_46409 : Int = _range_id_46401::Step;
+                            let _end_id_46414 : Int = _range_id_46401::End;
+                            while _step_id_46409 > 0 and _index_id_46404 <= _end_id_46414 or _step_id_46409 < 0 and _index_id_46404 >= _end_id_46414 {
+                                let _index : Int = _index_id_46404;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46395 += _step_id_46400;
+                                _index_id_46404 += _step_id_46409;
                             }
 
                         }
@@ -2287,13 +2287,13 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             Controlled S(ctls, item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2303,15 +2303,15 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46472 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46475 : Int = _range_id_46472::Start;
+                            let _step_id_46480 : Int = _range_id_46472::Step;
+                            let _end_id_46485 : Int = _range_id_46472::End;
+                            while _step_id_46480 > 0 and _index_id_46475 <= _end_id_46485 or _step_id_46480 < 0 and _index_id_46475 >= _end_id_46485 {
+                                let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint S(ctls, item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2365,13 +2365,13 @@ fn cross_package_apply_to_each_closure_arg_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__Empty__closure_(register : Qubit[], __capture_0 : Double) : Unit {
                 {
-                    let _array_id_46209 : Qubit[] = register;
-                    let _len_id_46213 : Int = Length(_array_id_46209);
-                    mutable _index_id_46218 : Int = 0;
-                    while _index_id_46218 < _len_id_46213 {
-                        let item : Qubit = _array_id_46209[_index_id_46218];
+                    let _array_id_46218 : Qubit[] = register;
+                    let _len_id_46222 : Int = Length(_array_id_46218);
+                    mutable _index_id_46227 : Int = 0;
+                    while _index_id_46227 < _len_id_46222 {
+                        let item : Qubit = _array_id_46218[_index_id_46227];
                         _lambda_2(__capture_0, item);
-                        _index_id_46218 += 1;
+                        _index_id_46227 += 1;
                     }
 
                 }
@@ -2413,13 +2413,13 @@ fn cross_package_apply_to_each_adjoint_arg_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__AdjCtl__Adj_S_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46209 : Qubit[] = register;
-                    let _len_id_46213 : Int = Length(_array_id_46209);
-                    mutable _index_id_46218 : Int = 0;
-                    while _index_id_46218 < _len_id_46213 {
-                        let item : Qubit = _array_id_46209[_index_id_46218];
+                    let _array_id_46218 : Qubit[] = register;
+                    let _len_id_46222 : Int = Length(_array_id_46218);
+                    mutable _index_id_46227 : Int = 0;
+                    while _index_id_46227 < _len_id_46222 {
+                        let item : Qubit = _array_id_46218[_index_id_46227];
                         Adjoint S(item);
-                        _index_id_46218 += 1;
+                        _index_id_46227 += 1;
                     }
 
                 }
@@ -2462,13 +2462,13 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
             operation ApplyToEachCA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46364 : Qubit[] = register;
-                        let _len_id_46368 : Int = Length(_array_id_46364);
-                        mutable _index_id_46373 : Int = 0;
-                        while _index_id_46373 < _len_id_46368 {
-                            let item : Qubit = _array_id_46364[_index_id_46373];
+                        let _array_id_46373 : Qubit[] = register;
+                        let _len_id_46377 : Int = Length(_array_id_46373);
+                        mutable _index_id_46382 : Int = 0;
+                        while _index_id_46382 < _len_id_46377 {
+                            let item : Qubit = _array_id_46373[_index_id_46382];
                             S(item);
-                            _index_id_46373 += 1;
+                            _index_id_46382 += 1;
                         }
 
                     }
@@ -2478,15 +2478,15 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46392 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46395 : Int = _range_id_46392::Start;
-                            let _step_id_46400 : Int = _range_id_46392::Step;
-                            let _end_id_46405 : Int = _range_id_46392::End;
-                            while _step_id_46400 > 0 and _index_id_46395 <= _end_id_46405 or _step_id_46400 < 0 and _index_id_46395 >= _end_id_46405 {
-                                let _index : Int = _index_id_46395;
+                            let _range_id_46401 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46404 : Int = _range_id_46401::Start;
+                            let _step_id_46409 : Int = _range_id_46401::Step;
+                            let _end_id_46414 : Int = _range_id_46401::End;
+                            while _step_id_46409 > 0 and _index_id_46404 <= _end_id_46414 or _step_id_46409 < 0 and _index_id_46404 >= _end_id_46414 {
+                                let _index : Int = _index_id_46404;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46395 += _step_id_46400;
+                                _index_id_46404 += _step_id_46409;
                             }
 
                         }
@@ -2496,13 +2496,13 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             Controlled S(ctls, item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2512,15 +2512,15 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46472 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46475 : Int = _range_id_46472::Start;
+                            let _step_id_46480 : Int = _range_id_46472::Step;
+                            let _end_id_46485 : Int = _range_id_46472::End;
+                            while _step_id_46480 > 0 and _index_id_46475 <= _end_id_46485 or _step_id_46480 < 0 and _index_id_46475 >= _end_id_46485 {
+                                let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint S(ctls, item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2638,13 +2638,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
             operation ApplyToEachCA_Qubit__AdjCtl__X_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46364 : Qubit[] = register;
-                        let _len_id_46368 : Int = Length(_array_id_46364);
-                        mutable _index_id_46373 : Int = 0;
-                        while _index_id_46373 < _len_id_46368 {
-                            let item : Qubit = _array_id_46364[_index_id_46373];
+                        let _array_id_46373 : Qubit[] = register;
+                        let _len_id_46377 : Int = Length(_array_id_46373);
+                        mutable _index_id_46382 : Int = 0;
+                        while _index_id_46382 < _len_id_46377 {
+                            let item : Qubit = _array_id_46373[_index_id_46382];
                             X(item);
-                            _index_id_46373 += 1;
+                            _index_id_46382 += 1;
                         }
 
                     }
@@ -2654,15 +2654,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46392 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46395 : Int = _range_id_46392::Start;
-                            let _step_id_46400 : Int = _range_id_46392::Step;
-                            let _end_id_46405 : Int = _range_id_46392::End;
-                            while _step_id_46400 > 0 and _index_id_46395 <= _end_id_46405 or _step_id_46400 < 0 and _index_id_46395 >= _end_id_46405 {
-                                let _index : Int = _index_id_46395;
+                            let _range_id_46401 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46404 : Int = _range_id_46401::Start;
+                            let _step_id_46409 : Int = _range_id_46401::Step;
+                            let _end_id_46414 : Int = _range_id_46401::End;
+                            while _step_id_46409 > 0 and _index_id_46404 <= _end_id_46414 or _step_id_46409 < 0 and _index_id_46404 >= _end_id_46414 {
+                                let _index : Int = _index_id_46404;
                                 let item : Qubit = _array[_index];
                                 Adjoint X(item);
-                                _index_id_46395 += _step_id_46400;
+                                _index_id_46404 += _step_id_46409;
                             }
 
                         }
@@ -2672,13 +2672,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             Controlled X(ctls, item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2688,15 +2688,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46472 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46475 : Int = _range_id_46472::Start;
+                            let _step_id_46480 : Int = _range_id_46472::Step;
+                            let _end_id_46485 : Int = _range_id_46472::End;
+                            while _step_id_46480 > 0 and _index_id_46475 <= _end_id_46485 or _step_id_46480 < 0 and _index_id_46475 >= _end_id_46485 {
+                                let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint X(ctls, item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2708,13 +2708,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
             operation ApplyToEachCA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46364 : Qubit[] = register;
-                        let _len_id_46368 : Int = Length(_array_id_46364);
-                        mutable _index_id_46373 : Int = 0;
-                        while _index_id_46373 < _len_id_46368 {
-                            let item : Qubit = _array_id_46364[_index_id_46373];
+                        let _array_id_46373 : Qubit[] = register;
+                        let _len_id_46377 : Int = Length(_array_id_46373);
+                        mutable _index_id_46382 : Int = 0;
+                        while _index_id_46382 < _len_id_46377 {
+                            let item : Qubit = _array_id_46373[_index_id_46382];
                             H(item);
-                            _index_id_46373 += 1;
+                            _index_id_46382 += 1;
                         }
 
                     }
@@ -2724,15 +2724,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46392 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46395 : Int = _range_id_46392::Start;
-                            let _step_id_46400 : Int = _range_id_46392::Step;
-                            let _end_id_46405 : Int = _range_id_46392::End;
-                            while _step_id_46400 > 0 and _index_id_46395 <= _end_id_46405 or _step_id_46400 < 0 and _index_id_46395 >= _end_id_46405 {
-                                let _index : Int = _index_id_46395;
+                            let _range_id_46401 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46404 : Int = _range_id_46401::Start;
+                            let _step_id_46409 : Int = _range_id_46401::Step;
+                            let _end_id_46414 : Int = _range_id_46401::End;
+                            while _step_id_46409 > 0 and _index_id_46404 <= _end_id_46414 or _step_id_46409 < 0 and _index_id_46404 >= _end_id_46414 {
+                                let _index : Int = _index_id_46404;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46395 += _step_id_46400;
+                                _index_id_46404 += _step_id_46409;
                             }
 
                         }
@@ -2742,13 +2742,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             Controlled H(ctls, item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2758,15 +2758,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46463 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46466 : Int = _range_id_46463::Start;
-                            let _step_id_46471 : Int = _range_id_46463::Step;
-                            let _end_id_46476 : Int = _range_id_46463::End;
-                            while _step_id_46471 > 0 and _index_id_46466 <= _end_id_46476 or _step_id_46471 < 0 and _index_id_46466 >= _end_id_46476 {
-                                let _index : Int = _index_id_46466;
+                            let _range_id_46472 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46475 : Int = _range_id_46472::Start;
+                            let _step_id_46480 : Int = _range_id_46472::Step;
+                            let _end_id_46485 : Int = _range_id_46472::End;
+                            while _step_id_46480 > 0 and _index_id_46475 <= _end_id_46485 or _step_id_46480 < 0 and _index_id_46475 >= _end_id_46485 {
+                                let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint H(ctls, item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2818,13 +2818,13 @@ fn cross_package_mapped_defunctionalizes() {
             function Mapped_Int__Int__Double_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45723 : Int[] = array;
-                    let _len_id_45727 : Int = Length(_array_id_45723);
-                    mutable _index_id_45732 : Int = 0;
-                    while _index_id_45732 < _len_id_45727 {
-                        let element : Int = _array_id_45723[_index_id_45732];
+                    let _array_id_45732 : Int[] = array;
+                    let _len_id_45736 : Int = Length(_array_id_45732);
+                    mutable _index_id_45741 : Int = 0;
+                    while _index_id_45741 < _len_id_45736 {
+                        let element : Int = _array_id_45732[_index_id_45741];
                         mapped += [Double(element)];
-                        _index_id_45732 += 1;
+                        _index_id_45741 += 1;
                     }
 
                 }
@@ -2868,13 +2868,13 @@ fn cross_package_for_each_defunctionalizes() {
             operation ForEach_Qubit__Unit__AdjCtl__H_(array : Qubit[]) : Unit[] {
                 mutable output : Unit[] = [];
                 {
-                    let _array_id_45495 : Qubit[] = array;
-                    let _len_id_45499 : Int = Length(_array_id_45495);
-                    mutable _index_id_45504 : Int = 0;
-                    while _index_id_45504 < _len_id_45499 {
-                        let element : Qubit = _array_id_45495[_index_id_45504];
+                    let _array_id_45504 : Qubit[] = array;
+                    let _len_id_45508 : Int = Length(_array_id_45504);
+                    mutable _index_id_45513 : Int = 0;
+                    while _index_id_45513 < _len_id_45508 {
+                        let element : Qubit = _array_id_45504[_index_id_45513];
                         output += [H(element)];
-                        _index_id_45504 += 1;
+                        _index_id_45513 += 1;
                     }
 
                 }
@@ -2929,13 +2929,13 @@ fn stdlib_hof_specialized_with_concrete_callable() {
             function Mapped_Int__Int__closure_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45723 : Int[] = array;
-                    let _len_id_45727 : Int = Length(_array_id_45723);
-                    mutable _index_id_45732 : Int = 0;
-                    while _index_id_45732 < _len_id_45727 {
-                        let element : Int = _array_id_45723[_index_id_45732];
+                    let _array_id_45732 : Int[] = array;
+                    let _len_id_45736 : Int = Length(_array_id_45732);
+                    mutable _index_id_45741 : Int = 0;
+                    while _index_id_45741 < _len_id_45736 {
+                        let element : Int = _array_id_45732[_index_id_45741];
                         mapped += [_lambda_2(element, )];
-                        _index_id_45732 += 1;
+                        _index_id_45741 += 1;
                     }
 
                 }
@@ -3013,13 +3013,13 @@ fn lambda_expression_sample_shape_has_no_defunctionalization_errors() {
             function Fold_Int__Int__closure_(state : Int, array : Int[]) : Int {
                 mutable current : Int = state;
                 {
-                    let _array_id_45467 : Int[] = array;
-                    let _len_id_45471 : Int = Length(_array_id_45467);
-                    mutable _index_id_45476 : Int = 0;
-                    while _index_id_45476 < _len_id_45471 {
-                        let element : Int = _array_id_45467[_index_id_45476];
+                    let _array_id_45476 : Int[] = array;
+                    let _len_id_45480 : Int = Length(_array_id_45476);
+                    mutable _index_id_45485 : Int = 0;
+                    while _index_id_45485 < _len_id_45480 {
+                        let element : Int = _array_id_45476[_index_id_45485];
                         current = _lambda_2((current, element), );
-                        _index_id_45476 += 1;
+                        _index_id_45485 += 1;
                     }
 
                 }
@@ -3029,13 +3029,13 @@ fn lambda_expression_sample_shape_has_no_defunctionalization_errors() {
             function Mapped_Int__Int__closure_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45723 : Int[] = array;
-                    let _len_id_45727 : Int = Length(_array_id_45723);
-                    mutable _index_id_45732 : Int = 0;
-                    while _index_id_45732 < _len_id_45727 {
-                        let element : Int = _array_id_45723[_index_id_45732];
+                    let _array_id_45732 : Int[] = array;
+                    let _len_id_45736 : Int = Length(_array_id_45732);
+                    mutable _index_id_45741 : Int = 0;
+                    while _index_id_45741 < _len_id_45736 {
+                        let element : Int = _array_id_45732[_index_id_45741];
                         mapped += [_lambda_4(element, )];
-                        _index_id_45732 += 1;
+                        _index_id_45741 += 1;
                     }
 
                 }
@@ -3151,13 +3151,13 @@ fn partial_application_sample_shape_has_no_defunctionalization_errors() {
             function Mapped_Int__Int__closure_(array : Int[], __capture_0 : Int) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45723 : Int[] = array;
-                    let _len_id_45727 : Int = Length(_array_id_45723);
-                    mutable _index_id_45732 : Int = 0;
-                    while _index_id_45732 < _len_id_45727 {
-                        let element : Int = _array_id_45723[_index_id_45732];
+                    let _array_id_45732 : Int[] = array;
+                    let _len_id_45736 : Int = Length(_array_id_45732);
+                    mutable _index_id_45741 : Int = 0;
+                    while _index_id_45741 < _len_id_45736 {
+                        let element : Int = _array_id_45732[_index_id_45741];
                         mapped += [_lambda_8(__capture_0, element)];
-                        _index_id_45732 += 1;
+                        _index_id_45741 += 1;
                     }
 
                 }

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/cross_package.rs
@@ -624,18 +624,18 @@ fn analysis_apply_operation_power_ca_consumer() {
             operation ApplyOperationPowerCA__Qubit_____AdjCtl__U_(power : Int, target : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _range_id_48101 : Range = 1..AbsI(power);
-                        mutable _index_id_48104 : Int = _range_id_48101::Start;
-                        let _step_id_48109 : Int = _range_id_48101::Step;
-                        let _end_id_48114 : Int = _range_id_48101::End;
-                        while _step_id_48109 > 0 and _index_id_48104 <= _end_id_48114 or _step_id_48109 < 0 and _index_id_48104 >= _end_id_48114 {
-                            let _ : Int = _index_id_48104;
+                        let _range_id_48110 : Range = 1..AbsI(power);
+                        mutable _index_id_48113 : Int = _range_id_48110::Start;
+                        let _step_id_48118 : Int = _range_id_48110::Step;
+                        let _end_id_48123 : Int = _range_id_48110::End;
+                        while _step_id_48118 > 0 and _index_id_48113 <= _end_id_48123 or _step_id_48118 < 0 and _index_id_48113 >= _end_id_48123 {
+                            let _ : Int = _index_id_48113;
                             if power >= 0 {
                                 U(target)
                             } else {
                                 Adjoint U(target)
                             };
-                            _index_id_48104 += _step_id_48109;
+                            _index_id_48113 += _step_id_48118;
                         }
 
                     }
@@ -645,18 +645,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                     {
                         let _range : Range = 1..AbsI(power);
                         {
-                            let _range_id_48144 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                            mutable _index_id_48147 : Int = _range_id_48144::Start;
-                            let _step_id_48152 : Int = _range_id_48144::Step;
-                            let _end_id_48157 : Int = _range_id_48144::End;
-                            while _step_id_48152 > 0 and _index_id_48147 <= _end_id_48157 or _step_id_48152 < 0 and _index_id_48147 >= _end_id_48157 {
-                                let _ : Int = _index_id_48147;
+                            let _range_id_48153 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                            mutable _index_id_48156 : Int = _range_id_48153::Start;
+                            let _step_id_48161 : Int = _range_id_48153::Step;
+                            let _end_id_48166 : Int = _range_id_48153::End;
+                            while _step_id_48161 > 0 and _index_id_48156 <= _end_id_48166 or _step_id_48161 < 0 and _index_id_48156 >= _end_id_48166 {
+                                let _ : Int = _index_id_48156;
                                 if power >= 0 {
                                     Adjoint U(target)
                                 } else {
                                     U(target)
                                 };
-                                _index_id_48147 += _step_id_48152;
+                                _index_id_48156 += _step_id_48161;
                             }
 
                         }
@@ -666,18 +666,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _range_id_48187 : Range = 1..AbsI(power);
-                        mutable _index_id_48190 : Int = _range_id_48187::Start;
-                        let _step_id_48195 : Int = _range_id_48187::Step;
-                        let _end_id_48200 : Int = _range_id_48187::End;
-                        while _step_id_48195 > 0 and _index_id_48190 <= _end_id_48200 or _step_id_48195 < 0 and _index_id_48190 >= _end_id_48200 {
-                            let _ : Int = _index_id_48190;
+                        let _range_id_48196 : Range = 1..AbsI(power);
+                        mutable _index_id_48199 : Int = _range_id_48196::Start;
+                        let _step_id_48204 : Int = _range_id_48196::Step;
+                        let _end_id_48209 : Int = _range_id_48196::End;
+                        while _step_id_48204 > 0 and _index_id_48199 <= _end_id_48209 or _step_id_48204 < 0 and _index_id_48199 >= _end_id_48209 {
+                            let _ : Int = _index_id_48199;
                             if power >= 0 {
                                 Controlled U(ctls, target)
                             } else {
                                 Controlled Adjoint U(ctls, target)
                             };
-                            _index_id_48190 += _step_id_48195;
+                            _index_id_48199 += _step_id_48204;
                         }
 
                     }
@@ -687,18 +687,18 @@ fn analysis_apply_operation_power_ca_consumer() {
                     {
                         let _range : Range = 1..AbsI(power);
                         {
-                            let _range_id_48230 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                            mutable _index_id_48233 : Int = _range_id_48230::Start;
-                            let _step_id_48238 : Int = _range_id_48230::Step;
-                            let _end_id_48243 : Int = _range_id_48230::End;
-                            while _step_id_48238 > 0 and _index_id_48233 <= _end_id_48243 or _step_id_48238 < 0 and _index_id_48233 >= _end_id_48243 {
-                                let _ : Int = _index_id_48233;
+                            let _range_id_48239 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                            mutable _index_id_48242 : Int = _range_id_48239::Start;
+                            let _step_id_48247 : Int = _range_id_48239::Step;
+                            let _end_id_48252 : Int = _range_id_48239::End;
+                            while _step_id_48247 > 0 and _index_id_48242 <= _end_id_48252 or _step_id_48247 < 0 and _index_id_48242 >= _end_id_48252 {
+                                let _ : Int = _index_id_48242;
                                 if power >= 0 {
                                     Controlled Adjoint U(ctls, target)
                                 } else {
                                     Controlled U(ctls, target)
                                 };
-                                _index_id_48233 += _step_id_48238;
+                                _index_id_48242 += _step_id_48247;
                             }
 
                         }
@@ -1016,13 +1016,13 @@ fn analysis_bernstein_vazirani_sample_shape() {
             operation ApplyToEachA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46318 : Qubit[] = register;
-                        let _len_id_46322 : Int = Length(_array_id_46318);
-                        mutable _index_id_46327 : Int = 0;
-                        while _index_id_46327 < _len_id_46322 {
-                            let item : Qubit = _array_id_46318[_index_id_46327];
+                        let _array_id_46327 : Qubit[] = register;
+                        let _len_id_46331 : Int = Length(_array_id_46327);
+                        mutable _index_id_46336 : Int = 0;
+                        while _index_id_46336 < _len_id_46331 {
+                            let item : Qubit = _array_id_46327[_index_id_46336];
                             H(item);
-                            _index_id_46327 += 1;
+                            _index_id_46336 += 1;
                         }
 
                     }
@@ -1032,15 +1032,15 @@ fn analysis_bernstein_vazirani_sample_shape() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46346 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46349 : Int = _range_id_46346::Start;
-                            let _step_id_46354 : Int = _range_id_46346::Step;
-                            let _end_id_46359 : Int = _range_id_46346::End;
-                            while _step_id_46354 > 0 and _index_id_46349 <= _end_id_46359 or _step_id_46354 < 0 and _index_id_46349 >= _end_id_46359 {
-                                let _index : Int = _index_id_46349;
+                            let _range_id_46355 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46358 : Int = _range_id_46355::Start;
+                            let _step_id_46363 : Int = _range_id_46355::Step;
+                            let _end_id_46368 : Int = _range_id_46355::End;
+                            while _step_id_46363 > 0 and _index_id_46358 <= _end_id_46368 or _step_id_46363 < 0 and _index_id_46358 >= _end_id_46368 {
+                                let _index : Int = _index_id_46358;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46349 += _step_id_46354;
+                                _index_id_46358 += _step_id_46363;
                             }
 
                         }
@@ -1052,13 +1052,13 @@ fn analysis_bernstein_vazirani_sample_shape() {
             operation ApplyToEachA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46318 : Qubit[] = register;
-                        let _len_id_46322 : Int = Length(_array_id_46318);
-                        mutable _index_id_46327 : Int = 0;
-                        while _index_id_46327 < _len_id_46322 {
-                            let item : Qubit = _array_id_46318[_index_id_46327];
+                        let _array_id_46327 : Qubit[] = register;
+                        let _len_id_46331 : Int = Length(_array_id_46327);
+                        mutable _index_id_46336 : Int = 0;
+                        while _index_id_46336 < _len_id_46331 {
+                            let item : Qubit = _array_id_46327[_index_id_46336];
                             H(item);
-                            _index_id_46327 += 1;
+                            _index_id_46336 += 1;
                         }
 
                     }
@@ -1068,15 +1068,15 @@ fn analysis_bernstein_vazirani_sample_shape() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46346 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46349 : Int = _range_id_46346::Start;
-                            let _step_id_46354 : Int = _range_id_46346::Step;
-                            let _end_id_46359 : Int = _range_id_46346::End;
-                            while _step_id_46354 > 0 and _index_id_46349 <= _end_id_46359 or _step_id_46354 < 0 and _index_id_46349 >= _end_id_46359 {
-                                let _index : Int = _index_id_46349;
+                            let _range_id_46355 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46358 : Int = _range_id_46355::Start;
+                            let _step_id_46363 : Int = _range_id_46355::Step;
+                            let _end_id_46368 : Int = _range_id_46355::End;
+                            while _step_id_46363 > 0 and _index_id_46358 <= _end_id_46368 or _step_id_46363 < 0 and _index_id_46358 >= _end_id_46368 {
+                                let _index : Int = _index_id_46358;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46349 += _step_id_46354;
+                                _index_id_46358 += _step_id_46363;
                             }
 
                         }
@@ -1951,13 +1951,13 @@ fn full_pipeline_handles_stdlib_apply_to_each() {
             }
             operation ApplyToEach_Qubit__AdjCtl__H_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46289 : Qubit[] = register;
+                    let _len_id_46293 : Int = Length(_array_id_46289);
+                    mutable _index_id_46298 : Int = 0;
+                    while _index_id_46298 < _len_id_46293 {
+                        let item : Qubit = _array_id_46289[_index_id_46298];
                         H(item);
-                        _index_id_46289 += 1;
+                        _index_id_46298 += 1;
                     }
 
                 }
@@ -1999,13 +1999,13 @@ fn full_pipeline_handles_stdlib_apply_to_each_with_custom_intrinsic() {
             }
             operation ApplyToEach_Qubit__AdjCtl__SX_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46289 : Qubit[] = register;
+                    let _len_id_46293 : Int = Length(_array_id_46289);
+                    mutable _index_id_46298 : Int = 0;
+                    while _index_id_46298 < _len_id_46293 {
+                        let item : Qubit = _array_id_46289[_index_id_46298];
                         SX(item);
-                        _index_id_46289 += 1;
+                        _index_id_46298 += 1;
                     }
 
                 }
@@ -2047,13 +2047,13 @@ fn apply_to_each_body_callable_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__AdjCtl__H_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46289 : Qubit[] = register;
+                    let _len_id_46293 : Int = Length(_array_id_46289);
+                    mutable _index_id_46298 : Int = 0;
+                    while _index_id_46298 < _len_id_46293 {
+                        let item : Qubit = _array_id_46289[_index_id_46298];
                         H(item);
-                        _index_id_46289 += 1;
+                        _index_id_46298 += 1;
                     }
 
                 }
@@ -2099,13 +2099,13 @@ fn apply_to_each_a_adjoint_callable_defunctionalizes() {
             operation ApplyToEachA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj {
                 body ... {
                     {
-                        let _array_id_46308 : Qubit[] = register;
-                        let _len_id_46312 : Int = Length(_array_id_46308);
-                        mutable _index_id_46317 : Int = 0;
-                        while _index_id_46317 < _len_id_46312 {
-                            let item : Qubit = _array_id_46308[_index_id_46317];
+                        let _array_id_46317 : Qubit[] = register;
+                        let _len_id_46321 : Int = Length(_array_id_46317);
+                        mutable _index_id_46326 : Int = 0;
+                        while _index_id_46326 < _len_id_46321 {
+                            let item : Qubit = _array_id_46317[_index_id_46326];
                             S(item);
-                            _index_id_46317 += 1;
+                            _index_id_46326 += 1;
                         }
 
                     }
@@ -2115,15 +2115,15 @@ fn apply_to_each_a_adjoint_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46336 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46339 : Int = _range_id_46336::Start;
-                            let _step_id_46344 : Int = _range_id_46336::Step;
-                            let _end_id_46349 : Int = _range_id_46336::End;
-                            while _step_id_46344 > 0 and _index_id_46339 <= _end_id_46349 or _step_id_46344 < 0 and _index_id_46339 >= _end_id_46349 {
-                                let _index : Int = _index_id_46339;
+                            let _range_id_46345 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46348 : Int = _range_id_46345::Start;
+                            let _step_id_46353 : Int = _range_id_46345::Step;
+                            let _end_id_46358 : Int = _range_id_46345::End;
+                            while _step_id_46353 > 0 and _index_id_46348 <= _end_id_46358 or _step_id_46353 < 0 and _index_id_46348 >= _end_id_46358 {
+                                let _index : Int = _index_id_46348;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46339 += _step_id_46344;
+                                _index_id_46348 += _step_id_46353;
                             }
 
                         }
@@ -2175,13 +2175,13 @@ fn apply_to_each_c_controlled_callable_defunctionalizes() {
             operation ApplyToEachC_Qubit__AdjCtl__X_(register : Qubit[]) : Unit is Ctl {
                 body ... {
                     {
-                        let _array_id_46379 : Qubit[] = register;
-                        let _len_id_46383 : Int = Length(_array_id_46379);
-                        mutable _index_id_46388 : Int = 0;
-                        while _index_id_46388 < _len_id_46383 {
-                            let item : Qubit = _array_id_46379[_index_id_46388];
+                        let _array_id_46388 : Qubit[] = register;
+                        let _len_id_46392 : Int = Length(_array_id_46388);
+                        mutable _index_id_46397 : Int = 0;
+                        while _index_id_46397 < _len_id_46392 {
+                            let item : Qubit = _array_id_46388[_index_id_46397];
                             X(item);
-                            _index_id_46388 += 1;
+                            _index_id_46397 += 1;
                         }
 
                     }
@@ -2189,13 +2189,13 @@ fn apply_to_each_c_controlled_callable_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46407 : Qubit[] = register;
-                        let _len_id_46411 : Int = Length(_array_id_46407);
-                        mutable _index_id_46416 : Int = 0;
-                        while _index_id_46416 < _len_id_46411 {
-                            let item : Qubit = _array_id_46407[_index_id_46416];
+                        let _array_id_46416 : Qubit[] = register;
+                        let _len_id_46420 : Int = Length(_array_id_46416);
+                        mutable _index_id_46425 : Int = 0;
+                        while _index_id_46425 < _len_id_46420 {
+                            let item : Qubit = _array_id_46416[_index_id_46425];
                             Controlled X(ctls, item);
-                            _index_id_46416 += 1;
+                            _index_id_46425 += 1;
                         }
 
                     }
@@ -2239,13 +2239,13 @@ fn apply_to_each_ca_callable_defunctionalizes() {
             operation ApplyToEachCA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             S(item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2263,7 +2263,7 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                                 let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2273,13 +2273,13 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46515 : Qubit[] = register;
+                        let _len_id_46519 : Int = Length(_array_id_46515);
+                        mutable _index_id_46524 : Int = 0;
+                        while _index_id_46524 < _len_id_46519 {
+                            let item : Qubit = _array_id_46515[_index_id_46524];
                             Controlled S(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46524 += 1;
                         }
 
                     }
@@ -2289,15 +2289,15 @@ fn apply_to_each_ca_callable_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46543 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46546 : Int = _range_id_46543::Start;
+                            let _step_id_46551 : Int = _range_id_46543::Step;
+                            let _end_id_46556 : Int = _range_id_46543::End;
+                            while _step_id_46551 > 0 and _index_id_46546 <= _end_id_46556 or _step_id_46551 < 0 and _index_id_46546 >= _end_id_46556 {
+                                let _index : Int = _index_id_46546;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint S(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46546 += _step_id_46551;
                             }
 
                         }
@@ -2351,13 +2351,13 @@ fn cross_package_apply_to_each_closure_arg_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__Empty__closure_(register : Qubit[], __capture_0 : Double) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46289 : Qubit[] = register;
+                    let _len_id_46293 : Int = Length(_array_id_46289);
+                    mutable _index_id_46298 : Int = 0;
+                    while _index_id_46298 < _len_id_46293 {
+                        let item : Qubit = _array_id_46289[_index_id_46298];
                         _lambda_2(__capture_0, item);
-                        _index_id_46289 += 1;
+                        _index_id_46298 += 1;
                     }
 
                 }
@@ -2399,13 +2399,13 @@ fn cross_package_apply_to_each_adjoint_arg_defunctionalizes() {
             }
             operation ApplyToEach_Qubit__AdjCtl__Adj_S_(register : Qubit[]) : Unit {
                 {
-                    let _array_id_46280 : Qubit[] = register;
-                    let _len_id_46284 : Int = Length(_array_id_46280);
-                    mutable _index_id_46289 : Int = 0;
-                    while _index_id_46289 < _len_id_46284 {
-                        let item : Qubit = _array_id_46280[_index_id_46289];
+                    let _array_id_46289 : Qubit[] = register;
+                    let _len_id_46293 : Int = Length(_array_id_46289);
+                    mutable _index_id_46298 : Int = 0;
+                    while _index_id_46298 < _len_id_46293 {
+                        let item : Qubit = _array_id_46289[_index_id_46298];
                         Adjoint S(item);
-                        _index_id_46289 += 1;
+                        _index_id_46298 += 1;
                     }
 
                 }
@@ -2448,13 +2448,13 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
             operation ApplyToEachCA_Qubit__AdjCtl__S_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             S(item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2472,7 +2472,7 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                                 let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Adjoint S(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2482,13 +2482,13 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46515 : Qubit[] = register;
+                        let _len_id_46519 : Int = Length(_array_id_46515);
+                        mutable _index_id_46524 : Int = 0;
+                        while _index_id_46524 < _len_id_46519 {
+                            let item : Qubit = _array_id_46515[_index_id_46524];
                             Controlled S(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46524 += 1;
                         }
 
                     }
@@ -2498,15 +2498,15 @@ fn adjoint_cross_package_apply_to_each_ca_defunctionalizes() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46543 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46546 : Int = _range_id_46543::Start;
+                            let _step_id_46551 : Int = _range_id_46543::Step;
+                            let _end_id_46556 : Int = _range_id_46543::End;
+                            while _step_id_46551 > 0 and _index_id_46546 <= _end_id_46556 or _step_id_46551 < 0 and _index_id_46546 >= _end_id_46556 {
+                                let _index : Int = _index_id_46546;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint S(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46546 += _step_id_46551;
                             }
 
                         }
@@ -2624,13 +2624,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
             operation ApplyToEachCA_Qubit__AdjCtl__X_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             X(item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2648,7 +2648,7 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                                 let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Adjoint X(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2658,13 +2658,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46515 : Qubit[] = register;
+                        let _len_id_46519 : Int = Length(_array_id_46515);
+                        mutable _index_id_46524 : Int = 0;
+                        while _index_id_46524 < _len_id_46519 {
+                            let item : Qubit = _array_id_46515[_index_id_46524];
                             Controlled X(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46524 += 1;
                         }
 
                     }
@@ -2674,15 +2674,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46543 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46546 : Int = _range_id_46543::Start;
+                            let _step_id_46551 : Int = _range_id_46543::Step;
+                            let _end_id_46556 : Int = _range_id_46543::End;
+                            while _step_id_46551 > 0 and _index_id_46546 <= _end_id_46556 or _step_id_46551 < 0 and _index_id_46546 >= _end_id_46556 {
+                                let _index : Int = _index_id_46546;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint X(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46546 += _step_id_46551;
                             }
 
                         }
@@ -2694,13 +2694,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
             operation ApplyToEachCA_Qubit__AdjCtl__H_(register : Qubit[]) : Unit is Adj + Ctl {
                 body ... {
                     {
-                        let _array_id_46435 : Qubit[] = register;
-                        let _len_id_46439 : Int = Length(_array_id_46435);
-                        mutable _index_id_46444 : Int = 0;
-                        while _index_id_46444 < _len_id_46439 {
-                            let item : Qubit = _array_id_46435[_index_id_46444];
+                        let _array_id_46444 : Qubit[] = register;
+                        let _len_id_46448 : Int = Length(_array_id_46444);
+                        mutable _index_id_46453 : Int = 0;
+                        while _index_id_46453 < _len_id_46448 {
+                            let item : Qubit = _array_id_46444[_index_id_46453];
                             H(item);
-                            _index_id_46444 += 1;
+                            _index_id_46453 += 1;
                         }
 
                     }
@@ -2718,7 +2718,7 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                                 let _index : Int = _index_id_46475;
                                 let item : Qubit = _array[_index];
                                 Adjoint H(item);
-                                _index_id_46466 += _step_id_46471;
+                                _index_id_46475 += _step_id_46480;
                             }
 
                         }
@@ -2728,13 +2728,13 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                 }
                 controlled (ctls, ...) {
                     {
-                        let _array_id_46506 : Qubit[] = register;
-                        let _len_id_46510 : Int = Length(_array_id_46506);
-                        mutable _index_id_46515 : Int = 0;
-                        while _index_id_46515 < _len_id_46510 {
-                            let item : Qubit = _array_id_46506[_index_id_46515];
+                        let _array_id_46515 : Qubit[] = register;
+                        let _len_id_46519 : Int = Length(_array_id_46515);
+                        mutable _index_id_46524 : Int = 0;
+                        while _index_id_46524 < _len_id_46519 {
+                            let item : Qubit = _array_id_46515[_index_id_46524];
                             Controlled H(ctls, item);
-                            _index_id_46515 += 1;
+                            _index_id_46524 += 1;
                         }
 
                     }
@@ -2744,15 +2744,15 @@ fn controlled_apply_to_each_ca_keeps_body_callable_static() {
                     {
                         let _array : Qubit[] = register;
                         {
-                            let _range_id_46534 : Range = Length(_array) - 1..-1..0;
-                            mutable _index_id_46537 : Int = _range_id_46534::Start;
-                            let _step_id_46542 : Int = _range_id_46534::Step;
-                            let _end_id_46547 : Int = _range_id_46534::End;
-                            while _step_id_46542 > 0 and _index_id_46537 <= _end_id_46547 or _step_id_46542 < 0 and _index_id_46537 >= _end_id_46547 {
-                                let _index : Int = _index_id_46537;
+                            let _range_id_46543 : Range = Length(_array) - 1..-1..0;
+                            mutable _index_id_46546 : Int = _range_id_46543::Start;
+                            let _step_id_46551 : Int = _range_id_46543::Step;
+                            let _end_id_46556 : Int = _range_id_46543::End;
+                            while _step_id_46551 > 0 and _index_id_46546 <= _end_id_46556 or _step_id_46551 < 0 and _index_id_46546 >= _end_id_46556 {
+                                let _index : Int = _index_id_46546;
                                 let item : Qubit = _array[_index];
                                 Controlled Adjoint H(ctls, item);
-                                _index_id_46537 += _step_id_46542;
+                                _index_id_46546 += _step_id_46551;
                             }
 
                         }
@@ -2804,13 +2804,13 @@ fn cross_package_mapped_defunctionalizes() {
             function Mapped_Int__Int__Double_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45803 : Int[] = array;
+                    let _len_id_45807 : Int = Length(_array_id_45803);
+                    mutable _index_id_45812 : Int = 0;
+                    while _index_id_45812 < _len_id_45807 {
+                        let element : Int = _array_id_45803[_index_id_45812];
                         mapped += [Double(element)];
-                        _index_id_45803 += 1;
+                        _index_id_45812 += 1;
                     }
 
                 }
@@ -2854,13 +2854,13 @@ fn cross_package_for_each_defunctionalizes() {
             operation ForEach_Qubit__Unit__AdjCtl__H_(array : Qubit[]) : Unit[] {
                 mutable output : Unit[] = [];
                 {
-                    let _array_id_45566 : Qubit[] = array;
-                    let _len_id_45570 : Int = Length(_array_id_45566);
-                    mutable _index_id_45575 : Int = 0;
-                    while _index_id_45575 < _len_id_45570 {
-                        let element : Qubit = _array_id_45566[_index_id_45575];
+                    let _array_id_45575 : Qubit[] = array;
+                    let _len_id_45579 : Int = Length(_array_id_45575);
+                    mutable _index_id_45584 : Int = 0;
+                    while _index_id_45584 < _len_id_45579 {
+                        let element : Qubit = _array_id_45575[_index_id_45584];
                         output += [H(element)];
-                        _index_id_45575 += 1;
+                        _index_id_45584 += 1;
                     }
 
                 }
@@ -2915,13 +2915,13 @@ fn stdlib_hof_specialized_with_concrete_callable() {
             function Mapped_Int__Int__closure_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45803 : Int[] = array;
+                    let _len_id_45807 : Int = Length(_array_id_45803);
+                    mutable _index_id_45812 : Int = 0;
+                    while _index_id_45812 < _len_id_45807 {
+                        let element : Int = _array_id_45803[_index_id_45812];
                         mapped += [_lambda_2(element, )];
-                        _index_id_45803 += 1;
+                        _index_id_45812 += 1;
                     }
 
                 }
@@ -2999,13 +2999,13 @@ fn lambda_expression_sample_shape_has_no_defunctionalization_errors() {
             function Fold_Int__Int__closure_(state : Int, array : Int[]) : Int {
                 mutable current : Int = state;
                 {
-                    let _array_id_45538 : Int[] = array;
-                    let _len_id_45542 : Int = Length(_array_id_45538);
-                    mutable _index_id_45547 : Int = 0;
-                    while _index_id_45547 < _len_id_45542 {
-                        let element : Int = _array_id_45538[_index_id_45547];
+                    let _array_id_45547 : Int[] = array;
+                    let _len_id_45551 : Int = Length(_array_id_45547);
+                    mutable _index_id_45556 : Int = 0;
+                    while _index_id_45556 < _len_id_45551 {
+                        let element : Int = _array_id_45547[_index_id_45556];
                         current = _lambda_2((current, element), );
-                        _index_id_45547 += 1;
+                        _index_id_45556 += 1;
                     }
 
                 }
@@ -3015,13 +3015,13 @@ fn lambda_expression_sample_shape_has_no_defunctionalization_errors() {
             function Mapped_Int__Int__closure_(array : Int[]) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45803 : Int[] = array;
+                    let _len_id_45807 : Int = Length(_array_id_45803);
+                    mutable _index_id_45812 : Int = 0;
+                    while _index_id_45812 < _len_id_45807 {
+                        let element : Int = _array_id_45803[_index_id_45812];
                         mapped += [_lambda_4(element, )];
-                        _index_id_45803 += 1;
+                        _index_id_45812 += 1;
                     }
 
                 }
@@ -3137,13 +3137,13 @@ fn partial_application_sample_shape_has_no_defunctionalization_errors() {
             function Mapped_Int__Int__closure_(array : Int[], __capture_0 : Int) : Int[] {
                 mutable mapped : Int[] = [];
                 {
-                    let _array_id_45794 : Int[] = array;
-                    let _len_id_45798 : Int = Length(_array_id_45794);
-                    mutable _index_id_45803 : Int = 0;
-                    while _index_id_45803 < _len_id_45798 {
-                        let element : Int = _array_id_45794[_index_id_45803];
+                    let _array_id_45803 : Int[] = array;
+                    let _len_id_45807 : Int = Length(_array_id_45803);
+                    mutable _index_id_45812 : Int = 0;
+                    while _index_id_45812 < _len_id_45807 {
+                        let element : Int = _array_id_45803[_index_id_45812];
                         mapped += [_lambda_8(__capture_0, element)];
-                        _index_id_45803 += 1;
+                        _index_id_45812 += 1;
                     }
 
                 }

--- a/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/grover.rs
+++ b/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/grover.rs
@@ -333,27 +333,27 @@ fn grover_sample_full_pipeline_reachable_items() {
         operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
             body ... {
                 {
-                    let _range_id_48949 : Range = 0..2..Length(ctls) - 2;
-                    mutable _index_id_48952 : Int = _range_id_48949::Start;
-                    let _step_id_48957 : Int = _range_id_48949::Step;
-                    let _end_id_48962 : Int = _range_id_48949::End;
-                    while _step_id_48957 > 0 and _index_id_48952 <= _end_id_48962 or _step_id_48957 < 0 and _index_id_48952 >= _end_id_48962 {
-                        let i : Int = _index_id_48952;
+                    let _range_id_48958 : Range = 0..2..Length(ctls) - 2;
+                    mutable _index_id_48961 : Int = _range_id_48958::Start;
+                    let _step_id_48966 : Int = _range_id_48958::Step;
+                    let _end_id_48971 : Int = _range_id_48958::End;
+                    while _step_id_48966 > 0 and _index_id_48961 <= _end_id_48971 or _step_id_48966 < 0 and _index_id_48961 >= _end_id_48971 {
+                        let i : Int = _index_id_48961;
                         CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                        _index_id_48952 += _step_id_48957;
+                        _index_id_48961 += _step_id_48966;
                     }
 
                 }
 
                 {
-                    let _range_id_48992 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
-                    mutable _index_id_48995 : Int = _range_id_48992::Start;
-                    let _step_id_49000 : Int = _range_id_48992::Step;
-                    let _end_id_49005 : Int = _range_id_48992::End;
-                    while _step_id_49000 > 0 and _index_id_48995 <= _end_id_49005 or _step_id_49000 < 0 and _index_id_48995 >= _end_id_49005 {
-                        let i : Int = _index_id_48995;
+                    let _range_id_49001 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
+                    mutable _index_id_49004 : Int = _range_id_49001::Start;
+                    let _step_id_49009 : Int = _range_id_49001::Step;
+                    let _end_id_49014 : Int = _range_id_49001::End;
+                    while _step_id_49009 > 0 and _index_id_49004 <= _end_id_49014 or _step_id_49009 < 0 and _index_id_49004 >= _end_id_49014 {
+                        let i : Int = _index_id_49004;
                         CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                        _index_id_48995 += _step_id_49000;
+                        _index_id_49004 += _step_id_49009;
                     }
 
                 }
@@ -363,14 +363,14 @@ fn grover_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(ctls) / 2 - 2 - adjustment;
                     {
-                        let _range_id_49035 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49038 : Int = _range_id_49035::Start;
-                        let _step_id_49043 : Int = _range_id_49035::Step;
-                        let _end_id_49048 : Int = _range_id_49035::End;
-                        while _step_id_49043 > 0 and _index_id_49038 <= _end_id_49048 or _step_id_49043 < 0 and _index_id_49038 >= _end_id_49048 {
-                            let i : Int = _index_id_49038;
+                        let _range_id_49044 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49047 : Int = _range_id_49044::Start;
+                        let _step_id_49052 : Int = _range_id_49044::Step;
+                        let _end_id_49057 : Int = _range_id_49044::End;
+                        while _step_id_49052 > 0 and _index_id_49047 <= _end_id_49057 or _step_id_49052 < 0 and _index_id_49047 >= _end_id_49057 {
+                            let i : Int = _index_id_49047;
                             Adjoint CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                            _index_id_49038 += _step_id_49043;
+                            _index_id_49047 += _step_id_49052;
                         }
 
                     }
@@ -380,14 +380,14 @@ fn grover_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..2..Length(ctls) - 2;
                     {
-                        let _range_id_49078 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49081 : Int = _range_id_49078::Start;
-                        let _step_id_49086 : Int = _range_id_49078::Step;
-                        let _end_id_49091 : Int = _range_id_49078::End;
-                        while _step_id_49086 > 0 and _index_id_49081 <= _end_id_49091 or _step_id_49086 < 0 and _index_id_49081 >= _end_id_49091 {
-                            let i : Int = _index_id_49081;
+                        let _range_id_49087 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49090 : Int = _range_id_49087::Start;
+                        let _step_id_49095 : Int = _range_id_49087::Step;
+                        let _end_id_49100 : Int = _range_id_49087::End;
+                        while _step_id_49095 > 0 and _index_id_49090 <= _end_id_49100 or _step_id_49095 < 0 and _index_id_49090 >= _end_id_49100 {
+                            let i : Int = _index_id_49090;
                             Adjoint CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                            _index_id_49081 += _step_id_49086;
+                            _index_id_49090 += _step_id_49095;
                         }
 
                     }
@@ -500,7 +500,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54052 : Unit = {
+                            let _generated_ident_54061 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -521,7 +521,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54052
+                            _generated_ident_54061
                         }
 
                     }
@@ -546,7 +546,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54066 : Unit = {
+                            let _generated_ident_54075 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -567,7 +567,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54066
+                            _generated_ident_54075
                         }
 
                     }
@@ -594,7 +594,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         CRz(ctls[0], theta, qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54122 : Unit = {
+                        let _generated_ident_54131 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -611,7 +611,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54122
+                        _generated_ident_54131
                     }
 
                 }
@@ -645,7 +645,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             Controlled CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54150 : Unit = {
+                            let _generated_ident_54159 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -666,7 +666,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54150
+                            _generated_ident_54159
                         }
 
                     }
@@ -691,7 +691,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             Controlled Adjoint CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54164 : Unit = {
+                            let _generated_ident_54173 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -712,7 +712,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54164
+                            _generated_ident_54173
                         }
 
                     }
@@ -739,7 +739,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54206 : Unit = {
+                        let _generated_ident_54215 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -756,7 +756,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54206
+                        _generated_ident_54215
                     }
 
                 }
@@ -773,7 +773,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         Adjoint CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54220 : Unit = {
+                        let _generated_ident_54229 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -790,7 +790,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54220
+                        _generated_ident_54229
                     }
 
                 }
@@ -821,7 +821,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54234 : Unit = {
+                            let _generated_ident_54243 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -842,7 +842,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54234
+                            _generated_ident_54243
                         }
 
                     }
@@ -867,7 +867,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54248 : Unit = {
+                            let _generated_ident_54257 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -888,7 +888,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54248
+                            _generated_ident_54257
                         }
 
                     }
@@ -921,7 +921,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCZ(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54290 : Unit = {
+                            let _generated_ident_54299 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -942,7 +942,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54290
+                            _generated_ident_54299
                         }
 
                     }
@@ -967,7 +967,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCZ(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54304 : Unit = {
+                            let _generated_ident_54313 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -988,7 +988,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54304
+                            _generated_ident_54313
                         }
 
                     }
@@ -1037,13 +1037,13 @@ fn grover_sample_full_pipeline_reachable_items() {
         operation MResetEachZ(register : Qubit[]) : Result[] {
             mutable results : Result[] = [];
             {
-                let _array_id_49717 : Qubit[] = register;
-                let _len_id_49721 : Int = Length(_array_id_49717);
-                mutable _index_id_49726 : Int = 0;
-                while _index_id_49726 < _len_id_49721 {
-                    let qubit : Qubit = _array_id_49717[_index_id_49726];
+                let _array_id_49726 : Qubit[] = register;
+                let _len_id_49730 : Int = Length(_array_id_49726);
+                mutable _index_id_49735 : Int = 0;
+                while _index_id_49735 < _len_id_49730 {
+                    let qubit : Qubit = _array_id_49726[_index_id_49735];
                     results += [MResetZ(qubit)];
-                    _index_id_49726 += 1;
+                    _index_id_49735 += 1;
                 }
 
             }

--- a/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/grover.rs
+++ b/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/grover.rs
@@ -333,27 +333,27 @@ fn grover_sample_full_pipeline_reachable_items() {
         operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
             body ... {
                 {
-                    let _range_id_48878 : Range = 0..2..Length(ctls) - 2;
-                    mutable _index_id_48881 : Int = _range_id_48878::Start;
-                    let _step_id_48886 : Int = _range_id_48878::Step;
-                    let _end_id_48891 : Int = _range_id_48878::End;
-                    while _step_id_48886 > 0 and _index_id_48881 <= _end_id_48891 or _step_id_48886 < 0 and _index_id_48881 >= _end_id_48891 {
-                        let i : Int = _index_id_48881;
+                    let _range_id_48887 : Range = 0..2..Length(ctls) - 2;
+                    mutable _index_id_48890 : Int = _range_id_48887::Start;
+                    let _step_id_48895 : Int = _range_id_48887::Step;
+                    let _end_id_48900 : Int = _range_id_48887::End;
+                    while _step_id_48895 > 0 and _index_id_48890 <= _end_id_48900 or _step_id_48895 < 0 and _index_id_48890 >= _end_id_48900 {
+                        let i : Int = _index_id_48890;
                         CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                        _index_id_48881 += _step_id_48886;
+                        _index_id_48890 += _step_id_48895;
                     }
 
                 }
 
                 {
-                    let _range_id_48921 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
-                    mutable _index_id_48924 : Int = _range_id_48921::Start;
-                    let _step_id_48929 : Int = _range_id_48921::Step;
-                    let _end_id_48934 : Int = _range_id_48921::End;
-                    while _step_id_48929 > 0 and _index_id_48924 <= _end_id_48934 or _step_id_48929 < 0 and _index_id_48924 >= _end_id_48934 {
-                        let i : Int = _index_id_48924;
+                    let _range_id_48930 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
+                    mutable _index_id_48933 : Int = _range_id_48930::Start;
+                    let _step_id_48938 : Int = _range_id_48930::Step;
+                    let _end_id_48943 : Int = _range_id_48930::End;
+                    while _step_id_48938 > 0 and _index_id_48933 <= _end_id_48943 or _step_id_48938 < 0 and _index_id_48933 >= _end_id_48943 {
+                        let i : Int = _index_id_48933;
                         CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                        _index_id_48924 += _step_id_48929;
+                        _index_id_48933 += _step_id_48938;
                     }
 
                 }
@@ -363,14 +363,14 @@ fn grover_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(ctls) / 2 - 2 - adjustment;
                     {
-                        let _range_id_48964 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_48967 : Int = _range_id_48964::Start;
-                        let _step_id_48972 : Int = _range_id_48964::Step;
-                        let _end_id_48977 : Int = _range_id_48964::End;
-                        while _step_id_48972 > 0 and _index_id_48967 <= _end_id_48977 or _step_id_48972 < 0 and _index_id_48967 >= _end_id_48977 {
-                            let i : Int = _index_id_48967;
+                        let _range_id_48973 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_48976 : Int = _range_id_48973::Start;
+                        let _step_id_48981 : Int = _range_id_48973::Step;
+                        let _end_id_48986 : Int = _range_id_48973::End;
+                        while _step_id_48981 > 0 and _index_id_48976 <= _end_id_48986 or _step_id_48981 < 0 and _index_id_48976 >= _end_id_48986 {
+                            let i : Int = _index_id_48976;
                             Adjoint CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                            _index_id_48967 += _step_id_48972;
+                            _index_id_48976 += _step_id_48981;
                         }
 
                     }
@@ -380,14 +380,14 @@ fn grover_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..2..Length(ctls) - 2;
                     {
-                        let _range_id_49007 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49010 : Int = _range_id_49007::Start;
-                        let _step_id_49015 : Int = _range_id_49007::Step;
-                        let _end_id_49020 : Int = _range_id_49007::End;
-                        while _step_id_49015 > 0 and _index_id_49010 <= _end_id_49020 or _step_id_49015 < 0 and _index_id_49010 >= _end_id_49020 {
-                            let i : Int = _index_id_49010;
+                        let _range_id_49016 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49019 : Int = _range_id_49016::Start;
+                        let _step_id_49024 : Int = _range_id_49016::Step;
+                        let _end_id_49029 : Int = _range_id_49016::End;
+                        while _step_id_49024 > 0 and _index_id_49019 <= _end_id_49029 or _step_id_49024 < 0 and _index_id_49019 >= _end_id_49029 {
+                            let i : Int = _index_id_49019;
                             Adjoint CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                            _index_id_49010 += _step_id_49015;
+                            _index_id_49019 += _step_id_49024;
                         }
 
                     }
@@ -500,7 +500,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_53981 : Unit = {
+                            let _generated_ident_53990 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -521,7 +521,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_53981
+                            _generated_ident_53990
                         }
 
                     }
@@ -546,7 +546,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_53995 : Unit = {
+                            let _generated_ident_54004 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -567,7 +567,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_53995
+                            _generated_ident_54004
                         }
 
                     }
@@ -594,7 +594,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         CRz(ctls[0], theta, qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54051 : Unit = {
+                        let _generated_ident_54060 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -611,7 +611,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54051
+                        _generated_ident_54060
                     }
 
                 }
@@ -645,7 +645,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             Controlled CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54079 : Unit = {
+                            let _generated_ident_54088 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -666,7 +666,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54079
+                            _generated_ident_54088
                         }
 
                     }
@@ -691,7 +691,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             Controlled Adjoint CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54093 : Unit = {
+                            let _generated_ident_54102 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -712,7 +712,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54093
+                            _generated_ident_54102
                         }
 
                     }
@@ -739,7 +739,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54135 : Unit = {
+                        let _generated_ident_54144 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -756,7 +756,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54135
+                        _generated_ident_54144
                     }
 
                 }
@@ -773,7 +773,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                         Adjoint CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54149 : Unit = {
+                        let _generated_ident_54158 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -790,7 +790,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54149
+                        _generated_ident_54158
                     }
 
                 }
@@ -821,7 +821,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54163 : Unit = {
+                            let _generated_ident_54172 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -842,7 +842,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54163
+                            _generated_ident_54172
                         }
 
                     }
@@ -867,7 +867,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54177 : Unit = {
+                            let _generated_ident_54186 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -888,7 +888,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54177
+                            _generated_ident_54186
                         }
 
                     }
@@ -921,7 +921,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCZ(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54219 : Unit = {
+                            let _generated_ident_54228 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -942,7 +942,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54219
+                            _generated_ident_54228
                         }
 
                     }
@@ -967,7 +967,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                             CCZ(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54233 : Unit = {
+                            let _generated_ident_54242 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -988,7 +988,7 @@ fn grover_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54233
+                            _generated_ident_54242
                         }
 
                     }
@@ -1037,13 +1037,13 @@ fn grover_sample_full_pipeline_reachable_items() {
         operation MResetEachZ(register : Qubit[]) : Result[] {
             mutable results : Result[] = [];
             {
-                let _array_id_49646 : Qubit[] = register;
-                let _len_id_49650 : Int = Length(_array_id_49646);
-                mutable _index_id_49655 : Int = 0;
-                while _index_id_49655 < _len_id_49650 {
-                    let qubit : Qubit = _array_id_49646[_index_id_49655];
+                let _array_id_49655 : Qubit[] = register;
+                let _len_id_49659 : Int = Length(_array_id_49655);
+                mutable _index_id_49664 : Int = 0;
+                while _index_id_49664 < _len_id_49659 {
+                    let qubit : Qubit = _array_id_49655[_index_id_49664];
                     results += [MResetZ(qubit)];
-                    _index_id_49655 += 1;
+                    _index_id_49664 += 1;
                 }
 
             }

--- a/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
+++ b/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
@@ -148,17 +148,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47781 : Qubit[] = target;
-                    let _len_id_47785 : Int = Length(_array_id_47781);
-                    mutable _index_id_47790 : Int = 0;
-                    while _index_id_47790 < _len_id_47785 {
-                        let q : Qubit = _array_id_47781[_index_id_47790];
+                    let _array_id_47790 : Qubit[] = target;
+                    let _len_id_47794 : Int = Length(_array_id_47790);
+                    mutable _index_id_47799 : Int = 0;
+                    while _index_id_47799 < _len_id_47794 {
+                        let q : Qubit = _array_id_47790[_index_id_47799];
                         if runningValue &&& 1 != 0 {
                             X(q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47790 += 1;
+                        _index_id_47799 += 1;
                     }
 
                 }
@@ -169,17 +169,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47809 : Qubit[] = target;
-                    let _len_id_47813 : Int = Length(_array_id_47809);
-                    mutable _index_id_47818 : Int = 0;
-                    while _index_id_47818 < _len_id_47813 {
-                        let q : Qubit = _array_id_47809[_index_id_47818];
+                    let _array_id_47818 : Qubit[] = target;
+                    let _len_id_47822 : Int = Length(_array_id_47818);
+                    mutable _index_id_47827 : Int = 0;
+                    while _index_id_47827 < _len_id_47822 {
+                        let q : Qubit = _array_id_47818[_index_id_47827];
                         if runningValue &&& 1 != 0 {
                             X(q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47818 += 1;
+                        _index_id_47827 += 1;
                     }
 
                 }
@@ -190,17 +190,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47837 : Qubit[] = target;
-                    let _len_id_47841 : Int = Length(_array_id_47837);
-                    mutable _index_id_47846 : Int = 0;
-                    while _index_id_47846 < _len_id_47841 {
-                        let q : Qubit = _array_id_47837[_index_id_47846];
+                    let _array_id_47846 : Qubit[] = target;
+                    let _len_id_47850 : Int = Length(_array_id_47846);
+                    mutable _index_id_47855 : Int = 0;
+                    while _index_id_47855 < _len_id_47850 {
+                        let q : Qubit = _array_id_47846[_index_id_47855];
                         if runningValue &&& 1 != 0 {
                             Controlled X(ctls, q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47846 += 1;
+                        _index_id_47855 += 1;
                     }
 
                 }
@@ -211,17 +211,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47865 : Qubit[] = target;
-                    let _len_id_47869 : Int = Length(_array_id_47865);
-                    mutable _index_id_47874 : Int = 0;
-                    while _index_id_47874 < _len_id_47869 {
-                        let q : Qubit = _array_id_47865[_index_id_47874];
+                    let _array_id_47874 : Qubit[] = target;
+                    let _len_id_47878 : Int = Length(_array_id_47874);
+                    mutable _index_id_47883 : Int = 0;
+                    while _index_id_47883 < _len_id_47878 {
+                        let q : Qubit = _array_id_47874[_index_id_47883];
                         if runningValue &&& 1 != 0 {
                             Controlled X(ctls, q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47874 += 1;
+                        _index_id_47883 += 1;
                     }
 
                 }
@@ -430,27 +430,27 @@ fn shor_sample_full_pipeline_reachable_items() {
         operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
             body ... {
                 {
-                    let _range_id_48949 : Range = 0..2..Length(ctls) - 2;
-                    mutable _index_id_48952 : Int = _range_id_48949::Start;
-                    let _step_id_48957 : Int = _range_id_48949::Step;
-                    let _end_id_48962 : Int = _range_id_48949::End;
-                    while _step_id_48957 > 0 and _index_id_48952 <= _end_id_48962 or _step_id_48957 < 0 and _index_id_48952 >= _end_id_48962 {
-                        let i : Int = _index_id_48952;
+                    let _range_id_48958 : Range = 0..2..Length(ctls) - 2;
+                    mutable _index_id_48961 : Int = _range_id_48958::Start;
+                    let _step_id_48966 : Int = _range_id_48958::Step;
+                    let _end_id_48971 : Int = _range_id_48958::End;
+                    while _step_id_48966 > 0 and _index_id_48961 <= _end_id_48971 or _step_id_48966 < 0 and _index_id_48961 >= _end_id_48971 {
+                        let i : Int = _index_id_48961;
                         CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                        _index_id_48952 += _step_id_48957;
+                        _index_id_48961 += _step_id_48966;
                     }
 
                 }
 
                 {
-                    let _range_id_48992 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
-                    mutable _index_id_48995 : Int = _range_id_48992::Start;
-                    let _step_id_49000 : Int = _range_id_48992::Step;
-                    let _end_id_49005 : Int = _range_id_48992::End;
-                    while _step_id_49000 > 0 and _index_id_48995 <= _end_id_49005 or _step_id_49000 < 0 and _index_id_48995 >= _end_id_49005 {
-                        let i : Int = _index_id_48995;
+                    let _range_id_49001 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
+                    mutable _index_id_49004 : Int = _range_id_49001::Start;
+                    let _step_id_49009 : Int = _range_id_49001::Step;
+                    let _end_id_49014 : Int = _range_id_49001::End;
+                    while _step_id_49009 > 0 and _index_id_49004 <= _end_id_49014 or _step_id_49009 < 0 and _index_id_49004 >= _end_id_49014 {
+                        let i : Int = _index_id_49004;
                         CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                        _index_id_48995 += _step_id_49000;
+                        _index_id_49004 += _step_id_49009;
                     }
 
                 }
@@ -460,14 +460,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(ctls) / 2 - 2 - adjustment;
                     {
-                        let _range_id_49035 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49038 : Int = _range_id_49035::Start;
-                        let _step_id_49043 : Int = _range_id_49035::Step;
-                        let _end_id_49048 : Int = _range_id_49035::End;
-                        while _step_id_49043 > 0 and _index_id_49038 <= _end_id_49048 or _step_id_49043 < 0 and _index_id_49038 >= _end_id_49048 {
-                            let i : Int = _index_id_49038;
+                        let _range_id_49044 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49047 : Int = _range_id_49044::Start;
+                        let _step_id_49052 : Int = _range_id_49044::Step;
+                        let _end_id_49057 : Int = _range_id_49044::End;
+                        while _step_id_49052 > 0 and _index_id_49047 <= _end_id_49057 or _step_id_49052 < 0 and _index_id_49047 >= _end_id_49057 {
+                            let i : Int = _index_id_49047;
                             Adjoint CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                            _index_id_49038 += _step_id_49043;
+                            _index_id_49047 += _step_id_49052;
                         }
 
                     }
@@ -477,14 +477,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..2..Length(ctls) - 2;
                     {
-                        let _range_id_49078 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49081 : Int = _range_id_49078::Start;
-                        let _step_id_49086 : Int = _range_id_49078::Step;
-                        let _end_id_49091 : Int = _range_id_49078::End;
-                        while _step_id_49086 > 0 and _index_id_49081 <= _end_id_49091 or _step_id_49086 < 0 and _index_id_49081 >= _end_id_49091 {
-                            let i : Int = _index_id_49081;
+                        let _range_id_49087 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49090 : Int = _range_id_49087::Start;
+                        let _step_id_49095 : Int = _range_id_49087::Step;
+                        let _end_id_49100 : Int = _range_id_49087::End;
+                        while _step_id_49095 > 0 and _index_id_49090 <= _end_id_49100 or _step_id_49095 < 0 and _index_id_49090 >= _end_id_49100 {
+                            let i : Int = _index_id_49090;
                             Adjoint CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                            _index_id_49081 += _step_id_49086;
+                            _index_id_49090 += _step_id_49095;
                         }
 
                     }
@@ -597,7 +597,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54052 : Unit = {
+                            let _generated_ident_54061 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -618,7 +618,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54052
+                            _generated_ident_54061
                         }
 
                     }
@@ -643,7 +643,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_54066 : Unit = {
+                            let _generated_ident_54075 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -664,7 +664,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54066
+                            _generated_ident_54075
                         }
 
                     }
@@ -749,13 +749,13 @@ fn shor_sample_full_pipeline_reachable_items() {
         }
         operation ResetAll(qubits : Qubit[]) : Unit {
             {
-                let _array_id_49450 : Qubit[] = qubits;
-                let _len_id_49454 : Int = Length(_array_id_49450);
-                mutable _index_id_49459 : Int = 0;
-                while _index_id_49459 < _len_id_49454 {
-                    let q : Qubit = _array_id_49450[_index_id_49459];
+                let _array_id_49459 : Qubit[] = qubits;
+                let _len_id_49463 : Int = Length(_array_id_49459);
+                mutable _index_id_49468 : Int = 0;
+                while _index_id_49468 < _len_id_49463 {
+                    let q : Qubit = _array_id_49459[_index_id_49468];
                     Reset(q);
-                    _index_id_49459 += 1;
+                    _index_id_49468 += 1;
                 }
 
             }
@@ -865,7 +865,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         CRz(ctls[0], theta, qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54122 : Unit = {
+                        let _generated_ident_54131 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -882,7 +882,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54122
+                        _generated_ident_54131
                     }
 
                 }
@@ -916,7 +916,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             Controlled CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54150 : Unit = {
+                            let _generated_ident_54159 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -937,7 +937,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54150
+                            _generated_ident_54159
                         }
 
                     }
@@ -962,7 +962,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             Controlled Adjoint CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54164 : Unit = {
+                            let _generated_ident_54173 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -983,7 +983,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54164
+                            _generated_ident_54173
                         }
 
                     }
@@ -1064,7 +1064,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54206 : Unit = {
+                        let _generated_ident_54215 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -1081,7 +1081,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54206
+                        _generated_ident_54215
                     }
 
                 }
@@ -1098,7 +1098,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         Adjoint CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54220 : Unit = {
+                        let _generated_ident_54229 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -1115,7 +1115,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54220
+                        _generated_ident_54229
                     }
 
                 }
@@ -1146,7 +1146,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54234 : Unit = {
+                            let _generated_ident_54243 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -1167,7 +1167,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54234
+                            _generated_ident_54243
                         }
 
                     }
@@ -1192,7 +1192,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54248 : Unit = {
+                            let _generated_ident_54257 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -1213,7 +1213,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54248
+                            _generated_ident_54257
                         }
 
                     }
@@ -1722,27 +1722,27 @@ fn shor_sample_full_pipeline_reachable_items() {
             body ... {
                 Fact(Length(xs) <= Length(ys), $"Input register ys must be at least as long as xs.");
                 {
-                    let _range_id_51250 : Range = 1..Length(xs) - 1;
-                    mutable _index_id_51253 : Int = _range_id_51250::Start;
-                    let _step_id_51258 : Int = _range_id_51250::Step;
-                    let _end_id_51263 : Int = _range_id_51250::End;
-                    while _step_id_51258 > 0 and _index_id_51253 <= _end_id_51263 or _step_id_51258 < 0 and _index_id_51253 >= _end_id_51263 {
-                        let i : Int = _index_id_51253;
+                    let _range_id_51259 : Range = 1..Length(xs) - 1;
+                    mutable _index_id_51262 : Int = _range_id_51259::Start;
+                    let _step_id_51267 : Int = _range_id_51259::Step;
+                    let _end_id_51272 : Int = _range_id_51259::End;
+                    while _step_id_51267 > 0 and _index_id_51262 <= _end_id_51272 or _step_id_51267 < 0 and _index_id_51262 >= _end_id_51272 {
+                        let i : Int = _index_id_51262;
                         CNOT(xs[i], ys[i]);
-                        _index_id_51253 += _step_id_51258;
+                        _index_id_51262 += _step_id_51267;
                     }
 
                 }
 
                 {
-                    let _range_id_51293 : Range = Length(xs) - 2..-1..1;
-                    mutable _index_id_51296 : Int = _range_id_51293::Start;
-                    let _step_id_51301 : Int = _range_id_51293::Step;
-                    let _end_id_51306 : Int = _range_id_51293::End;
-                    while _step_id_51301 > 0 and _index_id_51296 <= _end_id_51306 or _step_id_51301 < 0 and _index_id_51296 >= _end_id_51306 {
-                        let i : Int = _index_id_51296;
+                    let _range_id_51302 : Range = Length(xs) - 2..-1..1;
+                    mutable _index_id_51305 : Int = _range_id_51302::Start;
+                    let _step_id_51310 : Int = _range_id_51302::Step;
+                    let _end_id_51315 : Int = _range_id_51302::End;
+                    while _step_id_51310 > 0 and _index_id_51305 <= _end_id_51315 or _step_id_51310 < 0 and _index_id_51305 >= _end_id_51315 {
+                        let i : Int = _index_id_51305;
                         CNOT(xs[i], xs[i + 1]);
-                        _index_id_51296 += _step_id_51301;
+                        _index_id_51305 += _step_id_51310;
                     }
 
                 }
@@ -1753,14 +1753,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 2..-1..1;
                     {
-                        let _range_id_51336 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51339 : Int = _range_id_51336::Start;
-                        let _step_id_51344 : Int = _range_id_51336::Step;
-                        let _end_id_51349 : Int = _range_id_51336::End;
-                        while _step_id_51344 > 0 and _index_id_51339 <= _end_id_51349 or _step_id_51344 < 0 and _index_id_51339 >= _end_id_51349 {
-                            let i : Int = _index_id_51339;
+                        let _range_id_51345 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51348 : Int = _range_id_51345::Start;
+                        let _step_id_51353 : Int = _range_id_51345::Step;
+                        let _end_id_51358 : Int = _range_id_51345::End;
+                        while _step_id_51353 > 0 and _index_id_51348 <= _end_id_51358 or _step_id_51353 < 0 and _index_id_51348 >= _end_id_51358 {
+                            let i : Int = _index_id_51348;
                             Adjoint CNOT(xs[i], xs[i + 1]);
-                            _index_id_51339 += _step_id_51344;
+                            _index_id_51348 += _step_id_51353;
                         }
 
                     }
@@ -1770,14 +1770,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 1..Length(xs) - 1;
                     {
-                        let _range_id_51379 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51382 : Int = _range_id_51379::Start;
-                        let _step_id_51387 : Int = _range_id_51379::Step;
-                        let _end_id_51392 : Int = _range_id_51379::End;
-                        while _step_id_51387 > 0 and _index_id_51382 <= _end_id_51392 or _step_id_51387 < 0 and _index_id_51382 >= _end_id_51392 {
-                            let i : Int = _index_id_51382;
+                        let _range_id_51388 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51391 : Int = _range_id_51388::Start;
+                        let _step_id_51396 : Int = _range_id_51388::Step;
+                        let _end_id_51401 : Int = _range_id_51388::End;
+                        while _step_id_51396 > 0 and _index_id_51391 <= _end_id_51401 or _step_id_51396 < 0 and _index_id_51391 >= _end_id_51401 {
+                            let i : Int = _index_id_51391;
                             Adjoint CNOT(xs[i], ys[i]);
-                            _index_id_51382 += _step_id_51387;
+                            _index_id_51391 += _step_id_51396;
                         }
 
                     }
@@ -1788,27 +1788,27 @@ fn shor_sample_full_pipeline_reachable_items() {
             controlled (ctls, ...) {
                 Fact(Length(xs) <= Length(ys), $"Input register ys must be at least as long as xs.");
                 {
-                    let _range_id_51422 : Range = 1..Length(xs) - 1;
-                    mutable _index_id_51425 : Int = _range_id_51422::Start;
-                    let _step_id_51430 : Int = _range_id_51422::Step;
-                    let _end_id_51435 : Int = _range_id_51422::End;
-                    while _step_id_51430 > 0 and _index_id_51425 <= _end_id_51435 or _step_id_51430 < 0 and _index_id_51425 >= _end_id_51435 {
-                        let i : Int = _index_id_51425;
+                    let _range_id_51431 : Range = 1..Length(xs) - 1;
+                    mutable _index_id_51434 : Int = _range_id_51431::Start;
+                    let _step_id_51439 : Int = _range_id_51431::Step;
+                    let _end_id_51444 : Int = _range_id_51431::End;
+                    while _step_id_51439 > 0 and _index_id_51434 <= _end_id_51444 or _step_id_51439 < 0 and _index_id_51434 >= _end_id_51444 {
+                        let i : Int = _index_id_51434;
                         Controlled CNOT(ctls, (xs[i], ys[i]));
-                        _index_id_51425 += _step_id_51430;
+                        _index_id_51434 += _step_id_51439;
                     }
 
                 }
 
                 {
-                    let _range_id_51465 : Range = Length(xs) - 2..-1..1;
-                    mutable _index_id_51468 : Int = _range_id_51465::Start;
-                    let _step_id_51473 : Int = _range_id_51465::Step;
-                    let _end_id_51478 : Int = _range_id_51465::End;
-                    while _step_id_51473 > 0 and _index_id_51468 <= _end_id_51478 or _step_id_51473 < 0 and _index_id_51468 >= _end_id_51478 {
-                        let i : Int = _index_id_51468;
+                    let _range_id_51474 : Range = Length(xs) - 2..-1..1;
+                    mutable _index_id_51477 : Int = _range_id_51474::Start;
+                    let _step_id_51482 : Int = _range_id_51474::Step;
+                    let _end_id_51487 : Int = _range_id_51474::End;
+                    while _step_id_51482 > 0 and _index_id_51477 <= _end_id_51487 or _step_id_51482 < 0 and _index_id_51477 >= _end_id_51487 {
+                        let i : Int = _index_id_51477;
                         Controlled CNOT(ctls, (xs[i], xs[i + 1]));
-                        _index_id_51468 += _step_id_51473;
+                        _index_id_51477 += _step_id_51482;
                     }
 
                 }
@@ -1819,14 +1819,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 2..-1..1;
                     {
-                        let _range_id_51508 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51511 : Int = _range_id_51508::Start;
-                        let _step_id_51516 : Int = _range_id_51508::Step;
-                        let _end_id_51521 : Int = _range_id_51508::End;
-                        while _step_id_51516 > 0 and _index_id_51511 <= _end_id_51521 or _step_id_51516 < 0 and _index_id_51511 >= _end_id_51521 {
-                            let i : Int = _index_id_51511;
+                        let _range_id_51517 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51520 : Int = _range_id_51517::Start;
+                        let _step_id_51525 : Int = _range_id_51517::Step;
+                        let _end_id_51530 : Int = _range_id_51517::End;
+                        while _step_id_51525 > 0 and _index_id_51520 <= _end_id_51530 or _step_id_51525 < 0 and _index_id_51520 >= _end_id_51530 {
+                            let i : Int = _index_id_51520;
                             Controlled Adjoint CNOT(ctls, (xs[i], xs[i + 1]));
-                            _index_id_51511 += _step_id_51516;
+                            _index_id_51520 += _step_id_51525;
                         }
 
                     }
@@ -1836,14 +1836,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 1..Length(xs) - 1;
                     {
-                        let _range_id_51551 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51554 : Int = _range_id_51551::Start;
-                        let _step_id_51559 : Int = _range_id_51551::Step;
-                        let _end_id_51564 : Int = _range_id_51551::End;
-                        while _step_id_51559 > 0 and _index_id_51554 <= _end_id_51564 or _step_id_51559 < 0 and _index_id_51554 >= _end_id_51564 {
-                            let i : Int = _index_id_51554;
+                        let _range_id_51560 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51563 : Int = _range_id_51560::Start;
+                        let _step_id_51568 : Int = _range_id_51560::Step;
+                        let _end_id_51573 : Int = _range_id_51560::End;
+                        while _step_id_51568 > 0 and _index_id_51563 <= _end_id_51573 or _step_id_51568 < 0 and _index_id_51563 >= _end_id_51573 {
+                            let i : Int = _index_id_51563;
                             Controlled Adjoint CNOT(ctls, (xs[i], ys[i]));
-                            _index_id_51554 += _step_id_51559;
+                            _index_id_51563 += _step_id_51568;
                         }
 
                     }
@@ -1862,28 +1862,28 @@ fn shor_sample_full_pipeline_reachable_items() {
             controlled (controls, ...) {
                 Fact(Length(xs) == Length(ys), $"Input registers must have the same number of qubits.");
                 {
-                    let _range_id_51594 : Range = 0..Length(xs) - 2;
-                    mutable _index_id_51597 : Int = _range_id_51594::Start;
-                    let _step_id_51602 : Int = _range_id_51594::Step;
-                    let _end_id_51607 : Int = _range_id_51594::End;
-                    while _step_id_51602 > 0 and _index_id_51597 <= _end_id_51607 or _step_id_51602 < 0 and _index_id_51597 >= _end_id_51607 {
-                        let idx : Int = _index_id_51597;
+                    let _range_id_51603 : Range = 0..Length(xs) - 2;
+                    mutable _index_id_51606 : Int = _range_id_51603::Start;
+                    let _step_id_51611 : Int = _range_id_51603::Step;
+                    let _end_id_51616 : Int = _range_id_51603::End;
+                    while _step_id_51611 > 0 and _index_id_51606 <= _end_id_51616 or _step_id_51611 < 0 and _index_id_51606 >= _end_id_51616 {
+                        let idx : Int = _index_id_51606;
                         CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                        _index_id_51597 += _step_id_51602;
+                        _index_id_51606 += _step_id_51611;
                     }
 
                 }
 
                 {
-                    let _range_id_51637 : Range = Length(xs) - 1..-1..1;
-                    mutable _index_id_51640 : Int = _range_id_51637::Start;
-                    let _step_id_51645 : Int = _range_id_51637::Step;
-                    let _end_id_51650 : Int = _range_id_51637::End;
-                    while _step_id_51645 > 0 and _index_id_51640 <= _end_id_51650 or _step_id_51645 < 0 and _index_id_51640 >= _end_id_51650 {
-                        let idx : Int = _index_id_51640;
+                    let _range_id_51646 : Range = Length(xs) - 1..-1..1;
+                    mutable _index_id_51649 : Int = _range_id_51646::Start;
+                    let _step_id_51654 : Int = _range_id_51646::Step;
+                    let _end_id_51659 : Int = _range_id_51646::End;
+                    while _step_id_51654 > 0 and _index_id_51649 <= _end_id_51659 or _step_id_51654 < 0 and _index_id_51649 >= _end_id_51659 {
+                        let idx : Int = _index_id_51649;
                         Controlled CNOT(controls, (xs[idx], ys[idx]));
                         CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
-                        _index_id_51640 += _step_id_51645;
+                        _index_id_51649 += _step_id_51654;
                     }
 
                 }
@@ -1894,15 +1894,15 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 1..-1..1;
                     {
-                        let _range_id_51680 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51683 : Int = _range_id_51680::Start;
-                        let _step_id_51688 : Int = _range_id_51680::Step;
-                        let _end_id_51693 : Int = _range_id_51680::End;
-                        while _step_id_51688 > 0 and _index_id_51683 <= _end_id_51693 or _step_id_51688 < 0 and _index_id_51683 >= _end_id_51693 {
-                            let idx : Int = _index_id_51683;
+                        let _range_id_51689 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51692 : Int = _range_id_51689::Start;
+                        let _step_id_51697 : Int = _range_id_51689::Step;
+                        let _end_id_51702 : Int = _range_id_51689::End;
+                        while _step_id_51697 > 0 and _index_id_51692 <= _end_id_51702 or _step_id_51697 < 0 and _index_id_51692 >= _end_id_51702 {
+                            let idx : Int = _index_id_51692;
                             Adjoint CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
                             Adjoint Controlled CNOT(controls, (xs[idx], ys[idx]));
-                            _index_id_51683 += _step_id_51688;
+                            _index_id_51692 += _step_id_51697;
                         }
 
                     }
@@ -1912,14 +1912,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(xs) - 2;
                     {
-                        let _range_id_51723 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51726 : Int = _range_id_51723::Start;
-                        let _step_id_51731 : Int = _range_id_51723::Step;
-                        let _end_id_51736 : Int = _range_id_51723::End;
-                        while _step_id_51731 > 0 and _index_id_51726 <= _end_id_51736 or _step_id_51731 < 0 and _index_id_51726 >= _end_id_51736 {
-                            let idx : Int = _index_id_51726;
+                        let _range_id_51732 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51735 : Int = _range_id_51732::Start;
+                        let _step_id_51740 : Int = _range_id_51732::Step;
+                        let _end_id_51745 : Int = _range_id_51732::End;
+                        while _step_id_51740 > 0 and _index_id_51735 <= _end_id_51745 or _step_id_51740 < 0 and _index_id_51735 >= _end_id_51745 {
+                            let idx : Int = _index_id_51735;
                             Adjoint CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                            _index_id_51726 += _step_id_51731;
+                            _index_id_51735 += _step_id_51740;
                         }
 
                     }
@@ -1940,29 +1940,29 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(Length(xs) > 0, $"Array should not be empty.");
                 let nQubits : Int = Length(xs);
                 {
-                    let _range_id_51766 : Range = 0..nQubits - 2;
-                    mutable _index_id_51769 : Int = _range_id_51766::Start;
-                    let _step_id_51774 : Int = _range_id_51766::Step;
-                    let _end_id_51779 : Int = _range_id_51766::End;
-                    while _step_id_51774 > 0 and _index_id_51769 <= _end_id_51779 or _step_id_51774 < 0 and _index_id_51769 >= _end_id_51779 {
-                        let idx : Int = _index_id_51769;
+                    let _range_id_51775 : Range = 0..nQubits - 2;
+                    mutable _index_id_51778 : Int = _range_id_51775::Start;
+                    let _step_id_51783 : Int = _range_id_51775::Step;
+                    let _end_id_51788 : Int = _range_id_51775::End;
+                    while _step_id_51783 > 0 and _index_id_51778 <= _end_id_51788 or _step_id_51783 < 0 and _index_id_51778 >= _end_id_51788 {
+                        let idx : Int = _index_id_51778;
                         CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                        _index_id_51769 += _step_id_51774;
+                        _index_id_51778 += _step_id_51783;
                     }
 
                 }
 
                 Controlled CCNOT(controls, (xs[nQubits - 1], ys[nQubits - 1], ys[nQubits]));
                 {
-                    let _range_id_51809 : Range = nQubits - 1..-1..1;
-                    mutable _index_id_51812 : Int = _range_id_51809::Start;
-                    let _step_id_51817 : Int = _range_id_51809::Step;
-                    let _end_id_51822 : Int = _range_id_51809::End;
-                    while _step_id_51817 > 0 and _index_id_51812 <= _end_id_51822 or _step_id_51817 < 0 and _index_id_51812 >= _end_id_51822 {
-                        let idx : Int = _index_id_51812;
+                    let _range_id_51818 : Range = nQubits - 1..-1..1;
+                    mutable _index_id_51821 : Int = _range_id_51818::Start;
+                    let _step_id_51826 : Int = _range_id_51818::Step;
+                    let _end_id_51831 : Int = _range_id_51818::End;
+                    while _step_id_51826 > 0 and _index_id_51821 <= _end_id_51831 or _step_id_51826 < 0 and _index_id_51821 >= _end_id_51831 {
+                        let idx : Int = _index_id_51821;
                         Controlled CNOT(controls, (xs[idx], ys[idx]));
                         CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
-                        _index_id_51812 += _step_id_51817;
+                        _index_id_51821 += _step_id_51826;
                     }
 
                 }
@@ -1975,15 +1975,15 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = nQubits - 1..-1..1;
                     {
-                        let _range_id_51852 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51855 : Int = _range_id_51852::Start;
-                        let _step_id_51860 : Int = _range_id_51852::Step;
-                        let _end_id_51865 : Int = _range_id_51852::End;
-                        while _step_id_51860 > 0 and _index_id_51855 <= _end_id_51865 or _step_id_51860 < 0 and _index_id_51855 >= _end_id_51865 {
-                            let idx : Int = _index_id_51855;
+                        let _range_id_51861 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51864 : Int = _range_id_51861::Start;
+                        let _step_id_51869 : Int = _range_id_51861::Step;
+                        let _end_id_51874 : Int = _range_id_51861::End;
+                        while _step_id_51869 > 0 and _index_id_51864 <= _end_id_51874 or _step_id_51869 < 0 and _index_id_51864 >= _end_id_51874 {
+                            let idx : Int = _index_id_51864;
                             Adjoint CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
                             Adjoint Controlled CNOT(controls, (xs[idx], ys[idx]));
-                            _index_id_51855 += _step_id_51860;
+                            _index_id_51864 += _step_id_51869;
                         }
 
                     }
@@ -1994,14 +1994,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..nQubits - 2;
                     {
-                        let _range_id_51895 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51898 : Int = _range_id_51895::Start;
-                        let _step_id_51903 : Int = _range_id_51895::Step;
-                        let _end_id_51908 : Int = _range_id_51895::End;
-                        while _step_id_51903 > 0 and _index_id_51898 <= _end_id_51908 or _step_id_51903 < 0 and _index_id_51898 >= _end_id_51908 {
-                            let idx : Int = _index_id_51898;
+                        let _range_id_51904 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51907 : Int = _range_id_51904::Start;
+                        let _step_id_51912 : Int = _range_id_51904::Step;
+                        let _end_id_51917 : Int = _range_id_51904::End;
+                        while _step_id_51912 > 0 and _index_id_51907 <= _end_id_51917 or _step_id_51912 < 0 and _index_id_51907 >= _end_id_51917 {
+                            let idx : Int = _index_id_51907;
                             Adjoint CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                            _index_id_51898 += _step_id_51903;
+                            _index_id_51907 += _step_id_51912;
                         }
 
                     }
@@ -2079,7 +2079,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54492 : Unit = {
+                    let _generated_ident_54501 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2094,7 +2094,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54492
+                    _generated_ident_54501
                 }
 
             }
@@ -2106,7 +2106,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54506 : Unit = {
+                    let _generated_ident_54515 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2121,7 +2121,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54506
+                    _generated_ident_54515
                 }
 
             }
@@ -2133,7 +2133,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54520 : Unit = {
+                    let _generated_ident_54529 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2148,7 +2148,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54520
+                    _generated_ident_54529
                 }
 
             }
@@ -2160,7 +2160,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54534 : Unit = {
+                    let _generated_ident_54543 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2175,7 +2175,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54534
+                    _generated_ident_54543
                 }
 
             }
@@ -2707,21 +2707,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54663 : Unit = {
+                        let _generated_ident_54672 : Unit = {
                             {
                                 {
-                                    let _range_id_52611 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52614 : Int = _range_id_52611::Start;
-                                    let _step_id_52619 : Int = _range_id_52611::Step;
-                                    let _end_id_52624 : Int = _range_id_52611::End;
-                                    while _step_id_52619 > 0 and _index_id_52614 <= _end_id_52624 or _step_id_52619 < 0 and _index_id_52614 >= _end_id_52624 {
-                                        let i : Int = _index_id_52614;
+                                    let _range_id_52620 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52623 : Int = _range_id_52620::Start;
+                                    let _step_id_52628 : Int = _range_id_52620::Step;
+                                    let _end_id_52633 : Int = _range_id_52620::End;
+                                    while _step_id_52628 > 0 and _index_id_52623 <= _end_id_52633 or _step_id_52628 < 0 and _index_id_52623 >= _end_id_52633 {
+                                        let i : Int = _index_id_52623;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52614 += _step_id_52619;
+                                        _index_id_52623 += _step_id_52628;
                                     }
 
                                 }
@@ -2760,18 +2760,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52654 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52657 : Int = _range_id_52654::Start;
-                                        let _step_id_52662 : Int = _range_id_52654::Step;
-                                        let _end_id_52667 : Int = _range_id_52654::End;
-                                        while _step_id_52662 > 0 and _index_id_52657 <= _end_id_52667 or _step_id_52662 < 0 and _index_id_52657 >= _end_id_52667 {
-                                            let i : Int = _index_id_52657;
+                                        let _range_id_52663 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52666 : Int = _range_id_52663::Start;
+                                        let _step_id_52671 : Int = _range_id_52663::Step;
+                                        let _end_id_52676 : Int = _range_id_52663::End;
+                                        while _step_id_52671 > 0 and _index_id_52666 <= _end_id_52676 or _step_id_52671 < 0 and _index_id_52666 >= _end_id_52676 {
+                                            let i : Int = _index_id_52666;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52657 += _step_id_52662;
+                                            _index_id_52666 += _step_id_52671;
                                         }
 
                                     }
@@ -2783,7 +2783,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54663
+                        _generated_ident_54672
                     }
 
                 }
@@ -2816,21 +2816,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54677 : Unit = {
+                        let _generated_ident_54686 : Unit = {
                             {
                                 {
-                                    let _range_id_52697 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52700 : Int = _range_id_52697::Start;
-                                    let _step_id_52705 : Int = _range_id_52697::Step;
-                                    let _end_id_52710 : Int = _range_id_52697::End;
-                                    while _step_id_52705 > 0 and _index_id_52700 <= _end_id_52710 or _step_id_52705 < 0 and _index_id_52700 >= _end_id_52710 {
-                                        let i : Int = _index_id_52700;
+                                    let _range_id_52706 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52709 : Int = _range_id_52706::Start;
+                                    let _step_id_52714 : Int = _range_id_52706::Step;
+                                    let _end_id_52719 : Int = _range_id_52706::End;
+                                    while _step_id_52714 > 0 and _index_id_52709 <= _end_id_52719 or _step_id_52714 < 0 and _index_id_52709 >= _end_id_52719 {
+                                        let i : Int = _index_id_52709;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52700 += _step_id_52705;
+                                        _index_id_52709 += _step_id_52714;
                                     }
 
                                 }
@@ -2869,18 +2869,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52740 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52743 : Int = _range_id_52740::Start;
-                                        let _step_id_52748 : Int = _range_id_52740::Step;
-                                        let _end_id_52753 : Int = _range_id_52740::End;
-                                        while _step_id_52748 > 0 and _index_id_52743 <= _end_id_52753 or _step_id_52748 < 0 and _index_id_52743 >= _end_id_52753 {
-                                            let i : Int = _index_id_52743;
+                                        let _range_id_52749 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52752 : Int = _range_id_52749::Start;
+                                        let _step_id_52757 : Int = _range_id_52749::Step;
+                                        let _end_id_52762 : Int = _range_id_52749::End;
+                                        while _step_id_52757 > 0 and _index_id_52752 <= _end_id_52762 or _step_id_52757 < 0 and _index_id_52752 >= _end_id_52762 {
+                                            let i : Int = _index_id_52752;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52743 += _step_id_52748;
+                                            _index_id_52752 += _step_id_52757;
                                         }
 
                                     }
@@ -2892,7 +2892,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54677
+                        _generated_ident_54686
                     }
 
                 }
@@ -2925,21 +2925,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54691 : Unit = {
+                        let _generated_ident_54700 : Unit = {
                             {
                                 {
-                                    let _range_id_52783 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52786 : Int = _range_id_52783::Start;
-                                    let _step_id_52791 : Int = _range_id_52783::Step;
-                                    let _end_id_52796 : Int = _range_id_52783::End;
-                                    while _step_id_52791 > 0 and _index_id_52786 <= _end_id_52796 or _step_id_52791 < 0 and _index_id_52786 >= _end_id_52796 {
-                                        let i : Int = _index_id_52786;
+                                    let _range_id_52792 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52795 : Int = _range_id_52792::Start;
+                                    let _step_id_52800 : Int = _range_id_52792::Step;
+                                    let _end_id_52805 : Int = _range_id_52792::End;
+                                    while _step_id_52800 > 0 and _index_id_52795 <= _end_id_52805 or _step_id_52800 < 0 and _index_id_52795 >= _end_id_52805 {
+                                        let i : Int = _index_id_52795;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52786 += _step_id_52791;
+                                        _index_id_52795 += _step_id_52800;
                                     }
 
                                 }
@@ -2978,18 +2978,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52826 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52829 : Int = _range_id_52826::Start;
-                                        let _step_id_52834 : Int = _range_id_52826::Step;
-                                        let _end_id_52839 : Int = _range_id_52826::End;
-                                        while _step_id_52834 > 0 and _index_id_52829 <= _end_id_52839 or _step_id_52834 < 0 and _index_id_52829 >= _end_id_52839 {
-                                            let i : Int = _index_id_52829;
+                                        let _range_id_52835 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52838 : Int = _range_id_52835::Start;
+                                        let _step_id_52843 : Int = _range_id_52835::Step;
+                                        let _end_id_52848 : Int = _range_id_52835::End;
+                                        while _step_id_52843 > 0 and _index_id_52838 <= _end_id_52848 or _step_id_52843 < 0 and _index_id_52838 >= _end_id_52848 {
+                                            let i : Int = _index_id_52838;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52829 += _step_id_52834;
+                                            _index_id_52838 += _step_id_52843;
                                         }
 
                                     }
@@ -3001,7 +3001,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54691
+                        _generated_ident_54700
                     }
 
                 }
@@ -3034,21 +3034,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54705 : Unit = {
+                        let _generated_ident_54714 : Unit = {
                             {
                                 {
-                                    let _range_id_52869 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52872 : Int = _range_id_52869::Start;
-                                    let _step_id_52877 : Int = _range_id_52869::Step;
-                                    let _end_id_52882 : Int = _range_id_52869::End;
-                                    while _step_id_52877 > 0 and _index_id_52872 <= _end_id_52882 or _step_id_52877 < 0 and _index_id_52872 >= _end_id_52882 {
-                                        let i : Int = _index_id_52872;
+                                    let _range_id_52878 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52881 : Int = _range_id_52878::Start;
+                                    let _step_id_52886 : Int = _range_id_52878::Step;
+                                    let _end_id_52891 : Int = _range_id_52878::End;
+                                    while _step_id_52886 > 0 and _index_id_52881 <= _end_id_52891 or _step_id_52886 < 0 and _index_id_52881 >= _end_id_52891 {
+                                        let i : Int = _index_id_52881;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52872 += _step_id_52877;
+                                        _index_id_52881 += _step_id_52886;
                                     }
 
                                 }
@@ -3087,18 +3087,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52912 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52915 : Int = _range_id_52912::Start;
-                                        let _step_id_52920 : Int = _range_id_52912::Step;
-                                        let _end_id_52925 : Int = _range_id_52912::End;
-                                        while _step_id_52920 > 0 and _index_id_52915 <= _end_id_52925 or _step_id_52920 < 0 and _index_id_52915 >= _end_id_52925 {
-                                            let i : Int = _index_id_52915;
+                                        let _range_id_52921 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52924 : Int = _range_id_52921::Start;
+                                        let _step_id_52929 : Int = _range_id_52921::Step;
+                                        let _end_id_52934 : Int = _range_id_52921::End;
+                                        while _step_id_52929 > 0 and _index_id_52924 <= _end_id_52934 or _step_id_52929 < 0 and _index_id_52924 >= _end_id_52934 {
+                                            let i : Int = _index_id_52924;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52915 += _step_id_52920;
+                                            _index_id_52924 += _step_id_52929;
                                         }
 
                                     }
@@ -3110,7 +3110,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54705
+                        _generated_ident_54714
                     }
 
                 }

--- a/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
+++ b/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
@@ -148,17 +148,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47710 : Qubit[] = target;
-                    let _len_id_47714 : Int = Length(_array_id_47710);
-                    mutable _index_id_47719 : Int = 0;
-                    while _index_id_47719 < _len_id_47714 {
-                        let q : Qubit = _array_id_47710[_index_id_47719];
+                    let _array_id_47719 : Qubit[] = target;
+                    let _len_id_47723 : Int = Length(_array_id_47719);
+                    mutable _index_id_47728 : Int = 0;
+                    while _index_id_47728 < _len_id_47723 {
+                        let q : Qubit = _array_id_47719[_index_id_47728];
                         if runningValue &&& 1 != 0 {
                             X(q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47719 += 1;
+                        _index_id_47728 += 1;
                     }
 
                 }
@@ -169,17 +169,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47738 : Qubit[] = target;
-                    let _len_id_47742 : Int = Length(_array_id_47738);
-                    mutable _index_id_47747 : Int = 0;
-                    while _index_id_47747 < _len_id_47742 {
-                        let q : Qubit = _array_id_47738[_index_id_47747];
+                    let _array_id_47747 : Qubit[] = target;
+                    let _len_id_47751 : Int = Length(_array_id_47747);
+                    mutable _index_id_47756 : Int = 0;
+                    while _index_id_47756 < _len_id_47751 {
+                        let q : Qubit = _array_id_47747[_index_id_47756];
                         if runningValue &&& 1 != 0 {
                             X(q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47747 += 1;
+                        _index_id_47756 += 1;
                     }
 
                 }
@@ -190,17 +190,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47766 : Qubit[] = target;
-                    let _len_id_47770 : Int = Length(_array_id_47766);
-                    mutable _index_id_47775 : Int = 0;
-                    while _index_id_47775 < _len_id_47770 {
-                        let q : Qubit = _array_id_47766[_index_id_47775];
+                    let _array_id_47775 : Qubit[] = target;
+                    let _len_id_47779 : Int = Length(_array_id_47775);
+                    mutable _index_id_47784 : Int = 0;
+                    while _index_id_47784 < _len_id_47779 {
+                        let q : Qubit = _array_id_47775[_index_id_47784];
                         if runningValue &&& 1 != 0 {
                             Controlled X(ctls, q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47775 += 1;
+                        _index_id_47784 += 1;
                     }
 
                 }
@@ -211,17 +211,17 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(value >= 0, $"`value` must be non-negative.");
                 mutable runningValue : Int = value;
                 {
-                    let _array_id_47794 : Qubit[] = target;
-                    let _len_id_47798 : Int = Length(_array_id_47794);
-                    mutable _index_id_47803 : Int = 0;
-                    while _index_id_47803 < _len_id_47798 {
-                        let q : Qubit = _array_id_47794[_index_id_47803];
+                    let _array_id_47803 : Qubit[] = target;
+                    let _len_id_47807 : Int = Length(_array_id_47803);
+                    mutable _index_id_47812 : Int = 0;
+                    while _index_id_47812 < _len_id_47807 {
+                        let q : Qubit = _array_id_47803[_index_id_47812];
                         if runningValue &&& 1 != 0 {
                             Controlled X(ctls, q);
                         }
 
                         runningValue >>>= 1;
-                        _index_id_47803 += 1;
+                        _index_id_47812 += 1;
                     }
 
                 }
@@ -430,27 +430,27 @@ fn shor_sample_full_pipeline_reachable_items() {
         operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
             body ... {
                 {
-                    let _range_id_48878 : Range = 0..2..Length(ctls) - 2;
-                    mutable _index_id_48881 : Int = _range_id_48878::Start;
-                    let _step_id_48886 : Int = _range_id_48878::Step;
-                    let _end_id_48891 : Int = _range_id_48878::End;
-                    while _step_id_48886 > 0 and _index_id_48881 <= _end_id_48891 or _step_id_48886 < 0 and _index_id_48881 >= _end_id_48891 {
-                        let i : Int = _index_id_48881;
+                    let _range_id_48887 : Range = 0..2..Length(ctls) - 2;
+                    mutable _index_id_48890 : Int = _range_id_48887::Start;
+                    let _step_id_48895 : Int = _range_id_48887::Step;
+                    let _end_id_48900 : Int = _range_id_48887::End;
+                    while _step_id_48895 > 0 and _index_id_48890 <= _end_id_48900 or _step_id_48895 < 0 and _index_id_48890 >= _end_id_48900 {
+                        let i : Int = _index_id_48890;
                         CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                        _index_id_48881 += _step_id_48886;
+                        _index_id_48890 += _step_id_48895;
                     }
 
                 }
 
                 {
-                    let _range_id_48921 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
-                    mutable _index_id_48924 : Int = _range_id_48921::Start;
-                    let _step_id_48929 : Int = _range_id_48921::Step;
-                    let _end_id_48934 : Int = _range_id_48921::End;
-                    while _step_id_48929 > 0 and _index_id_48924 <= _end_id_48934 or _step_id_48929 < 0 and _index_id_48924 >= _end_id_48934 {
-                        let i : Int = _index_id_48924;
+                    let _range_id_48930 : Range = 0..Length(ctls) / 2 - 2 - adjustment;
+                    mutable _index_id_48933 : Int = _range_id_48930::Start;
+                    let _step_id_48938 : Int = _range_id_48930::Step;
+                    let _end_id_48943 : Int = _range_id_48930::End;
+                    while _step_id_48938 > 0 and _index_id_48933 <= _end_id_48943 or _step_id_48938 < 0 and _index_id_48933 >= _end_id_48943 {
+                        let i : Int = _index_id_48933;
                         CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                        _index_id_48924 += _step_id_48929;
+                        _index_id_48933 += _step_id_48938;
                     }
 
                 }
@@ -460,14 +460,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(ctls) / 2 - 2 - adjustment;
                     {
-                        let _range_id_48964 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_48967 : Int = _range_id_48964::Start;
-                        let _step_id_48972 : Int = _range_id_48964::Step;
-                        let _end_id_48977 : Int = _range_id_48964::End;
-                        while _step_id_48972 > 0 and _index_id_48967 <= _end_id_48977 or _step_id_48972 < 0 and _index_id_48967 >= _end_id_48977 {
-                            let i : Int = _index_id_48967;
+                        let _range_id_48973 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_48976 : Int = _range_id_48973::Start;
+                        let _step_id_48981 : Int = _range_id_48973::Step;
+                        let _end_id_48986 : Int = _range_id_48973::End;
+                        while _step_id_48981 > 0 and _index_id_48976 <= _end_id_48986 or _step_id_48981 < 0 and _index_id_48976 >= _end_id_48986 {
+                            let i : Int = _index_id_48976;
                             Adjoint CCNOT(aux[i * 2], aux[i * 2 + 1], aux[i + Length(ctls) / 2]);
-                            _index_id_48967 += _step_id_48972;
+                            _index_id_48976 += _step_id_48981;
                         }
 
                     }
@@ -477,14 +477,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..2..Length(ctls) - 2;
                     {
-                        let _range_id_49007 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_49010 : Int = _range_id_49007::Start;
-                        let _step_id_49015 : Int = _range_id_49007::Step;
-                        let _end_id_49020 : Int = _range_id_49007::End;
-                        while _step_id_49015 > 0 and _index_id_49010 <= _end_id_49020 or _step_id_49015 < 0 and _index_id_49010 >= _end_id_49020 {
-                            let i : Int = _index_id_49010;
+                        let _range_id_49016 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_49019 : Int = _range_id_49016::Start;
+                        let _step_id_49024 : Int = _range_id_49016::Step;
+                        let _end_id_49029 : Int = _range_id_49016::End;
+                        while _step_id_49024 > 0 and _index_id_49019 <= _end_id_49029 or _step_id_49024 < 0 and _index_id_49019 >= _end_id_49029 {
+                            let i : Int = _index_id_49019;
                             Adjoint CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
-                            _index_id_49010 += _step_id_49015;
+                            _index_id_49019 += _step_id_49024;
                         }
 
                     }
@@ -597,7 +597,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_53981 : Unit = {
+                            let _generated_ident_53990 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -618,7 +618,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_53981
+                            _generated_ident_53990
                         }
 
                     }
@@ -643,7 +643,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             CCH(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1 - Length(ctls) % 2);
-                            let _generated_ident_53995 : Unit = {
+                            let _generated_ident_54004 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 0);
                                 }
@@ -664,7 +664,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_53995
+                            _generated_ident_54004
                         }
 
                     }
@@ -749,13 +749,13 @@ fn shor_sample_full_pipeline_reachable_items() {
         }
         operation ResetAll(qubits : Qubit[]) : Unit {
             {
-                let _array_id_49379 : Qubit[] = qubits;
-                let _len_id_49383 : Int = Length(_array_id_49379);
-                mutable _index_id_49388 : Int = 0;
-                while _index_id_49388 < _len_id_49383 {
-                    let q : Qubit = _array_id_49379[_index_id_49388];
+                let _array_id_49388 : Qubit[] = qubits;
+                let _len_id_49392 : Int = Length(_array_id_49388);
+                mutable _index_id_49397 : Int = 0;
+                while _index_id_49397 < _len_id_49392 {
+                    let q : Qubit = _array_id_49388[_index_id_49397];
                     Reset(q);
-                    _index_id_49388 += 1;
+                    _index_id_49397 += 1;
                 }
 
             }
@@ -865,7 +865,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         CRz(ctls[0], theta, qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54051 : Unit = {
+                        let _generated_ident_54060 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -882,7 +882,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54051
+                        _generated_ident_54060
                     }
 
                 }
@@ -916,7 +916,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             Controlled CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54079 : Unit = {
+                            let _generated_ident_54088 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -937,7 +937,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54079
+                            _generated_ident_54088
                         }
 
                     }
@@ -962,7 +962,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             Controlled Adjoint CS([ctls[0]], (ctls[1], qubit));
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54093 : Unit = {
+                            let _generated_ident_54102 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -983,7 +983,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54093
+                            _generated_ident_54102
                         }
 
                     }
@@ -1064,7 +1064,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54135 : Unit = {
+                        let _generated_ident_54144 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -1081,7 +1081,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54135
+                        _generated_ident_54144
                     }
 
                 }
@@ -1098,7 +1098,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         Adjoint CT(ctls[0], qubit);
                     } else {
                         let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 1);
-                        let _generated_ident_54149 : Unit = {
+                        let _generated_ident_54158 : Unit = {
                             {
                                 CollectControls(ctls, aux, 0);
                                 AdjustForSingleControl(ctls, aux);
@@ -1115,7 +1115,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(aux);
-                        _generated_ident_54149
+                        _generated_ident_54158
                     }
 
                 }
@@ -1146,7 +1146,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54163 : Unit = {
+                            let _generated_ident_54172 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -1167,7 +1167,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54163
+                            _generated_ident_54172
                         }
 
                     }
@@ -1192,7 +1192,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             __quantum__qis__ccx__body(ctls[0], ctls[1], qubit);
                         } else {
                             let aux : Qubit[] = AllocateQubitArray(Length(ctls) - 2);
-                            let _generated_ident_54177 : Unit = {
+                            let _generated_ident_54186 : Unit = {
                                 {
                                     CollectControls(ctls, aux, 1 - Length(ctls) % 2);
                                 }
@@ -1213,7 +1213,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 _apply_res
                             };
                             ReleaseQubitArray(aux);
-                            _generated_ident_54177
+                            _generated_ident_54186
                         }
 
                     }
@@ -1722,27 +1722,27 @@ fn shor_sample_full_pipeline_reachable_items() {
             body ... {
                 Fact(Length(xs) <= Length(ys), $"Input register ys must be at least as long as xs.");
                 {
-                    let _range_id_51179 : Range = 1..Length(xs) - 1;
-                    mutable _index_id_51182 : Int = _range_id_51179::Start;
-                    let _step_id_51187 : Int = _range_id_51179::Step;
-                    let _end_id_51192 : Int = _range_id_51179::End;
-                    while _step_id_51187 > 0 and _index_id_51182 <= _end_id_51192 or _step_id_51187 < 0 and _index_id_51182 >= _end_id_51192 {
-                        let i : Int = _index_id_51182;
+                    let _range_id_51188 : Range = 1..Length(xs) - 1;
+                    mutable _index_id_51191 : Int = _range_id_51188::Start;
+                    let _step_id_51196 : Int = _range_id_51188::Step;
+                    let _end_id_51201 : Int = _range_id_51188::End;
+                    while _step_id_51196 > 0 and _index_id_51191 <= _end_id_51201 or _step_id_51196 < 0 and _index_id_51191 >= _end_id_51201 {
+                        let i : Int = _index_id_51191;
                         CNOT(xs[i], ys[i]);
-                        _index_id_51182 += _step_id_51187;
+                        _index_id_51191 += _step_id_51196;
                     }
 
                 }
 
                 {
-                    let _range_id_51222 : Range = Length(xs) - 2..-1..1;
-                    mutable _index_id_51225 : Int = _range_id_51222::Start;
-                    let _step_id_51230 : Int = _range_id_51222::Step;
-                    let _end_id_51235 : Int = _range_id_51222::End;
-                    while _step_id_51230 > 0 and _index_id_51225 <= _end_id_51235 or _step_id_51230 < 0 and _index_id_51225 >= _end_id_51235 {
-                        let i : Int = _index_id_51225;
+                    let _range_id_51231 : Range = Length(xs) - 2..-1..1;
+                    mutable _index_id_51234 : Int = _range_id_51231::Start;
+                    let _step_id_51239 : Int = _range_id_51231::Step;
+                    let _end_id_51244 : Int = _range_id_51231::End;
+                    while _step_id_51239 > 0 and _index_id_51234 <= _end_id_51244 or _step_id_51239 < 0 and _index_id_51234 >= _end_id_51244 {
+                        let i : Int = _index_id_51234;
                         CNOT(xs[i], xs[i + 1]);
-                        _index_id_51225 += _step_id_51230;
+                        _index_id_51234 += _step_id_51239;
                     }
 
                 }
@@ -1753,14 +1753,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 2..-1..1;
                     {
-                        let _range_id_51265 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51268 : Int = _range_id_51265::Start;
-                        let _step_id_51273 : Int = _range_id_51265::Step;
-                        let _end_id_51278 : Int = _range_id_51265::End;
-                        while _step_id_51273 > 0 and _index_id_51268 <= _end_id_51278 or _step_id_51273 < 0 and _index_id_51268 >= _end_id_51278 {
-                            let i : Int = _index_id_51268;
+                        let _range_id_51274 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51277 : Int = _range_id_51274::Start;
+                        let _step_id_51282 : Int = _range_id_51274::Step;
+                        let _end_id_51287 : Int = _range_id_51274::End;
+                        while _step_id_51282 > 0 and _index_id_51277 <= _end_id_51287 or _step_id_51282 < 0 and _index_id_51277 >= _end_id_51287 {
+                            let i : Int = _index_id_51277;
                             Adjoint CNOT(xs[i], xs[i + 1]);
-                            _index_id_51268 += _step_id_51273;
+                            _index_id_51277 += _step_id_51282;
                         }
 
                     }
@@ -1770,14 +1770,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 1..Length(xs) - 1;
                     {
-                        let _range_id_51308 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51311 : Int = _range_id_51308::Start;
-                        let _step_id_51316 : Int = _range_id_51308::Step;
-                        let _end_id_51321 : Int = _range_id_51308::End;
-                        while _step_id_51316 > 0 and _index_id_51311 <= _end_id_51321 or _step_id_51316 < 0 and _index_id_51311 >= _end_id_51321 {
-                            let i : Int = _index_id_51311;
+                        let _range_id_51317 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51320 : Int = _range_id_51317::Start;
+                        let _step_id_51325 : Int = _range_id_51317::Step;
+                        let _end_id_51330 : Int = _range_id_51317::End;
+                        while _step_id_51325 > 0 and _index_id_51320 <= _end_id_51330 or _step_id_51325 < 0 and _index_id_51320 >= _end_id_51330 {
+                            let i : Int = _index_id_51320;
                             Adjoint CNOT(xs[i], ys[i]);
-                            _index_id_51311 += _step_id_51316;
+                            _index_id_51320 += _step_id_51325;
                         }
 
                     }
@@ -1788,27 +1788,27 @@ fn shor_sample_full_pipeline_reachable_items() {
             controlled (ctls, ...) {
                 Fact(Length(xs) <= Length(ys), $"Input register ys must be at least as long as xs.");
                 {
-                    let _range_id_51351 : Range = 1..Length(xs) - 1;
-                    mutable _index_id_51354 : Int = _range_id_51351::Start;
-                    let _step_id_51359 : Int = _range_id_51351::Step;
-                    let _end_id_51364 : Int = _range_id_51351::End;
-                    while _step_id_51359 > 0 and _index_id_51354 <= _end_id_51364 or _step_id_51359 < 0 and _index_id_51354 >= _end_id_51364 {
-                        let i : Int = _index_id_51354;
+                    let _range_id_51360 : Range = 1..Length(xs) - 1;
+                    mutable _index_id_51363 : Int = _range_id_51360::Start;
+                    let _step_id_51368 : Int = _range_id_51360::Step;
+                    let _end_id_51373 : Int = _range_id_51360::End;
+                    while _step_id_51368 > 0 and _index_id_51363 <= _end_id_51373 or _step_id_51368 < 0 and _index_id_51363 >= _end_id_51373 {
+                        let i : Int = _index_id_51363;
                         Controlled CNOT(ctls, (xs[i], ys[i]));
-                        _index_id_51354 += _step_id_51359;
+                        _index_id_51363 += _step_id_51368;
                     }
 
                 }
 
                 {
-                    let _range_id_51394 : Range = Length(xs) - 2..-1..1;
-                    mutable _index_id_51397 : Int = _range_id_51394::Start;
-                    let _step_id_51402 : Int = _range_id_51394::Step;
-                    let _end_id_51407 : Int = _range_id_51394::End;
-                    while _step_id_51402 > 0 and _index_id_51397 <= _end_id_51407 or _step_id_51402 < 0 and _index_id_51397 >= _end_id_51407 {
-                        let i : Int = _index_id_51397;
+                    let _range_id_51403 : Range = Length(xs) - 2..-1..1;
+                    mutable _index_id_51406 : Int = _range_id_51403::Start;
+                    let _step_id_51411 : Int = _range_id_51403::Step;
+                    let _end_id_51416 : Int = _range_id_51403::End;
+                    while _step_id_51411 > 0 and _index_id_51406 <= _end_id_51416 or _step_id_51411 < 0 and _index_id_51406 >= _end_id_51416 {
+                        let i : Int = _index_id_51406;
                         Controlled CNOT(ctls, (xs[i], xs[i + 1]));
-                        _index_id_51397 += _step_id_51402;
+                        _index_id_51406 += _step_id_51411;
                     }
 
                 }
@@ -1819,14 +1819,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 2..-1..1;
                     {
-                        let _range_id_51437 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51440 : Int = _range_id_51437::Start;
-                        let _step_id_51445 : Int = _range_id_51437::Step;
-                        let _end_id_51450 : Int = _range_id_51437::End;
-                        while _step_id_51445 > 0 and _index_id_51440 <= _end_id_51450 or _step_id_51445 < 0 and _index_id_51440 >= _end_id_51450 {
-                            let i : Int = _index_id_51440;
+                        let _range_id_51446 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51449 : Int = _range_id_51446::Start;
+                        let _step_id_51454 : Int = _range_id_51446::Step;
+                        let _end_id_51459 : Int = _range_id_51446::End;
+                        while _step_id_51454 > 0 and _index_id_51449 <= _end_id_51459 or _step_id_51454 < 0 and _index_id_51449 >= _end_id_51459 {
+                            let i : Int = _index_id_51449;
                             Controlled Adjoint CNOT(ctls, (xs[i], xs[i + 1]));
-                            _index_id_51440 += _step_id_51445;
+                            _index_id_51449 += _step_id_51454;
                         }
 
                     }
@@ -1836,14 +1836,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 1..Length(xs) - 1;
                     {
-                        let _range_id_51480 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51483 : Int = _range_id_51480::Start;
-                        let _step_id_51488 : Int = _range_id_51480::Step;
-                        let _end_id_51493 : Int = _range_id_51480::End;
-                        while _step_id_51488 > 0 and _index_id_51483 <= _end_id_51493 or _step_id_51488 < 0 and _index_id_51483 >= _end_id_51493 {
-                            let i : Int = _index_id_51483;
+                        let _range_id_51489 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51492 : Int = _range_id_51489::Start;
+                        let _step_id_51497 : Int = _range_id_51489::Step;
+                        let _end_id_51502 : Int = _range_id_51489::End;
+                        while _step_id_51497 > 0 and _index_id_51492 <= _end_id_51502 or _step_id_51497 < 0 and _index_id_51492 >= _end_id_51502 {
+                            let i : Int = _index_id_51492;
                             Controlled Adjoint CNOT(ctls, (xs[i], ys[i]));
-                            _index_id_51483 += _step_id_51488;
+                            _index_id_51492 += _step_id_51497;
                         }
 
                     }
@@ -1862,28 +1862,28 @@ fn shor_sample_full_pipeline_reachable_items() {
             controlled (controls, ...) {
                 Fact(Length(xs) == Length(ys), $"Input registers must have the same number of qubits.");
                 {
-                    let _range_id_51523 : Range = 0..Length(xs) - 2;
-                    mutable _index_id_51526 : Int = _range_id_51523::Start;
-                    let _step_id_51531 : Int = _range_id_51523::Step;
-                    let _end_id_51536 : Int = _range_id_51523::End;
-                    while _step_id_51531 > 0 and _index_id_51526 <= _end_id_51536 or _step_id_51531 < 0 and _index_id_51526 >= _end_id_51536 {
-                        let idx : Int = _index_id_51526;
+                    let _range_id_51532 : Range = 0..Length(xs) - 2;
+                    mutable _index_id_51535 : Int = _range_id_51532::Start;
+                    let _step_id_51540 : Int = _range_id_51532::Step;
+                    let _end_id_51545 : Int = _range_id_51532::End;
+                    while _step_id_51540 > 0 and _index_id_51535 <= _end_id_51545 or _step_id_51540 < 0 and _index_id_51535 >= _end_id_51545 {
+                        let idx : Int = _index_id_51535;
                         CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                        _index_id_51526 += _step_id_51531;
+                        _index_id_51535 += _step_id_51540;
                     }
 
                 }
 
                 {
-                    let _range_id_51566 : Range = Length(xs) - 1..-1..1;
-                    mutable _index_id_51569 : Int = _range_id_51566::Start;
-                    let _step_id_51574 : Int = _range_id_51566::Step;
-                    let _end_id_51579 : Int = _range_id_51566::End;
-                    while _step_id_51574 > 0 and _index_id_51569 <= _end_id_51579 or _step_id_51574 < 0 and _index_id_51569 >= _end_id_51579 {
-                        let idx : Int = _index_id_51569;
+                    let _range_id_51575 : Range = Length(xs) - 1..-1..1;
+                    mutable _index_id_51578 : Int = _range_id_51575::Start;
+                    let _step_id_51583 : Int = _range_id_51575::Step;
+                    let _end_id_51588 : Int = _range_id_51575::End;
+                    while _step_id_51583 > 0 and _index_id_51578 <= _end_id_51588 or _step_id_51583 < 0 and _index_id_51578 >= _end_id_51588 {
+                        let idx : Int = _index_id_51578;
                         Controlled CNOT(controls, (xs[idx], ys[idx]));
                         CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
-                        _index_id_51569 += _step_id_51574;
+                        _index_id_51578 += _step_id_51583;
                     }
 
                 }
@@ -1894,15 +1894,15 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = Length(xs) - 1..-1..1;
                     {
-                        let _range_id_51609 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51612 : Int = _range_id_51609::Start;
-                        let _step_id_51617 : Int = _range_id_51609::Step;
-                        let _end_id_51622 : Int = _range_id_51609::End;
-                        while _step_id_51617 > 0 and _index_id_51612 <= _end_id_51622 or _step_id_51617 < 0 and _index_id_51612 >= _end_id_51622 {
-                            let idx : Int = _index_id_51612;
+                        let _range_id_51618 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51621 : Int = _range_id_51618::Start;
+                        let _step_id_51626 : Int = _range_id_51618::Step;
+                        let _end_id_51631 : Int = _range_id_51618::End;
+                        while _step_id_51626 > 0 and _index_id_51621 <= _end_id_51631 or _step_id_51626 < 0 and _index_id_51621 >= _end_id_51631 {
+                            let idx : Int = _index_id_51621;
                             Adjoint CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
                             Adjoint Controlled CNOT(controls, (xs[idx], ys[idx]));
-                            _index_id_51612 += _step_id_51617;
+                            _index_id_51621 += _step_id_51626;
                         }
 
                     }
@@ -1912,14 +1912,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..Length(xs) - 2;
                     {
-                        let _range_id_51652 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51655 : Int = _range_id_51652::Start;
-                        let _step_id_51660 : Int = _range_id_51652::Step;
-                        let _end_id_51665 : Int = _range_id_51652::End;
-                        while _step_id_51660 > 0 and _index_id_51655 <= _end_id_51665 or _step_id_51660 < 0 and _index_id_51655 >= _end_id_51665 {
-                            let idx : Int = _index_id_51655;
+                        let _range_id_51661 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51664 : Int = _range_id_51661::Start;
+                        let _step_id_51669 : Int = _range_id_51661::Step;
+                        let _end_id_51674 : Int = _range_id_51661::End;
+                        while _step_id_51669 > 0 and _index_id_51664 <= _end_id_51674 or _step_id_51669 < 0 and _index_id_51664 >= _end_id_51674 {
+                            let idx : Int = _index_id_51664;
                             Adjoint CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                            _index_id_51655 += _step_id_51660;
+                            _index_id_51664 += _step_id_51669;
                         }
 
                     }
@@ -1940,29 +1940,29 @@ fn shor_sample_full_pipeline_reachable_items() {
                 Fact(Length(xs) > 0, $"Array should not be empty.");
                 let nQubits : Int = Length(xs);
                 {
-                    let _range_id_51695 : Range = 0..nQubits - 2;
-                    mutable _index_id_51698 : Int = _range_id_51695::Start;
-                    let _step_id_51703 : Int = _range_id_51695::Step;
-                    let _end_id_51708 : Int = _range_id_51695::End;
-                    while _step_id_51703 > 0 and _index_id_51698 <= _end_id_51708 or _step_id_51703 < 0 and _index_id_51698 >= _end_id_51708 {
-                        let idx : Int = _index_id_51698;
+                    let _range_id_51704 : Range = 0..nQubits - 2;
+                    mutable _index_id_51707 : Int = _range_id_51704::Start;
+                    let _step_id_51712 : Int = _range_id_51704::Step;
+                    let _end_id_51717 : Int = _range_id_51704::End;
+                    while _step_id_51712 > 0 and _index_id_51707 <= _end_id_51717 or _step_id_51712 < 0 and _index_id_51707 >= _end_id_51717 {
+                        let idx : Int = _index_id_51707;
                         CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                        _index_id_51698 += _step_id_51703;
+                        _index_id_51707 += _step_id_51712;
                     }
 
                 }
 
                 Controlled CCNOT(controls, (xs[nQubits - 1], ys[nQubits - 1], ys[nQubits]));
                 {
-                    let _range_id_51738 : Range = nQubits - 1..-1..1;
-                    mutable _index_id_51741 : Int = _range_id_51738::Start;
-                    let _step_id_51746 : Int = _range_id_51738::Step;
-                    let _end_id_51751 : Int = _range_id_51738::End;
-                    while _step_id_51746 > 0 and _index_id_51741 <= _end_id_51751 or _step_id_51746 < 0 and _index_id_51741 >= _end_id_51751 {
-                        let idx : Int = _index_id_51741;
+                    let _range_id_51747 : Range = nQubits - 1..-1..1;
+                    mutable _index_id_51750 : Int = _range_id_51747::Start;
+                    let _step_id_51755 : Int = _range_id_51747::Step;
+                    let _end_id_51760 : Int = _range_id_51747::End;
+                    while _step_id_51755 > 0 and _index_id_51750 <= _end_id_51760 or _step_id_51755 < 0 and _index_id_51750 >= _end_id_51760 {
+                        let idx : Int = _index_id_51750;
                         Controlled CNOT(controls, (xs[idx], ys[idx]));
                         CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
-                        _index_id_51741 += _step_id_51746;
+                        _index_id_51750 += _step_id_51755;
                     }
 
                 }
@@ -1975,15 +1975,15 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = nQubits - 1..-1..1;
                     {
-                        let _range_id_51781 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51784 : Int = _range_id_51781::Start;
-                        let _step_id_51789 : Int = _range_id_51781::Step;
-                        let _end_id_51794 : Int = _range_id_51781::End;
-                        while _step_id_51789 > 0 and _index_id_51784 <= _end_id_51794 or _step_id_51789 < 0 and _index_id_51784 >= _end_id_51794 {
-                            let idx : Int = _index_id_51784;
+                        let _range_id_51790 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51793 : Int = _range_id_51790::Start;
+                        let _step_id_51798 : Int = _range_id_51790::Step;
+                        let _end_id_51803 : Int = _range_id_51790::End;
+                        while _step_id_51798 > 0 and _index_id_51793 <= _end_id_51803 or _step_id_51798 < 0 and _index_id_51793 >= _end_id_51803 {
+                            let idx : Int = _index_id_51793;
                             Adjoint CCNOT(xs[idx - 1], ys[idx - 1], xs[idx]);
                             Adjoint Controlled CNOT(controls, (xs[idx], ys[idx]));
-                            _index_id_51784 += _step_id_51789;
+                            _index_id_51793 += _step_id_51798;
                         }
 
                     }
@@ -1994,14 +1994,14 @@ fn shor_sample_full_pipeline_reachable_items() {
                 {
                     let _range : Range = 0..nQubits - 2;
                     {
-                        let _range_id_51824 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                        mutable _index_id_51827 : Int = _range_id_51824::Start;
-                        let _step_id_51832 : Int = _range_id_51824::Step;
-                        let _end_id_51837 : Int = _range_id_51824::End;
-                        while _step_id_51832 > 0 and _index_id_51827 <= _end_id_51837 or _step_id_51832 < 0 and _index_id_51827 >= _end_id_51837 {
-                            let idx : Int = _index_id_51827;
+                        let _range_id_51833 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                        mutable _index_id_51836 : Int = _range_id_51833::Start;
+                        let _step_id_51841 : Int = _range_id_51833::Step;
+                        let _end_id_51846 : Int = _range_id_51833::End;
+                        while _step_id_51841 > 0 and _index_id_51836 <= _end_id_51846 or _step_id_51841 < 0 and _index_id_51836 >= _end_id_51846 {
+                            let idx : Int = _index_id_51836;
                             Adjoint CCNOT(xs[idx], ys[idx], xs[idx + 1]);
-                            _index_id_51827 += _step_id_51832;
+                            _index_id_51836 += _step_id_51841;
                         }
 
                     }
@@ -2079,7 +2079,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54421 : Unit = {
+                    let _generated_ident_54430 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2094,7 +2094,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54421
+                    _generated_ident_54430
                 }
 
             }
@@ -2106,7 +2106,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54435 : Unit = {
+                    let _generated_ident_54444 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2121,7 +2121,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54435
+                    _generated_ident_54444
                 }
 
             }
@@ -2133,7 +2133,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54449 : Unit = {
+                    let _generated_ident_54458 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2148,7 +2148,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54449
+                    _generated_ident_54458
                 }
 
             }
@@ -2160,7 +2160,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 if c != 0 {
                     let j : Int = TrailingZeroCountI(c);
                     let x : Qubit[] = AllocateQubitArray(ysLen - j);
-                    let _generated_ident_54463 : Unit = {
+                    let _generated_ident_54472 : Unit = {
                         {
                             ApplyXorInPlace(c >>> j, x);
                         }
@@ -2175,7 +2175,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                         _apply_res
                     };
                     ReleaseQubitArray(x);
-                    _generated_ident_54463
+                    _generated_ident_54472
                 }
 
             }
@@ -2707,21 +2707,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54592 : Unit = {
+                        let _generated_ident_54601 : Unit = {
                             {
                                 {
-                                    let _range_id_52540 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52543 : Int = _range_id_52540::Start;
-                                    let _step_id_52548 : Int = _range_id_52540::Step;
-                                    let _end_id_52553 : Int = _range_id_52540::End;
-                                    while _step_id_52548 > 0 and _index_id_52543 <= _end_id_52553 or _step_id_52548 < 0 and _index_id_52543 >= _end_id_52553 {
-                                        let i : Int = _index_id_52543;
+                                    let _range_id_52549 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52552 : Int = _range_id_52549::Start;
+                                    let _step_id_52557 : Int = _range_id_52549::Step;
+                                    let _end_id_52562 : Int = _range_id_52549::End;
+                                    while _step_id_52557 > 0 and _index_id_52552 <= _end_id_52562 or _step_id_52557 < 0 and _index_id_52552 >= _end_id_52562 {
+                                        let i : Int = _index_id_52552;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52543 += _step_id_52548;
+                                        _index_id_52552 += _step_id_52557;
                                     }
 
                                 }
@@ -2760,18 +2760,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52583 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52586 : Int = _range_id_52583::Start;
-                                        let _step_id_52591 : Int = _range_id_52583::Step;
-                                        let _end_id_52596 : Int = _range_id_52583::End;
-                                        while _step_id_52591 > 0 and _index_id_52586 <= _end_id_52596 or _step_id_52591 < 0 and _index_id_52586 >= _end_id_52596 {
-                                            let i : Int = _index_id_52586;
+                                        let _range_id_52592 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52595 : Int = _range_id_52592::Start;
+                                        let _step_id_52600 : Int = _range_id_52592::Step;
+                                        let _end_id_52605 : Int = _range_id_52592::End;
+                                        while _step_id_52600 > 0 and _index_id_52595 <= _end_id_52605 or _step_id_52600 < 0 and _index_id_52595 >= _end_id_52605 {
+                                            let i : Int = _index_id_52595;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52586 += _step_id_52591;
+                                            _index_id_52595 += _step_id_52600;
                                         }
 
                                     }
@@ -2783,7 +2783,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54592
+                        _generated_ident_54601
                     }
 
                 }
@@ -2816,21 +2816,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54606 : Unit = {
+                        let _generated_ident_54615 : Unit = {
                             {
                                 {
-                                    let _range_id_52626 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52629 : Int = _range_id_52626::Start;
-                                    let _step_id_52634 : Int = _range_id_52626::Step;
-                                    let _end_id_52639 : Int = _range_id_52626::End;
-                                    while _step_id_52634 > 0 and _index_id_52629 <= _end_id_52639 or _step_id_52634 < 0 and _index_id_52629 >= _end_id_52639 {
-                                        let i : Int = _index_id_52629;
+                                    let _range_id_52635 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52638 : Int = _range_id_52635::Start;
+                                    let _step_id_52643 : Int = _range_id_52635::Step;
+                                    let _end_id_52648 : Int = _range_id_52635::End;
+                                    while _step_id_52643 > 0 and _index_id_52638 <= _end_id_52648 or _step_id_52643 < 0 and _index_id_52638 >= _end_id_52648 {
+                                        let i : Int = _index_id_52638;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52629 += _step_id_52634;
+                                        _index_id_52638 += _step_id_52643;
                                     }
 
                                 }
@@ -2869,18 +2869,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52669 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52672 : Int = _range_id_52669::Start;
-                                        let _step_id_52677 : Int = _range_id_52669::Step;
-                                        let _end_id_52682 : Int = _range_id_52669::End;
-                                        while _step_id_52677 > 0 and _index_id_52672 <= _end_id_52682 or _step_id_52677 < 0 and _index_id_52672 >= _end_id_52682 {
-                                            let i : Int = _index_id_52672;
+                                        let _range_id_52678 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52681 : Int = _range_id_52678::Start;
+                                        let _step_id_52686 : Int = _range_id_52678::Step;
+                                        let _end_id_52691 : Int = _range_id_52678::End;
+                                        while _step_id_52686 > 0 and _index_id_52681 <= _end_id_52691 or _step_id_52686 < 0 and _index_id_52681 >= _end_id_52691 {
+                                            let i : Int = _index_id_52681;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52672 += _step_id_52677;
+                                            _index_id_52681 += _step_id_52686;
                                         }
 
                                     }
@@ -2892,7 +2892,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54606
+                        _generated_ident_54615
                     }
 
                 }
@@ -2925,21 +2925,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54620 : Unit = {
+                        let _generated_ident_54629 : Unit = {
                             {
                                 {
-                                    let _range_id_52712 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52715 : Int = _range_id_52712::Start;
-                                    let _step_id_52720 : Int = _range_id_52712::Step;
-                                    let _end_id_52725 : Int = _range_id_52712::End;
-                                    while _step_id_52720 > 0 and _index_id_52715 <= _end_id_52725 or _step_id_52720 < 0 and _index_id_52715 >= _end_id_52725 {
-                                        let i : Int = _index_id_52715;
+                                    let _range_id_52721 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52724 : Int = _range_id_52721::Start;
+                                    let _step_id_52729 : Int = _range_id_52721::Step;
+                                    let _end_id_52734 : Int = _range_id_52721::End;
+                                    while _step_id_52729 > 0 and _index_id_52724 <= _end_id_52734 or _step_id_52729 < 0 and _index_id_52724 >= _end_id_52734 {
+                                        let i : Int = _index_id_52724;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52715 += _step_id_52720;
+                                        _index_id_52724 += _step_id_52729;
                                     }
 
                                 }
@@ -2978,18 +2978,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52755 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52758 : Int = _range_id_52755::Start;
-                                        let _step_id_52763 : Int = _range_id_52755::Step;
-                                        let _end_id_52768 : Int = _range_id_52755::End;
-                                        while _step_id_52763 > 0 and _index_id_52758 <= _end_id_52768 or _step_id_52763 < 0 and _index_id_52758 >= _end_id_52768 {
-                                            let i : Int = _index_id_52758;
+                                        let _range_id_52764 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52767 : Int = _range_id_52764::Start;
+                                        let _step_id_52772 : Int = _range_id_52764::Step;
+                                        let _end_id_52777 : Int = _range_id_52764::End;
+                                        while _step_id_52772 > 0 and _index_id_52767 <= _end_id_52777 or _step_id_52772 < 0 and _index_id_52767 >= _end_id_52777 {
+                                            let i : Int = _index_id_52767;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52758 += _step_id_52763;
+                                            _index_id_52767 += _step_id_52772;
                                         }
 
                                     }
@@ -3001,7 +3001,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54620
+                        _generated_ident_54629
                     }
 
                 }
@@ -3034,21 +3034,21 @@ fn shor_sample_full_pipeline_reachable_items() {
                             [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
                         };
                         Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54634 : Unit = {
+                        let _generated_ident_54643 : Unit = {
                             {
                                 {
-                                    let _range_id_52798 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52801 : Int = _range_id_52798::Start;
-                                    let _step_id_52806 : Int = _range_id_52798::Step;
-                                    let _end_id_52811 : Int = _range_id_52798::End;
-                                    while _step_id_52806 > 0 and _index_id_52801 <= _end_id_52811 or _step_id_52806 < 0 and _index_id_52801 >= _end_id_52811 {
-                                        let i : Int = _index_id_52801;
+                                    let _range_id_52807 : Range = 0..Length(cs1) - 1;
+                                    mutable _index_id_52810 : Int = _range_id_52807::Start;
+                                    let _step_id_52815 : Int = _range_id_52807::Step;
+                                    let _end_id_52820 : Int = _range_id_52807::End;
+                                    while _step_id_52815 > 0 and _index_id_52810 <= _end_id_52820 or _step_id_52815 < 0 and _index_id_52810 >= _end_id_52820 {
+                                        let i : Int = _index_id_52810;
                                         if cNormalized &&& 1L <<< i + 1 != 0L {
                                             AND(cs1[i], xNormalized[i + 1], qs[i])
                                         } else {
                                             ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                         };
-                                        _index_id_52801 += _step_id_52806;
+                                        _index_id_52810 += _step_id_52815;
                                     }
 
                                 }
@@ -3087,18 +3087,18 @@ fn shor_sample_full_pipeline_reachable_items() {
                                 {
                                     let _range : Range = 0..Length(cs1) - 1;
                                     {
-                                        let _range_id_52841 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52844 : Int = _range_id_52841::Start;
-                                        let _step_id_52849 : Int = _range_id_52841::Step;
-                                        let _end_id_52854 : Int = _range_id_52841::End;
-                                        while _step_id_52849 > 0 and _index_id_52844 <= _end_id_52854 or _step_id_52849 < 0 and _index_id_52844 >= _end_id_52854 {
-                                            let i : Int = _index_id_52844;
+                                        let _range_id_52850 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                        mutable _index_id_52853 : Int = _range_id_52850::Start;
+                                        let _step_id_52858 : Int = _range_id_52850::Step;
+                                        let _end_id_52863 : Int = _range_id_52850::End;
+                                        while _step_id_52858 > 0 and _index_id_52853 <= _end_id_52863 or _step_id_52858 < 0 and _index_id_52853 >= _end_id_52863 {
+                                            let i : Int = _index_id_52853;
                                             if cNormalized &&& 1L <<< i + 1 != 0L {
                                                 Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
                                             } else {
                                                 Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
                                             };
-                                            _index_id_52844 += _step_id_52849;
+                                            _index_id_52853 += _step_id_52858;
                                         }
 
                                     }
@@ -3110,7 +3110,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                             _apply_res
                         };
                         ReleaseQubitArray(qs);
-                        _generated_ident_54634
+                        _generated_ident_54643
                     }
 
                 }

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -1234,6 +1234,7 @@ impl<'a> PartialEvaluator<'a> {
             exec_graph,
             ExecGraphConfig::NoDebug,
             None,
+            FxHashMap::default(),
             ErrorBehavior::FailOnError,
         );
         let classical_result = state.eval(

--- a/source/compiler/qsc_partial_eval/src/tests/debug_metadata.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/debug_metadata.rs
@@ -58,10 +58,10 @@ fn one_gate() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-40)
-                1 = SubProgram name=H location=(1-111225)
+                1 = SubProgram name=H location=(1-111899)
             dbg_locations:
                 [1]: scope=0 location=(2-99)
-                [2]: scope=1 location=(1-111297) inlined_at=1"#]],
+                [2]: scope=1 location=(1-111971) inlined_at=1"#]],
     );
 }
 
@@ -93,13 +93,13 @@ fn one_measurement() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-40)
-                1 = SubProgram name=H location=(1-111225)
-                2 = SubProgram name=M location=(1-112934)
+                1 = SubProgram name=H location=(1-111899)
+                2 = SubProgram name=M location=(1-113608)
             dbg_locations:
                 [1]: scope=0 location=(2-103)
-                [2]: scope=1 location=(1-111297) inlined_at=1
+                [2]: scope=1 location=(1-111971) inlined_at=1
                 [3]: scope=0 location=(2-126)
-                [4]: scope=2 location=(1-112976) inlined_at=3"#]],
+                [4]: scope=2 location=(1-113650) inlined_at=3"#]],
     );
 }
 
@@ -134,14 +134,14 @@ fn calls_to_other_callables() {
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-40)
                 1 = SubProgram name=Foo location=(2-138)
-                2 = SubProgram name=H location=(1-111225)
-                3 = SubProgram name=MResetZ location=(1-182278)
+                2 = SubProgram name=H location=(1-111899)
+                3 = SubProgram name=MResetZ location=(1-182952)
             dbg_locations:
                 [1]: scope=0 location=(2-99)
                 [2]: scope=1 location=(2-179) inlined_at=1
-                [3]: scope=2 location=(1-111297) inlined_at=2
+                [3]: scope=2 location=(1-111971) inlined_at=2
                 [4]: scope=0 location=(2-115)
-                [5]: scope=3 location=(1-182327) inlined_at=4"#]],
+                [5]: scope=3 location=(1-183001) inlined_at=4"#]],
     );
 }
 
@@ -187,27 +187,27 @@ fn classical_for_loop() {
                 0 = SubProgram name=Main location=(2-40)
                 1 = LexicalBlockFile location=(2-99) discriminator=1
                 2 = SubProgram name=Foo location=(2-156)
-                3 = SubProgram name=X location=(1-134027)
-                4 = SubProgram name=Y location=(1-135249)
+                3 = SubProgram name=X location=(1-134701)
+                4 = SubProgram name=Y location=(1-135923)
                 5 = LexicalBlockFile location=(2-99) discriminator=2
                 6 = LexicalBlockFile location=(2-99) discriminator=3
             dbg_locations:
                 [1]: scope=0 location=(2-99)
                 [2]: scope=1 location=(2-127) inlined_at=1
                 [3]: scope=2 location=(2-197) inlined_at=2
-                [4]: scope=3 location=(1-134099) inlined_at=3
+                [4]: scope=3 location=(1-134773) inlined_at=3
                 [5]: scope=2 location=(2-211) inlined_at=2
-                [6]: scope=4 location=(1-135321) inlined_at=5
+                [6]: scope=4 location=(1-135995) inlined_at=5
                 [7]: scope=5 location=(2-127) inlined_at=1
                 [8]: scope=2 location=(2-197) inlined_at=7
-                [9]: scope=3 location=(1-134099) inlined_at=8
+                [9]: scope=3 location=(1-134773) inlined_at=8
                 [10]: scope=2 location=(2-211) inlined_at=7
-                [11]: scope=4 location=(1-135321) inlined_at=10
+                [11]: scope=4 location=(1-135995) inlined_at=10
                 [12]: scope=6 location=(2-127) inlined_at=1
                 [13]: scope=2 location=(2-197) inlined_at=12
-                [14]: scope=3 location=(1-134099) inlined_at=13
+                [14]: scope=3 location=(1-134773) inlined_at=13
                 [15]: scope=2 location=(2-211) inlined_at=12
-                [16]: scope=4 location=(1-135321) inlined_at=15"#]],
+                [16]: scope=4 location=(1-135995) inlined_at=15"#]],
     );
 }
 
@@ -274,7 +274,7 @@ fn nested_classical_for_loop() {
                 5 = LexicalBlockFile location=(2-101) discriminator=1
                 6 = LexicalBlockFile location=(2-129) discriminator=1
                 7 = SubProgram name=Foo location=(2-208)
-                8 = SubProgram name=X location=(1-134027)
+                8 = SubProgram name=X location=(1-134701)
                 9 = LexicalBlockFile location=(2-129) discriminator=2
                 10 = LexicalBlockFile location=(2-129) discriminator=3
                 11 = LexicalBlockFile location=(2-101) discriminator=2
@@ -284,33 +284,33 @@ fn nested_classical_for_loop() {
                 [6]: scope=5 location=(2-129) inlined_at=5
                 [7]: scope=6 location=(2-161) inlined_at=6
                 [8]: scope=7 location=(2-249) inlined_at=7
-                [9]: scope=8 location=(1-134099) inlined_at=8
+                [9]: scope=8 location=(1-134773) inlined_at=8
                 [10]: scope=9 location=(2-161) inlined_at=6
                 [11]: scope=7 location=(2-249) inlined_at=10
-                [12]: scope=8 location=(1-134099) inlined_at=11
+                [12]: scope=8 location=(1-134773) inlined_at=11
                 [13]: scope=10 location=(2-161) inlined_at=6
                 [14]: scope=7 location=(2-249) inlined_at=13
-                [15]: scope=8 location=(1-134099) inlined_at=14
+                [15]: scope=8 location=(1-134773) inlined_at=14
                 [16]: scope=11 location=(2-129) inlined_at=5
                 [17]: scope=6 location=(2-161) inlined_at=16
                 [18]: scope=7 location=(2-249) inlined_at=17
-                [19]: scope=8 location=(1-134099) inlined_at=18
+                [19]: scope=8 location=(1-134773) inlined_at=18
                 [20]: scope=9 location=(2-161) inlined_at=16
                 [21]: scope=7 location=(2-249) inlined_at=20
-                [22]: scope=8 location=(1-134099) inlined_at=21
+                [22]: scope=8 location=(1-134773) inlined_at=21
                 [23]: scope=10 location=(2-161) inlined_at=16
                 [24]: scope=7 location=(2-249) inlined_at=23
-                [25]: scope=8 location=(1-134099) inlined_at=24
+                [25]: scope=8 location=(1-134773) inlined_at=24
                 [26]: scope=12 location=(2-129) inlined_at=5
                 [27]: scope=6 location=(2-161) inlined_at=26
                 [28]: scope=7 location=(2-249) inlined_at=27
-                [29]: scope=8 location=(1-134099) inlined_at=28
+                [29]: scope=8 location=(1-134773) inlined_at=28
                 [30]: scope=9 location=(2-161) inlined_at=26
                 [31]: scope=7 location=(2-249) inlined_at=30
-                [32]: scope=8 location=(1-134099) inlined_at=31
+                [32]: scope=8 location=(1-134773) inlined_at=31
                 [33]: scope=10 location=(2-161) inlined_at=26
                 [34]: scope=7 location=(2-249) inlined_at=33
-                [35]: scope=8 location=(1-134099) inlined_at=34"#]],
+                [35]: scope=8 location=(1-134773) inlined_at=34"#]],
     );
 }
 
@@ -339,11 +339,11 @@ fn lambda() {
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-1)
                 1 = SubProgram name=.lambda_2 location=(2-65)
-                2 = SubProgram name=H location=(1-111225)
+                2 = SubProgram name=H location=(1-111899)
             dbg_locations:
                 [1]: scope=0 location=(2-99)
                 [2]: scope=1 location=(2-82) inlined_at=1
-                [3]: scope=2 location=(1-111297) inlined_at=2"#]],
+                [3]: scope=2 location=(1-111971) inlined_at=2"#]],
     );
 }
 
@@ -386,20 +386,20 @@ fn result_comparison_to_literal() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-22)
-                1 = SubProgram name=H location=(1-111225)
-                2 = SubProgram name=M location=(1-112934)
-                3 = SubProgram name=X location=(1-134027)
-                4 = SubProgram name=Reset location=(1-117327)
+                1 = SubProgram name=H location=(1-111899)
+                2 = SubProgram name=M location=(1-113608)
+                3 = SubProgram name=X location=(1-134701)
+                4 = SubProgram name=Reset location=(1-118001)
             dbg_locations:
                 [1]: scope=0 location=(2-86)
-                [2]: scope=1 location=(1-111297) inlined_at=1
+                [2]: scope=1 location=(1-111971) inlined_at=1
                 [3]: scope=0 location=(2-110)
-                [4]: scope=2 location=(1-112976) inlined_at=3
+                [4]: scope=2 location=(1-113650) inlined_at=3
                 [5]: scope=0 location=(2-154)
-                [6]: scope=3 location=(1-134099) inlined_at=5
+                [6]: scope=3 location=(1-134773) inlined_at=5
                 [7]: scope=0 location=(2-125)
                 [8]: scope=0 location=(2-179)
-                [9]: scope=4 location=(1-117371) inlined_at=8"#]],
+                [9]: scope=4 location=(1-118045) inlined_at=8"#]],
     );
 }
 
@@ -449,22 +449,22 @@ fn if_else() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-22)
-                1 = SubProgram name=H location=(1-111225)
-                2 = SubProgram name=M location=(1-112934)
-                3 = SubProgram name=X location=(1-134027)
-                4 = SubProgram name=Y location=(1-135249)
+                1 = SubProgram name=H location=(1-111899)
+                2 = SubProgram name=M location=(1-113608)
+                3 = SubProgram name=X location=(1-134701)
+                4 = SubProgram name=Y location=(1-135923)
             dbg_locations:
                 [2]: scope=0 location=(2-112)
-                [3]: scope=1 location=(1-111297) inlined_at=2
+                [3]: scope=1 location=(1-111971) inlined_at=2
                 [4]: scope=0 location=(2-135)
-                [5]: scope=2 location=(1-112976) inlined_at=4
+                [5]: scope=2 location=(1-113650) inlined_at=4
                 [6]: scope=0 location=(2-176)
-                [7]: scope=3 location=(1-134099) inlined_at=6
+                [7]: scope=3 location=(1-134773) inlined_at=6
                 [8]: scope=0 location=(2-212)
-                [9]: scope=4 location=(1-135321) inlined_at=8
+                [9]: scope=4 location=(1-135995) inlined_at=8
                 [10]: scope=0 location=(2-150)
                 [11]: scope=0 location=(2-246)
-                [12]: scope=2 location=(1-112976) inlined_at=11"#]],
+                [12]: scope=2 location=(1-113650) inlined_at=11"#]],
     );
 }
 
@@ -506,17 +506,17 @@ fn branch_due_to_binop_short_circuit() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-1)
-                1 = SubProgram name=H location=(1-111225)
-                2 = SubProgram name=M location=(1-112934)
+                1 = SubProgram name=H location=(1-111899)
+                2 = SubProgram name=M location=(1-113608)
             dbg_locations:
                 [2]: scope=0 location=(2-75)
-                [3]: scope=1 location=(1-111297) inlined_at=2
+                [3]: scope=1 location=(1-111971) inlined_at=2
                 [4]: scope=0 location=(2-86)
-                [5]: scope=1 location=(1-111297) inlined_at=4
+                [5]: scope=1 location=(1-111971) inlined_at=4
                 [6]: scope=0 location=(2-107)
-                [7]: scope=2 location=(1-112976) inlined_at=6
+                [7]: scope=2 location=(1-113650) inlined_at=6
                 [8]: scope=0 location=(2-129)
-                [9]: scope=2 location=(1-112976) inlined_at=8
+                [9]: scope=2 location=(1-113650) inlined_at=8
                 [10]: scope=0 location=(2-127)"#]],
     );
 }

--- a/source/compiler/qsc_partial_eval/src/tests/debug_metadata.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/debug_metadata.rs
@@ -58,10 +58,10 @@ fn one_gate() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-40)
-                1 = SubProgram name=H location=(1-111899)
+                1 = SubProgram name=H location=(1-111900)
             dbg_locations:
                 [1]: scope=0 location=(2-99)
-                [2]: scope=1 location=(1-111971) inlined_at=1"#]],
+                [2]: scope=1 location=(1-111972) inlined_at=1"#]],
     );
 }
 
@@ -93,13 +93,13 @@ fn one_measurement() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-40)
-                1 = SubProgram name=H location=(1-111899)
-                2 = SubProgram name=M location=(1-113608)
+                1 = SubProgram name=H location=(1-111900)
+                2 = SubProgram name=M location=(1-113609)
             dbg_locations:
                 [1]: scope=0 location=(2-103)
-                [2]: scope=1 location=(1-111971) inlined_at=1
+                [2]: scope=1 location=(1-111972) inlined_at=1
                 [3]: scope=0 location=(2-126)
-                [4]: scope=2 location=(1-113650) inlined_at=3"#]],
+                [4]: scope=2 location=(1-113651) inlined_at=3"#]],
     );
 }
 
@@ -134,14 +134,14 @@ fn calls_to_other_callables() {
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-40)
                 1 = SubProgram name=Foo location=(2-138)
-                2 = SubProgram name=H location=(1-111899)
-                3 = SubProgram name=MResetZ location=(1-182952)
+                2 = SubProgram name=H location=(1-111900)
+                3 = SubProgram name=MResetZ location=(1-182953)
             dbg_locations:
                 [1]: scope=0 location=(2-99)
                 [2]: scope=1 location=(2-179) inlined_at=1
-                [3]: scope=2 location=(1-111971) inlined_at=2
+                [3]: scope=2 location=(1-111972) inlined_at=2
                 [4]: scope=0 location=(2-115)
-                [5]: scope=3 location=(1-183001) inlined_at=4"#]],
+                [5]: scope=3 location=(1-183002) inlined_at=4"#]],
     );
 }
 
@@ -187,27 +187,27 @@ fn classical_for_loop() {
                 0 = SubProgram name=Main location=(2-40)
                 1 = LexicalBlockFile location=(2-99) discriminator=1
                 2 = SubProgram name=Foo location=(2-156)
-                3 = SubProgram name=X location=(1-134701)
-                4 = SubProgram name=Y location=(1-135923)
+                3 = SubProgram name=X location=(1-134702)
+                4 = SubProgram name=Y location=(1-135924)
                 5 = LexicalBlockFile location=(2-99) discriminator=2
                 6 = LexicalBlockFile location=(2-99) discriminator=3
             dbg_locations:
                 [1]: scope=0 location=(2-99)
                 [2]: scope=1 location=(2-127) inlined_at=1
                 [3]: scope=2 location=(2-197) inlined_at=2
-                [4]: scope=3 location=(1-134773) inlined_at=3
+                [4]: scope=3 location=(1-134774) inlined_at=3
                 [5]: scope=2 location=(2-211) inlined_at=2
-                [6]: scope=4 location=(1-135995) inlined_at=5
+                [6]: scope=4 location=(1-135996) inlined_at=5
                 [7]: scope=5 location=(2-127) inlined_at=1
                 [8]: scope=2 location=(2-197) inlined_at=7
-                [9]: scope=3 location=(1-134773) inlined_at=8
+                [9]: scope=3 location=(1-134774) inlined_at=8
                 [10]: scope=2 location=(2-211) inlined_at=7
-                [11]: scope=4 location=(1-135995) inlined_at=10
+                [11]: scope=4 location=(1-135996) inlined_at=10
                 [12]: scope=6 location=(2-127) inlined_at=1
                 [13]: scope=2 location=(2-197) inlined_at=12
-                [14]: scope=3 location=(1-134773) inlined_at=13
+                [14]: scope=3 location=(1-134774) inlined_at=13
                 [15]: scope=2 location=(2-211) inlined_at=12
-                [16]: scope=4 location=(1-135995) inlined_at=15"#]],
+                [16]: scope=4 location=(1-135996) inlined_at=15"#]],
     );
 }
 
@@ -274,7 +274,7 @@ fn nested_classical_for_loop() {
                 5 = LexicalBlockFile location=(2-101) discriminator=1
                 6 = LexicalBlockFile location=(2-129) discriminator=1
                 7 = SubProgram name=Foo location=(2-208)
-                8 = SubProgram name=X location=(1-134701)
+                8 = SubProgram name=X location=(1-134702)
                 9 = LexicalBlockFile location=(2-129) discriminator=2
                 10 = LexicalBlockFile location=(2-129) discriminator=3
                 11 = LexicalBlockFile location=(2-101) discriminator=2
@@ -284,33 +284,33 @@ fn nested_classical_for_loop() {
                 [6]: scope=5 location=(2-129) inlined_at=5
                 [7]: scope=6 location=(2-161) inlined_at=6
                 [8]: scope=7 location=(2-249) inlined_at=7
-                [9]: scope=8 location=(1-134773) inlined_at=8
+                [9]: scope=8 location=(1-134774) inlined_at=8
                 [10]: scope=9 location=(2-161) inlined_at=6
                 [11]: scope=7 location=(2-249) inlined_at=10
-                [12]: scope=8 location=(1-134773) inlined_at=11
+                [12]: scope=8 location=(1-134774) inlined_at=11
                 [13]: scope=10 location=(2-161) inlined_at=6
                 [14]: scope=7 location=(2-249) inlined_at=13
-                [15]: scope=8 location=(1-134773) inlined_at=14
+                [15]: scope=8 location=(1-134774) inlined_at=14
                 [16]: scope=11 location=(2-129) inlined_at=5
                 [17]: scope=6 location=(2-161) inlined_at=16
                 [18]: scope=7 location=(2-249) inlined_at=17
-                [19]: scope=8 location=(1-134773) inlined_at=18
+                [19]: scope=8 location=(1-134774) inlined_at=18
                 [20]: scope=9 location=(2-161) inlined_at=16
                 [21]: scope=7 location=(2-249) inlined_at=20
-                [22]: scope=8 location=(1-134773) inlined_at=21
+                [22]: scope=8 location=(1-134774) inlined_at=21
                 [23]: scope=10 location=(2-161) inlined_at=16
                 [24]: scope=7 location=(2-249) inlined_at=23
-                [25]: scope=8 location=(1-134773) inlined_at=24
+                [25]: scope=8 location=(1-134774) inlined_at=24
                 [26]: scope=12 location=(2-129) inlined_at=5
                 [27]: scope=6 location=(2-161) inlined_at=26
                 [28]: scope=7 location=(2-249) inlined_at=27
-                [29]: scope=8 location=(1-134773) inlined_at=28
+                [29]: scope=8 location=(1-134774) inlined_at=28
                 [30]: scope=9 location=(2-161) inlined_at=26
                 [31]: scope=7 location=(2-249) inlined_at=30
-                [32]: scope=8 location=(1-134773) inlined_at=31
+                [32]: scope=8 location=(1-134774) inlined_at=31
                 [33]: scope=10 location=(2-161) inlined_at=26
                 [34]: scope=7 location=(2-249) inlined_at=33
-                [35]: scope=8 location=(1-134773) inlined_at=34"#]],
+                [35]: scope=8 location=(1-134774) inlined_at=34"#]],
     );
 }
 
@@ -339,11 +339,11 @@ fn lambda() {
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-1)
                 1 = SubProgram name=.lambda_2 location=(2-65)
-                2 = SubProgram name=H location=(1-111899)
+                2 = SubProgram name=H location=(1-111900)
             dbg_locations:
                 [1]: scope=0 location=(2-99)
                 [2]: scope=1 location=(2-82) inlined_at=1
-                [3]: scope=2 location=(1-111971) inlined_at=2"#]],
+                [3]: scope=2 location=(1-111972) inlined_at=2"#]],
     );
 }
 
@@ -386,20 +386,20 @@ fn result_comparison_to_literal() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-22)
-                1 = SubProgram name=H location=(1-111899)
-                2 = SubProgram name=M location=(1-113608)
-                3 = SubProgram name=X location=(1-134701)
-                4 = SubProgram name=Reset location=(1-118001)
+                1 = SubProgram name=H location=(1-111900)
+                2 = SubProgram name=M location=(1-113609)
+                3 = SubProgram name=X location=(1-134702)
+                4 = SubProgram name=Reset location=(1-118002)
             dbg_locations:
                 [1]: scope=0 location=(2-86)
-                [2]: scope=1 location=(1-111971) inlined_at=1
+                [2]: scope=1 location=(1-111972) inlined_at=1
                 [3]: scope=0 location=(2-110)
-                [4]: scope=2 location=(1-113650) inlined_at=3
+                [4]: scope=2 location=(1-113651) inlined_at=3
                 [5]: scope=0 location=(2-154)
-                [6]: scope=3 location=(1-134773) inlined_at=5
+                [6]: scope=3 location=(1-134774) inlined_at=5
                 [7]: scope=0 location=(2-125)
                 [8]: scope=0 location=(2-179)
-                [9]: scope=4 location=(1-118045) inlined_at=8"#]],
+                [9]: scope=4 location=(1-118046) inlined_at=8"#]],
     );
 }
 
@@ -449,22 +449,22 @@ fn if_else() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-22)
-                1 = SubProgram name=H location=(1-111899)
-                2 = SubProgram name=M location=(1-113608)
-                3 = SubProgram name=X location=(1-134701)
-                4 = SubProgram name=Y location=(1-135923)
+                1 = SubProgram name=H location=(1-111900)
+                2 = SubProgram name=M location=(1-113609)
+                3 = SubProgram name=X location=(1-134702)
+                4 = SubProgram name=Y location=(1-135924)
             dbg_locations:
                 [2]: scope=0 location=(2-112)
-                [3]: scope=1 location=(1-111971) inlined_at=2
+                [3]: scope=1 location=(1-111972) inlined_at=2
                 [4]: scope=0 location=(2-135)
-                [5]: scope=2 location=(1-113650) inlined_at=4
+                [5]: scope=2 location=(1-113651) inlined_at=4
                 [6]: scope=0 location=(2-176)
-                [7]: scope=3 location=(1-134773) inlined_at=6
+                [7]: scope=3 location=(1-134774) inlined_at=6
                 [8]: scope=0 location=(2-212)
-                [9]: scope=4 location=(1-135995) inlined_at=8
+                [9]: scope=4 location=(1-135996) inlined_at=8
                 [10]: scope=0 location=(2-150)
                 [11]: scope=0 location=(2-246)
-                [12]: scope=2 location=(1-113650) inlined_at=11"#]],
+                [12]: scope=2 location=(1-113651) inlined_at=11"#]],
     );
 }
 
@@ -506,17 +506,17 @@ fn branch_due_to_binop_short_circuit() {
 
             dbg_scopes:
                 0 = SubProgram name=Main location=(2-1)
-                1 = SubProgram name=H location=(1-111899)
-                2 = SubProgram name=M location=(1-113608)
+                1 = SubProgram name=H location=(1-111900)
+                2 = SubProgram name=M location=(1-113609)
             dbg_locations:
                 [2]: scope=0 location=(2-75)
-                [3]: scope=1 location=(1-111971) inlined_at=2
+                [3]: scope=1 location=(1-111972) inlined_at=2
                 [4]: scope=0 location=(2-86)
-                [5]: scope=1 location=(1-111971) inlined_at=4
+                [5]: scope=1 location=(1-111972) inlined_at=4
                 [6]: scope=0 location=(2-107)
-                [7]: scope=2 location=(1-113650) inlined_at=6
+                [7]: scope=2 location=(1-113651) inlined_at=6
                 [8]: scope=0 location=(2-129)
-                [9]: scope=2 location=(1-113650) inlined_at=8
+                [9]: scope=2 location=(1-113651) inlined_at=8
                 [10]: scope=0 location=(2-127)"#]],
     );
 }

--- a/source/qdk_package/README.md
+++ b/source/qdk_package/README.md
@@ -103,6 +103,24 @@ For convenience, the following helpers and types are also importable directly fr
 | `PhaseFlipNoise`     | class    | `qdk.qsharp.PhaseFlipNoise`     | Phase-flip noise model spec.                                           |
 | `Context`            | class    | `qdk.Context`                   | Isolated Q# and OpenQASM interpreter context for independent sessions. |
 
+### Configuration Map
+
+You can provide simple host-side configuration values and read them from Q#.
+
+- Python: use `Context.set_config(key, value)` where `value` is one of `int`, `float`, `str`, or `bool`.
+- Q#: read values with `Std.Diagnostics.GetConfig(name, defaultValue)`.
+
+Example:
+
+```python
+import qdk
+
+ctx = qdk.Context()
+ctx.set_config("experiment_name", "baseline")
+name = ctx.eval('Std.Diagnostics.GetConfig("experiment_name", "")')
+assert name == "baseline"
+```
+
 ## Telemetry
 
 This library sends telemetry. Minimal anonymous data is collected to help measure feature usage and performance.

--- a/source/qdk_package/qdk/_context.py
+++ b/source/qdk_package/qdk/_context.py
@@ -1021,3 +1021,16 @@ class Context:
     def get_target_profile(self) -> TargetProfile:
         """Returns target profile for this Context."""
         return self._target_profile
+
+    def set_config(self, key: str, value: int | float | str | bool) -> None:
+        """
+        Sets a read-only configuration value for this context.
+
+        Values set here can be read from Q# with
+        ``Std.Diagnostics.GetConfig(name, defaultValue)``.
+
+        :param key: The configuration key.
+        :param value: The configuration value. Supported types are
+            ``int``, ``float``, ``str``, and ``bool``.
+        """
+        self._interpreter.set_config(key, value)

--- a/source/qdk_package/qdk/_native.pyi
+++ b/source/qdk_package/qdk/_native.pyi
@@ -339,6 +339,17 @@ class Interpreter:
         """
         ...
 
+    def set_config(self, key: str, value: int | float | str | bool) -> None:
+        """
+        Sets a read-only config value that can be accessed from Q# with
+        ``Std.Diagnostics.GetConfig``.
+
+        :param key: The config key.
+        :param value: The config value. Supported types are
+            ``int``, ``float``, ``str``, and ``bool``.
+        """
+        ...
+
     def dump_machine(self) -> StateDumpData:
         """
         Returns the sparse state vector of the simulator as a StateDump object.

--- a/source/qdk_package/src/interpreter.rs
+++ b/source/qdk_package/src/interpreter.rs
@@ -690,6 +690,7 @@ impl Interpreter {
     }
 
     /// Sets a read-only config value available from Q# via Std.Diagnostics.GetConfig.
+    #[allow(clippy::needless_pass_by_value)]
     fn set_config(&mut self, py: Python, key: &str, value: Py<PyAny>) -> PyResult<()> {
         let value = value.bind(py);
         let config_value = if value.is_instance_of::<PyBool>() {

--- a/source/qdk_package/src/interpreter.rs
+++ b/source/qdk_package/src/interpreter.rs
@@ -40,9 +40,9 @@ use num_bigint::BigUint;
 use num_complex::Complex64;
 use pyo3::{
     IntoPyObjectExt, create_exception,
-    exceptions::{PyException, PyValueError},
+    exceptions::{PyException, PyTypeError, PyValueError},
     prelude::*,
-    types::{PyDict, PyList, PyString, PyTuple, PyType},
+    types::{PyBool, PyDict, PyList, PyString, PyTuple, PyType},
 };
 use qsc::{
     LanguageFeatures, PackageType, SourceMap,
@@ -687,6 +687,27 @@ impl Interpreter {
     #[pyo3(signature=(seed=None))]
     fn set_classical_seed(&mut self, seed: Option<u64>) {
         self.interpreter.set_classical_seed(seed);
+    }
+
+    /// Sets a read-only config value available from Q# via Std.Diagnostics.GetConfig.
+    fn set_config(&mut self, py: Python, key: &str, value: Py<PyAny>) -> PyResult<()> {
+        let value = value.bind(py);
+        let config_value = if value.is_instance_of::<PyBool>() {
+            Value::Bool(value.extract::<bool>()?)
+        } else if let Ok(value) = value.extract::<i64>() {
+            Value::Int(value)
+        } else if let Ok(value) = value.extract::<f64>() {
+            Value::Double(value)
+        } else if let Ok(value) = value.extract::<String>() {
+            Value::String(value.into())
+        } else {
+            return Err(PyTypeError::new_err(
+                "config value must be bool, int, float, or str",
+            ));
+        };
+
+        self.interpreter.set_config(key, config_value);
+        Ok(())
     }
 
     /// Dumps the quantum state of the interpreter.

--- a/source/qdk_package/tests/test_context.py
+++ b/source/qdk_package/tests/test_context.py
@@ -204,3 +204,32 @@ def test_context_released_after_drop() -> None:
     del ctx
     gc.collect()
     assert ref() is None
+
+
+def test_config(context: qdk.Context) -> None:
+    context.set_config("int_config", 123)
+    assert context.eval("""Std.Diagnostics.GetConfig("int_config",0)""") == 123
+
+    context.set_config("bool_config", True)
+    assert context.eval("""Std.Diagnostics.GetConfig("bool_config",true)""") is True
+
+    context.set_config("string_config", "value")
+    assert context.eval("""Std.Diagnostics.GetConfig("string_config","")""") == "value"
+
+    context.set_config("double_config", 124.1)
+    assert context.eval("""Std.Diagnostics.GetConfig("double_config",0.0)""") == 124.1
+
+    # Default values.
+    assert context.eval("""Std.Diagnostics.GetConfig("unknown", "foo")""") == "foo"
+    assert context.eval("""Std.Diagnostics.GetConfig("unknown", false)""") is False
+    assert context.eval("""Std.Diagnostics.GetConfig("unknown", 12)""") == 12
+    assert context.eval("""Std.Diagnostics.GetConfig("unknown", 12.0)""") == 12.0
+
+    # Can overwrite an existing value.
+    context.set_config("int_config", 100)
+    assert context.eval("""Std.Diagnostics.GetConfig("int_config",0)""") == 100
+
+
+def test_config_invalid_type(context: qdk.Context) -> None:
+    with pytest.raises(TypeError):
+        context.set_config("invalid", {"a": 1})

--- a/source/qdk_package/tests/test_context.py
+++ b/source/qdk_package/tests/test_context.py
@@ -232,4 +232,4 @@ def test_config(context: qdk.Context) -> None:
 
 def test_config_invalid_type(context: qdk.Context) -> None:
     with pytest.raises(TypeError):
-        context.set_config("invalid", {"a": 1})
+        context.set_config("invalid", {"a": 1}) # type: ignore


### PR DESCRIPTION
This PR adds a key-value configuration map to the interpreter, that can be written into from interpreter call site and can be read from inside Q# code. It also adds Python API to write into it. Fixes https://github.com/microsoft/qdk/issues/3271