### PR TITLE
Fix QIR generation panic on mutable qubit variables

### DIFF
--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -2926,8 +2926,9 @@ impl<'a> PartialEvaluator<'a> {
                                 .config
                                 .capabilities
                                 .contains(TargetCapabilityFlags::BackwardsBranching))
+                        && let Some(value) = map_rir_literal_to_eval_value(*literal)
                     {
-                        map_rir_literal_to_eval_value(*literal)
+                        value
                     } else {
                         bound_value.clone()
                     }
@@ -5073,12 +5074,12 @@ fn map_fir_type_to_rir_type(ty: &Ty) -> Result<rir::Ty, String> {
     }
 }
 
-fn map_rir_literal_to_eval_value(literal: rir::Literal) -> Value {
+fn map_rir_literal_to_eval_value(literal: rir::Literal) -> Option<Value> {
     match literal {
-        rir::Literal::Bool(b) => Value::Bool(b),
-        rir::Literal::Double(d) => Value::Double(d),
-        rir::Literal::Integer(i) => Value::Int(i),
-        _ => panic!("{literal:?} RIR literal cannot be mapped to evaluator value"),
+        rir::Literal::Bool(b) => Some(Value::Bool(b)),
+        rir::Literal::Double(d) => Some(Value::Double(d)),
+        rir::Literal::Integer(i) => Some(Value::Int(i)),
+        _ => None,
     }
 }
 

--- a/source/compiler/qsc_partial_eval/src/tests/bindings.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/bindings.rs
@@ -7,6 +7,8 @@
     clippy::too_many_lines
 )]
 
+use crate::tests::get_rir_program_with_adaptive_profile;
+
 use super::{assert_block_instructions, assert_blocks, assert_callable, get_rir_program};
 use expect_test::expect;
 use indoc::indoc;
@@ -562,5 +564,54 @@ fn mutable_double_binding_does_generate_store_instruction() {
             Block 3:Block:
                 Variable(2, Double) = Store Double(1.1)
                 Jump(1)"#]],
+    );
+}
+
+#[test]
+fn mutable_qubit_var_generates_successfully() {
+    let program = get_rir_program(indoc! {r#"
+        operation Main() : Unit {
+            use q = Qubit();
+            mutable q = q;
+            H(q);
+        }
+    "#});
+
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Pointer, )
+                Variable(0, Qubit) = Store Qubit(0)
+                Call id(2), args( Variable(0, Qubit), )
+                Call id(3), args( Integer(0), Tag(0, 3), )
+                Return Integer(0)"#]],
+    );
+}
+
+#[test]
+fn mutable_qubit_var_generates_adaptive_successfully() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {r#"
+        operation Main() : Unit {
+            use q = Qubit();
+            mutable q = q;
+            H(q);
+        }
+    "#});
+
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Pointer, )
+                Variable(0, Qubit) = Store Qubit(0)
+                Call id(2), args( Variable(0, Qubit), )
+                Call id(4), args( Integer(0), Tag(0, 3), )
+                Return Integer(0)
+            Block 1:Block:
+                Call id(3), args( Variable(1, Qubit), )
+                Return"#]],
     );
 }


### PR DESCRIPTION
This fixes a panic in QIR generation introduced by the support for qubit variables. Rather than triggering a panic, the code now uses an existing fallback path to generate store instructions that will later get transformed away.