### PR TITLE
Types for target modeling (qubit, QECStrategy, Target) and tests

### DIFF
--- a/source/qdk_package/qdk/qre/__init__.py
+++ b/source/qdk_package/qdk/qre/__init__.py
@@ -2,7 +2,13 @@
 # Licensed under the MIT License.
 
 from ._application import Application, TraceParameters
-from ._architecture import Architecture, ISAContext
+from ._architecture import (
+    Architecture,
+    ISAContext,
+    TechnologyFamily,
+    qubit,
+    QUBIT_MODELS,
+)
 from ._estimation import estimate
 from ._instruction import (
     LOGICAL,
@@ -38,6 +44,7 @@ from ._results import (
     EstimationTableEntry,
     plot_estimates,
 )
+from ._target import QECStrategy, Target
 from ._trace import (
     LatticeSurgery,
     PSSPC,
@@ -90,6 +97,10 @@ __all__ = [
     "PSSPC",
     "property_name",
     "property_name_to_key",
+    "QECStrategy",
+    "qubit",
+    "Target",
+    "TechnologyFamily",
     "Trace",
     "TraceParameters",
     "TraceQuery",
@@ -97,4 +108,5 @@ __all__ = [
     "Unmemory",
     "LOGICAL",
     "PHYSICAL",
+    "QUBIT_MODELS",
 ]

--- a/source/qdk_package/qdk/qre/_architecture.py
+++ b/source/qdk_package/qdk/qre/_architecture.py
@@ -2,29 +2,43 @@
 # Licensed under the MIT License.
 
 from __future__ import annotations
-import copy
-from typing import cast, TYPE_CHECKING
 
+import copy
+import dataclasses
 from abc import ABC, abstractmethod
+from enum import IntEnum
+from typing import TYPE_CHECKING, cast
 
 from ._qre import (
     ISA,
-    _ProvenanceGraph,
     Instruction,
-    _IntFunction,
     _FloatFunction,
+    _IntFunction,
+    _ProvenanceGraph,
     constant_function,
     property_name_to_key,
 )
+from .instruction_ids import INSTRUCTION_ID_MAP
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Any, Optional, Type, Union
 
-    from ._instruction import ISATransform, Encoding
+    from ._instruction import Encoding, ISATransform
+
+
+class TechnologyFamily(IntEnum):
+    UNKNOWN = 0
+    TOPOLOGICAL = 1
+    SUPERCONDUCTING = 2
+    ION_TRAP = 3
+    NEUTRAL_ATOM = 4
+    SOLID_STATE = 5
 
 
 class Architecture(ABC):
     """Abstract base class for quantum hardware architectures."""
+
+    family: TechnologyFamily = TechnologyFamily.UNKNOWN
 
     @abstractmethod
     def provided_isa(self, ctx: ISAContext) -> ISA:
@@ -48,6 +62,153 @@ class Architecture(ABC):
             ISAContext: A new enumeration context.
         """
         return ISAContext(self)
+
+    @property
+    def assumptions(self) -> list[str]:
+        """
+        A list of assumptions for the architecture.
+
+        Returns:
+            list[str]: A list of assumptions.
+        """
+        return []
+
+    @property
+    def references(self) -> list[str]:
+        """
+        A list of technical references for the architecture.
+
+        Returns:
+            list[str]: A list of technical references.
+        """
+        return []
+
+
+def qubit(
+    base_class: Optional[Union[Type[Architecture], type]] = None,
+    name: Optional[str] = None,
+    *,
+    family: TechnologyFamily = TechnologyFamily.UNKNOWN,
+) -> Any:
+    """Decorator that turns a plain class into an Architecture subclass.
+
+    Args:
+        base_class: An Architecture subclass to inherit from.  If ``None``,
+            ``provided_isa`` is auto-generated from instruction ID attributes.
+        name: Human-readable name.  Defaults to the class name.
+        family: The technology family this qubit belongs to.
+
+    Returns:
+        The returned type is intentionally ``Any`` because the generated class
+        combines the decorated class with a dynamically chosen ``Architecture``
+        base, which cannot be expressed statically.
+
+    Examples::
+
+        @qubit(Majorana, family=TechnologyFamily.TOPOLOGICAL)
+        class MajoranaQubit:
+            error_rate: float = 1e-6
+
+        @qubit(family=TechnologyFamily.SUPERCONDUCTING)
+        class FastGoodQubit:
+            CNOT = {"arity": 2, "time": 100, "error_rate": 1e-6}
+    """
+
+    def decorator(cls):
+        nonlocal base_class, name
+
+        actual_base = base_class if base_class is not None else Architecture
+        actual_name = name if name is not None else cls.__name__
+
+        attrs = {
+            key: value for key, value in cls.__dict__.items() if not key.startswith("_")
+        }
+        annotations = dict(getattr(cls, "__annotations__", {}))
+
+        # When the base is a dataclass, promote bare attributes that match a
+        # parent dataclass field into annotations so they become proper field
+        # overrides rather than plain class attributes shadowed by __init__.
+        if dataclasses.is_dataclass(actual_base):
+            parent_fields = {f.name: f for f in dataclasses.fields(actual_base)}
+            for attr_name, value in list(attrs.items()):
+                if attr_name in parent_fields and attr_name not in annotations:
+                    annotations[attr_name] = parent_fields[attr_name].type
+
+        # When no base class provides provided_isa, generate one from
+        # attributes that match instruction ID names.
+        if base_class is None:
+            instruction_attrs: dict[str, dict] = {}
+            for attr_name in list(attrs):
+                if attr_name in INSTRUCTION_ID_MAP and isinstance(
+                    attrs[attr_name], dict
+                ):
+                    instruction_attrs[attr_name] = attrs.pop(attr_name)
+                    annotations.pop(attr_name, None)
+
+            def _provided_isa(self, ctx: ISAContext, _instr=instruction_attrs) -> ISA:
+                sources = []
+                for instr_name, kwargs in _instr.items():
+                    instr_id = INSTRUCTION_ID_MAP[instr_name]
+                    sources.append(ctx.add_instruction(instr_id, **kwargs))
+                return ctx.make_isa(*sources)
+
+            attrs["provided_isa"] = _provided_isa
+
+        attrs["__annotations__"] = annotations
+        attrs["__str__"] = lambda self, n=actual_name: n
+        attrs["__qualname__"] = cls.__qualname__
+        attrs["__module__"] = cls.__module__
+
+        attrs["family"] = family
+
+        new_cls = type(cls.__name__, (actual_base,), attrs)
+
+        if dataclasses.is_dataclass(actual_base):
+            new_cls = dataclasses.dataclass(new_cls)
+
+        # Register the model for auto-derived target lookup.
+        _register_qubit_model(new_cls, actual_name)
+
+        return new_cls
+
+    # Support @qubit without parentheses (bare decorator on a class).
+    if (
+        base_class is not None
+        and isinstance(base_class, type)
+        and not issubclass(base_class, Architecture)
+    ):
+        # Called as @qubit with no args — base_class is actually the class.
+        cls = base_class
+        base_class = None
+        name = None
+        return decorator(cls)
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Global qubit model registry — populated by the @qubit decorator.
+# Maps a model's display name to its qubit model class.
+# ---------------------------------------------------------------------------
+
+QUBIT_MODELS: dict[str, type] = {}
+
+
+def _register_qubit_model(cls: type, display_name: str) -> None:
+    """Register a qubit model class under its display name.
+
+    Args:
+        cls (type): The qubit model class to register.
+        display_name (str): The name to register the model under.
+
+    Raises:
+        ValueError: If a different model is already registered under
+            ``display_name``.
+    """
+    existing = QUBIT_MODELS.get(display_name)
+    if existing is not None and existing is not cls:
+        raise ValueError(f"A qubit model named {display_name!r} is already registered.")
+    QUBIT_MODELS[display_name] = cls
 
 
 class ISAContext:

--- a/source/qdk_package/qdk/qre/_target.py
+++ b/source/qdk_package/qdk/qre/_target.py
@@ -1,0 +1,142 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from ._architecture import Architecture
+from ._isa_enumeration import ISAQuery
+from ._results import EstimationTableEntry
+
+
+@dataclass(frozen=True)
+class QECStrategy:
+    """Encapsulates QEC-specific behaviour for a target.
+
+    A ``QECStrategy`` bundles together everything that varies between error
+    correction schemes: how to enumerate the corresponding ISAs, which
+    lattice-surgery and magic-state transforms are required, and the extra
+    result columns and assumptions to surface. Instances are defined once as
+    module-level constants and combined with an :class:`Architecture` to form a
+    :class:`Target`.
+
+    Instances are immutable (``frozen=True``) so they can be safely shared as
+    module-level singletons.
+
+    Attributes:
+        suffix: Short, machine-friendly identifier for the strategy (e.g.
+            ``"sc"``, ``"3aux"``).
+        name: Human-readable label for the strategy (e.g.
+            ``"Surface Code"``, ``"Lattice Surgery (3aux)"``) for display.
+        build_isa_query: Zero-argument factory that constructs the
+            :class:`ISAQuery` enumeration tree for this strategy. Stored as a
+            callable (rather than a prebuilt query) so the tree is only built
+            lazily when :attr:`isa_query` is accessed, and so each access yields
+            a fresh, independently consumable tree. Prefer the :attr:`isa_query`
+            property over calling this directly.
+        needs_lattice_surgery_transform: Whether estimation must insert a
+            lattice-surgery transform when lowering the application to this
+            strategy's ISA.
+        supports_ccx_states: Whether the strategy can consume CCX (Toffoli)
+            magic states directly. When ``True``, estimation requests CCX magic
+            states from the PSSPC layer and reports a ``num_ccx_states`` column.
+        columns: Extra result columns to append to the estimation table,
+            each a ``(column_name, extractor)`` pair where ``extractor`` maps an
+            :class:`EstimationTableEntry` to the cell value (e.g. code
+            distances, cycle times). Stored as a tuple so instances remain
+            fully immutable.
+        assumptions: Human-readable assumptions specific to this strategy,
+            merged with the architecture's assumptions and rendered in report
+            output.
+    """
+
+    suffix: str
+    name: str
+    build_isa_query: Callable[[], ISAQuery]
+    needs_lattice_surgery_transform: bool = True
+    supports_ccx_states: bool = False
+    columns: tuple[tuple[str, Callable[[EstimationTableEntry], Any]], ...] = ()
+    assumptions: tuple[str, ...] = ()
+
+    @property
+    def isa_query(self) -> ISAQuery:
+        """Build and return a fresh :class:`ISAQuery` for this strategy.
+
+        Invokes :attr:`build_isa_query` on every access, so each call returns
+        a new enumeration tree that can be consumed independently by an
+        estimation run.
+        """
+        return self.build_isa_query()
+
+
+@dataclass(frozen=True)
+class Target:
+    """A target is an architecture paired with a QEC strategy.
+
+    It describes a specific physical machine together with the error correction
+    and magic state factories needed to create logical instructions. A target
+    is the unit passed to estimation: it supplies the architecture, the ISA
+    enumeration to search over, and the strategy-specific transforms, columns,
+    and assumptions.
+
+    Targets are constructed by pairing a qubit model / architecture with a
+    :class:`QECStrategy`. Instances are immutable (``frozen=True``); the
+    remaining public surface consists of read-only properties that delegate to
+    the wrapped :class:`QECStrategy`.
+
+    Attributes:
+        architecture (Architecture): The physical qubit model / architecture
+            (e.g. a neutral-atom or superconducting model) this target runs on.
+        qec (QECStrategy): The :class:`QECStrategy` describing how logical
+            instructions are realised on that architecture.
+    """
+
+    architecture: Architecture
+    qec: QECStrategy
+
+    @property
+    def name(self) -> str:
+        """Unique target name, formatted as ``"{architecture}+{suffix}"``."""
+        return f"{self.architecture}+{self.qec.suffix}"
+
+    @property
+    def isa_query(self) -> ISAQuery:
+        """Fresh :class:`ISAQuery` enumeration tree for this target.
+
+        Delegates to :attr:`QECStrategy.isa_query`, so each access returns a
+        newly built, independently consumable tree.
+        """
+        return self.qec.isa_query
+
+    @property
+    def needs_lattice_surgery_transform(self) -> bool:
+        """Whether estimation must insert a lattice-surgery transform.
+
+        Delegates to :attr:`QECStrategy.needs_lattice_surgery_transform`.
+        """
+        return self.qec.needs_lattice_surgery_transform
+
+    @property
+    def supports_ccx_states(self) -> bool:
+        """Whether the strategy can consume CCX (Toffoli) magic states.
+
+        Delegates to :attr:`QECStrategy.supports_ccx_states`.
+        """
+        return self.qec.supports_ccx_states
+
+    @property
+    def columns(self) -> tuple[tuple[str, Callable[[EstimationTableEntry], Any]], ...]:
+        """Extra ``(name, extractor)`` result columns for this target.
+
+        Delegates to :attr:`QECStrategy.columns`.
+        """
+        return self.qec.columns
+
+    @property
+    def assumptions(self) -> list[str]:
+        """Combined assumptions to surface in report output.
+
+        Concatenates the architecture's assumptions with the QEC strategy's
+        assumptions.
+        """
+        return self.architecture.assumptions + list(self.qec.assumptions)

--- a/source/qdk_package/qdk/qre/instruction_ids.py
+++ b/source/qdk_package/qdk/qre/instruction_ids.py
@@ -6,5 +6,10 @@
 
 from .._native import instruction_ids
 
-for name in instruction_ids.__all__:
-    globals()[name] = getattr(instruction_ids, name)
+INSTRUCTION_ID_MAP: dict[str, int] = {
+    attr: getattr(instruction_ids, attr)
+    for attr in dir(instruction_ids)
+    if not attr.startswith("_") and isinstance(getattr(instruction_ids, attr), int)
+}
+
+globals().update(INSTRUCTION_ID_MAP)

--- a/source/qdk_package/qdk/qre/instruction_ids.pyi
+++ b/source/qdk_package/qdk/qre/instruction_ids.pyi
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+INSTRUCTION_ID_MAP: dict[str, int]
+
 # Paulis
 PAULI_I: int
 PAULI_X: int

--- a/source/qdk_package/tests/qre/test_qubit_and_target.py
+++ b/source/qdk_package/tests/qre/test_qubit_and_target.py
@@ -1,0 +1,285 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from dataclasses import FrozenInstanceError, dataclass
+from typing import Any, cast
+
+import pytest
+
+from qdk.qre import (
+    PHYSICAL,
+    Architecture,
+    QECStrategy,
+    QUBIT_MODELS,
+    Target,
+    TechnologyFamily,
+    qubit,
+)
+from qdk.qre._architecture import ISAContext
+from qdk.qre._instruction import ISA
+from qdk.qre._isa_enumeration import ISAQuery
+from qdk.qre.instruction_ids import CNOT, MEAS_Z
+
+
+def _dummy_query() -> ISAQuery:
+    """Return a placeholder ISAQuery for tests that never consume it."""
+    return cast(ISAQuery, object())
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    """Snapshot and restore the global QUBIT_MODELS registry around each test."""
+    saved = dict(QUBIT_MODELS)
+    try:
+        yield
+    finally:
+        QUBIT_MODELS.clear()
+        QUBIT_MODELS.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# @qubit decorator
+# ---------------------------------------------------------------------------
+
+
+def test_qubit_bare_decorator():
+    """A bare @qubit (no parentheses) produces an Architecture subclass."""
+
+    @qubit
+    class BareModel:
+        pass
+
+    assert issubclass(BareModel, Architecture)
+    assert isinstance(BareModel(), Architecture)
+
+
+def test_qubit_default_name_and_family():
+    """@qubit defaults the display name to the class name and family to UNKNOWN."""
+
+    @qubit
+    class DefaultNameModel:
+        pass
+
+    assert str(DefaultNameModel()) == "DefaultNameModel"
+    assert DefaultNameModel().family is TechnologyFamily.UNKNOWN
+
+
+def test_qubit_family_and_name_override():
+    """The family keyword and name argument are applied to the generated class."""
+
+    @qubit(name="Fancy", family=TechnologyFamily.SUPERCONDUCTING)
+    class RenamedModel:
+        pass
+
+    assert str(RenamedModel()) == "Fancy"
+    assert RenamedModel().family is TechnologyFamily.SUPERCONDUCTING
+
+
+def test_qubit_auto_generated_provided_isa():
+    """Instruction-dict attributes are turned into an auto-generated ISA."""
+
+    @qubit(family=TechnologyFamily.SUPERCONDUCTING)
+    class AutoIsaModel:
+        CNOT = {"arity": 2, "time": 100, "error_rate": 1e-3, "encoding": PHYSICAL}
+        MEAS_Z = {"arity": 1, "time": 50, "error_rate": 1e-3, "encoding": PHYSICAL}
+
+    model = AutoIsaModel()
+    isa: ISA = model.provided_isa(model.context())
+
+    assert CNOT in isa
+    assert MEAS_Z in isa
+    assert len(isa) == 2
+    assert isa[CNOT].time() == 100
+    assert isa[MEAS_Z].error_rate() == 1e-3
+
+
+def test_qubit_class_level_metadata():
+    """Class-level assumptions/references lists surface via the properties."""
+
+    @qubit
+    class MetadataModel:
+        assumptions = ["assume-x"]
+        references = ["ref-y"]
+
+    model = MetadataModel()
+    assert model.assumptions == ["assume-x"]
+    assert model.references == ["ref-y"]
+
+
+def test_qubit_preserves_base_metadata():
+    """Inherited assumptions are preserved when the subclass does not override."""
+
+    class Base(Architecture):
+        @property
+        def assumptions(self) -> list[str]:
+            return ["base-assumption"]
+
+        def provided_isa(self, ctx: ISAContext) -> ISA:
+            return ctx.make_isa()
+
+    @qubit(Base)
+    class DerivedModel:
+        pass
+
+    assert DerivedModel().assumptions == ["base-assumption"]
+
+
+def test_qubit_dataclass_field_override():
+    """Bare attributes matching a dataclass base field become field overrides."""
+
+    @dataclass
+    class DataBase(Architecture):
+        error_rate: float = 1e-3
+
+        def provided_isa(self, ctx: ISAContext) -> ISA:
+            return ctx.make_isa()
+
+    @qubit(DataBase)
+    class TunedModel:
+        error_rate = 1e-6
+
+    assert TunedModel().error_rate == 1e-6
+    # The override is a proper dataclass field, so it can still be set via init.
+    assert TunedModel(error_rate=1e-9).error_rate == 1e-9
+
+
+def test_qubit_registers_model():
+    """Decorated models are registered in QUBIT_MODELS under their display name."""
+
+    @qubit(name="RegisteredModel")
+    class _Registered:
+        pass
+
+    assert QUBIT_MODELS["RegisteredModel"] is _Registered
+
+
+def test_qubit_duplicate_name_raises():
+    """Registering two different models under the same name raises ValueError."""
+
+    @qubit(name="CollidingModel")
+    class _First:
+        pass
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @qubit(name="CollidingModel")
+        class _Second:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# QECStrategy
+# ---------------------------------------------------------------------------
+
+
+def test_qec_strategy_defaults():
+    """QECStrategy applies documented defaults for optional fields."""
+
+    strategy = QECStrategy(
+        suffix="sc", name="Surface Code", build_isa_query=_dummy_query
+    )
+
+    assert strategy.needs_lattice_surgery_transform is True
+    assert strategy.supports_ccx_states is False
+    assert strategy.columns == ()
+    assert strategy.assumptions == ()
+
+
+def test_qec_strategy_is_frozen():
+    """QECStrategy instances are immutable."""
+
+    strategy = QECStrategy(
+        suffix="sc", name="Surface Code", build_isa_query=_dummy_query
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        strategy.suffix = "other"  # type: ignore[misc]
+
+
+def test_qec_strategy_isa_query_is_fresh_each_access():
+    """isa_query invokes build_isa_query on every access, yielding fresh trees."""
+
+    calls = {"n": 0}
+
+    def build() -> ISAQuery:
+        calls["n"] += 1
+        return cast(ISAQuery, object())
+
+    strategy = QECStrategy(suffix="sc", name="Surface Code", build_isa_query=build)
+
+    first = strategy.isa_query
+    second = strategy.isa_query
+
+    assert calls["n"] == 2
+    assert first is not second
+
+
+# ---------------------------------------------------------------------------
+# Target
+# ---------------------------------------------------------------------------
+
+
+@qubit(name="TargetTestQubit", family=TechnologyFamily.SUPERCONDUCTING)
+class _TargetQubit:
+    assumptions = ["arch-assumption"]
+
+
+def _make_strategy(**kwargs) -> QECStrategy:
+    params: dict[str, Any] = dict(
+        suffix="sc", name="Surface Code", build_isa_query=_dummy_query
+    )
+    params.update(kwargs)
+    return QECStrategy(**params)
+
+
+def test_target_clean_constructor():
+    """Target exposes clean, non-underscore constructor parameters."""
+
+    arch = _TargetQubit()
+    strategy = _make_strategy()
+
+    target = Target(architecture=arch, qec=strategy)
+
+    assert target.architecture is arch
+    assert target.qec is strategy
+
+
+def test_target_name_format():
+    """Target name combines the architecture name and the strategy suffix."""
+
+    target = Target(architecture=_TargetQubit(), qec=_make_strategy(suffix="3aux"))
+
+    assert target.name == "TargetTestQubit+3aux"
+
+
+def test_target_delegates_to_strategy():
+    """Target read-only properties delegate to the wrapped QECStrategy."""
+
+    strategy = _make_strategy(
+        needs_lattice_surgery_transform=False,
+        supports_ccx_states=True,
+        columns=(("distance", lambda entry: 7),),
+    )
+    target = Target(architecture=_TargetQubit(), qec=strategy)
+
+    assert target.needs_lattice_surgery_transform is False
+    assert target.supports_ccx_states is True
+    assert target.columns == strategy.columns
+
+
+def test_target_assumptions_concatenated():
+    """Target assumptions concatenate architecture and strategy assumptions."""
+
+    strategy = _make_strategy(assumptions=("qec-assumption",))
+    target = Target(architecture=_TargetQubit(), qec=strategy)
+
+    assert target.assumptions == ["arch-assumption", "qec-assumption"]
+
+
+def test_target_is_frozen():
+    """Target instances are immutable."""
+
+    target = Target(architecture=_TargetQubit(), qec=_make_strategy())
+
+    with pytest.raises(FrozenInstanceError):
+        target.qec = _make_strategy()  # type: ignore[misc]


### PR DESCRIPTION
A target combines an architecture with a QEC strategy, e.g., a super conducting qubit architecture with surface code and round-based T state distillation.

A decorator `@qubit` that can build new qubit architectures from scratch (by defining the explicit gate set) or by subclassing generic models (e.g., Majorana or NeutralAtom).