### PR TITLE
Allow use of deprecated `.loss` attr

### DIFF
--- a/source/qdk_package/src/qir_simulation.rs
+++ b/source/qdk_package/src/qir_simulation.rs
@@ -532,6 +532,9 @@ impl NoiseTable {
             2 => {
                 let single = value * (1.0 - value);
                 let both = value * value;
+                for fault in ["XL", "YL", "ZL", "LX", "LY", "LZ"] {
+                    self.set_pauli_noise_elt(fault, 0.0)?;
+                }
                 self.set_pauli_noise_elt("IL", single)?;
                 self.set_pauli_noise_elt("LI", single)?;
                 self.set_pauli_noise_elt("LL", both)
@@ -546,6 +549,16 @@ impl NoiseTable {
         match self.qubits {
             1 => self.get_pauli_noise_elt("L"),
             2 => {
+                for fault in ["XL", "YL", "ZL", "LX", "LY", "LZ"] {
+                    if self.get_pauli_noise_elt(fault)? > 0.0 {
+                        return Err(PyAttributeError::new_err(
+                            "`.loss` convenience mechanism should not be used with setting correlated faults individually.
+To get the loss probabilities, access the correlated strings individually.
+E.g.: `noise_config.cz.IL`"
+                                .to_string(),
+                        ));
+                    }
+                }
                 let both = self.get_pauli_noise_elt("LL")?;
                 Ok(both.sqrt())
             }

--- a/source/qdk_package/src/qir_simulation.rs
+++ b/source/qdk_package/src/qir_simulation.rs
@@ -541,6 +541,19 @@ impl NoiseTable {
             ))),
         }
     }
+
+    fn get_loss(&self) -> PyResult<Probability> {
+        match self.qubits {
+            1 => self.get_pauli_noise_elt("L"),
+            2 => {
+                let both = self.get_pauli_noise_elt("LL")?;
+                Ok(both.sqrt())
+            }
+            n => Err(PyAttributeError::new_err(format!(
+                "The `loss` attribute is only supported for one- and two-qubit operations, but this operation targets {n} qubits."
+            ))),
+        }
+    }
 }
 
 #[allow(
@@ -565,12 +578,7 @@ impl NoiseTable {
     /// for arbitrary pauli fields.
     fn __getattr__(&mut self, name: &str) -> PyResult<Probability> {
         if name == "loss" {
-            return Err(PyAttributeError::new_err(
-                "`.loss` is a convenience over setting correlated faults individually.
-To get the loss probabilities, access the correlated strings individually.
-E.g.: `noise_config.cz.IL`"
-                    .to_string(),
-            ));
+            return self.get_loss();
         }
         self.get_pauli_noise_elt(&name.to_uppercase())
     }


### PR DESCRIPTION
Removing the `.loss` getter on `NoiseTable` ended up being a breaking change for some consumers (specifically, qdk-chemistry unit tests). We should just support it.