### PR TITLE
FIR transform side effect updates

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -905,21 +905,21 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
         block_1:
           br label %block_2
         block_2:
-          %var_259 = phi i1 [true, %block_0], [false, %block_1]
+          %var_235 = phi i1 [true, %block_0], [false, %block_1]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
           %var_11 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 1 to %Result*))
           br i1 %var_11, label %block_3, label %block_4
         block_3:
           br label %block_4
         block_4:
-          %var_260 = phi i1 [%var_259, %block_2], [false, %block_3]
+          %var_236 = phi i1 [%var_235, %block_2], [false, %block_3]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
           %var_13 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 2 to %Result*))
           br i1 %var_13, label %block_5, label %block_6
         block_5:
           br label %block_6
         block_6:
-          %var_261 = phi i1 [%var_260, %block_4], [false, %block_5]
+          %var_237 = phi i1 [%var_236, %block_4], [false, %block_5]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -936,21 +936,21 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
         block_7:
           br label %block_8
         block_8:
-          %var_262 = phi i1 [true, %block_6], [false, %block_7]
+          %var_238 = phi i1 [true, %block_6], [false, %block_7]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
           %var_27 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 4 to %Result*))
           br i1 %var_27, label %block_9, label %block_10
         block_9:
           br label %block_10
         block_10:
-          %var_263 = phi i1 [%var_262, %block_8], [false, %block_9]
+          %var_239 = phi i1 [%var_238, %block_8], [false, %block_9]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
           %var_29 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 5 to %Result*))
           br i1 %var_29, label %block_11, label %block_12
         block_11:
           br label %block_12
         block_12:
-          %var_264 = phi i1 [%var_263, %block_10], [false, %block_11]
+          %var_240 = phi i1 [%var_239, %block_10], [false, %block_11]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -1009,26 +1009,26 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
-          %var_170 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 6 to %Result*))
-          br i1 %var_170, label %block_13, label %block_14
+          %var_154 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 6 to %Result*))
+          br i1 %var_154, label %block_13, label %block_14
         block_13:
           br label %block_14
         block_14:
-          %var_265 = phi i1 [true, %block_12], [false, %block_13]
+          %var_241 = phi i1 [true, %block_12], [false, %block_13]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
-          %var_172 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 7 to %Result*))
-          br i1 %var_172, label %block_15, label %block_16
+          %var_156 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 7 to %Result*))
+          br i1 %var_156, label %block_15, label %block_16
         block_15:
           br label %block_16
         block_16:
-          %var_266 = phi i1 [%var_265, %block_14], [false, %block_15]
+          %var_242 = phi i1 [%var_241, %block_14], [false, %block_15]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 8 to %Result*))
-          %var_174 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 8 to %Result*))
-          br i1 %var_174, label %block_17, label %block_18
+          %var_158 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 8 to %Result*))
+          br i1 %var_158, label %block_17, label %block_18
         block_17:
           br label %block_18
         block_18:
-          %var_267 = phi i1 [%var_266, %block_16], [false, %block_17]
+          %var_243 = phi i1 [%var_242, %block_16], [false, %block_17]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -1067,32 +1067,32 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 9 to %Result*))
-          %var_251 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 9 to %Result*))
-          br i1 %var_251, label %block_19, label %block_20
+          %var_227 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 9 to %Result*))
+          br i1 %var_227, label %block_19, label %block_20
         block_19:
           br label %block_20
         block_20:
-          %var_268 = phi i1 [true, %block_18], [false, %block_19]
+          %var_244 = phi i1 [true, %block_18], [false, %block_19]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 10 to %Result*))
-          %var_253 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 10 to %Result*))
-          br i1 %var_253, label %block_21, label %block_22
+          %var_229 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 10 to %Result*))
+          br i1 %var_229, label %block_21, label %block_22
         block_21:
           br label %block_22
         block_22:
-          %var_269 = phi i1 [%var_268, %block_20], [false, %block_21]
+          %var_245 = phi i1 [%var_244, %block_20], [false, %block_21]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 11 to %Result*))
-          %var_255 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 11 to %Result*))
-          br i1 %var_255, label %block_23, label %block_24
+          %var_231 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 11 to %Result*))
+          br i1 %var_231, label %block_23, label %block_24
         block_23:
           br label %block_24
         block_24:
-          %var_270 = phi i1 [%var_269, %block_22], [false, %block_23]
+          %var_246 = phi i1 [%var_245, %block_22], [false, %block_23]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__rt__array_record_output(i64 4, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_261, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_264, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_267, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_270, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_237, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_240, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_243, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_246, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
           ret i64 0
         }
 

--- a/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
@@ -2323,39 +2323,39 @@ fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
 
         declare void @__quantum__rt__initialize(ptr)
 
-        define void @S__Adj(ptr %var_4) {
+        define void @S__Adj(ptr %var_3) {
         block_1:
-          call void @__quantum__qis__s__adj(ptr %var_4)
+          call void @__quantum__qis__s__adj(ptr %var_3)
           ret void
         }
 
         declare void @__quantum__qis__s__adj(ptr)
 
-        define void @H(ptr %var_5) {
+        define void @H(ptr %var_4) {
         block_2:
-          call void @__quantum__qis__h__body(ptr %var_5)
+          call void @__quantum__qis__h__body(ptr %var_4)
           ret void
         }
 
         declare void @__quantum__qis__h__body(ptr)
 
-        define void @Rz(double %var_13, ptr %var_14) {
+        define void @Rz(double %var_11, ptr %var_12) {
         block_3:
-          call void @__quantum__qis__rz__body(double %var_13, ptr %var_14)
+          call void @__quantum__qis__rz__body(double %var_11, ptr %var_12)
           ret void
         }
 
         declare void @__quantum__qis__rz__body(double, ptr)
 
-        define void @H__Adj(ptr %var_15) {
+        define void @H__Adj(ptr %var_13) {
         block_4:
-          call void @__quantum__qis__h__body(ptr %var_15)
+          call void @__quantum__qis__h__body(ptr %var_13)
           ret void
         }
 
-        define void @S(ptr %var_16) {
+        define void @S(ptr %var_14) {
         block_5:
-          call void @__quantum__qis__s__body(ptr %var_16)
+          call void @__quantum__qis__s__body(ptr %var_14)
           ret void
         }
 

--- a/source/compiler/qsc_fir_transforms/src/cond_normalize.rs
+++ b/source/compiler/qsc_fir_transforms/src/cond_normalize.rs
@@ -44,8 +44,8 @@
 //!
 //! Left untouched: value-position `if`s (defunctionalization removes the
 //! binding and rebuilds a tree referencing each guard once); `while` guards
-//! (re-evaluated per iteration); and provably-pure conditions, per the
-//! conservative [`crate::walk_utils::expr_is_side_effect_free`] predicate.
+//! (re-evaluated per iteration); and conditions whose evaluation is locally
+//! proven side-effect-free by [`crate::walk_utils::expr_is_side_effect_free`].
 //!
 //! # Binding placement
 //!
@@ -154,7 +154,7 @@ fn normalize_conditions_in_package(
     // callables in this package are considered.
     let mut targets: Vec<ConditionTarget> = Vec::new();
     for (_item_id, decl) in reachable_local_callables(package, package_id, reachable) {
-        collect_targets_in_callable_impl(package, &decl.implementation, &mut targets);
+        collect_targets_in_callable_impl(package, package_id, &decl.implementation, &mut targets);
     }
 
     if targets.is_empty() {
@@ -189,6 +189,7 @@ fn normalize_conditions_in_package(
         let cond_temp_counter = cond_temp_counters.entry(root_block).or_default();
         let inserted = hoist_condition(
             package,
+            package_id,
             assigner,
             root_block,
             enclosing_block,
@@ -217,16 +218,23 @@ fn normalize_conditions_in_package(
 /// across all functored specializations of a callable implementation.
 fn collect_targets_in_callable_impl(
     package: &Package,
+    package_id: PackageId,
     callable_impl: &CallableImpl,
     targets: &mut Vec<ConditionTarget>,
 ) {
     match callable_impl {
         CallableImpl::Intrinsic => {}
         CallableImpl::Spec(spec_impl) => {
-            collect_targets_in_spec_impl(package, spec_impl, targets);
+            collect_targets_in_spec_impl(package, package_id, spec_impl, targets);
         }
         CallableImpl::SimulatableIntrinsic(spec_decl) => {
-            collect_targets_in_block(package, spec_decl.block, spec_decl.block, targets);
+            collect_targets_in_block(
+                package,
+                package_id,
+                spec_decl.block,
+                spec_decl.block,
+                targets,
+            );
         }
     }
 }
@@ -235,18 +243,25 @@ fn collect_targets_in_callable_impl(
 /// `adj`, `ctl`, `ctl-adj`) of a spec implementation.
 fn collect_targets_in_spec_impl(
     package: &Package,
+    package_id: PackageId,
     spec_impl: &SpecImpl,
     targets: &mut Vec<ConditionTarget>,
 ) {
-    collect_targets_in_block(package, spec_impl.body.block, spec_impl.body.block, targets);
+    collect_targets_in_block(
+        package,
+        package_id,
+        spec_impl.body.block,
+        spec_impl.body.block,
+        targets,
+    );
     if let Some(adj) = &spec_impl.adj {
-        collect_targets_in_block(package, adj.block, adj.block, targets);
+        collect_targets_in_block(package, package_id, adj.block, adj.block, targets);
     }
     if let Some(ctl) = &spec_impl.ctl {
-        collect_targets_in_block(package, ctl.block, ctl.block, targets);
+        collect_targets_in_block(package, package_id, ctl.block, ctl.block, targets);
     }
     if let Some(ctl_adj) = &spec_impl.ctl_adj {
-        collect_targets_in_block(package, ctl_adj.block, ctl_adj.block, targets);
+        collect_targets_in_block(package, package_id, ctl_adj.block, ctl_adj.block, targets);
     }
 }
 
@@ -255,6 +270,7 @@ fn collect_targets_in_spec_impl(
 /// is threaded unchanged so each target knows the dominating scope.
 fn collect_targets_in_block(
     package: &Package,
+    package_id: PackageId,
     root_block: BlockId,
     block_id: BlockId,
     targets: &mut Vec<ConditionTarget>,
@@ -267,7 +283,7 @@ fn collect_targets_in_block(
             StmtKind::Expr(e) | StmtKind::Semi(e) => {
                 let surface = *e;
                 if matches!(&package.get_expr(surface).kind, ExprKind::If(..))
-                    && if_chain_has_side_effecting_cond(package, surface)
+                    && if_chain_has_side_effecting_cond(package, package_id, surface)
                 {
                     targets.push((root_block, block_id, stmt_index, surface));
                 }
@@ -282,7 +298,7 @@ fn collect_targets_in_block(
         let mut child_blocks = Vec::new();
         collect_child_blocks(package, value_expr, &mut child_blocks);
         for child in child_blocks {
-            collect_targets_in_block(package, root_block, child, targets);
+            collect_targets_in_block(package, package_id, root_block, child, targets);
         }
     }
 }
@@ -299,17 +315,21 @@ fn collect_child_blocks(package: &Package, expr_id: ExprId, out: &mut Vec<BlockI
 }
 
 /// Returns `true` when the outer condition or any `else if` condition in the
-/// chain headed by `if_expr_id` carries side effects (per the conservative
-/// [`expr_is_side_effect_free`] predicate). Only `else if` links — an `If`
+/// chain headed by `if_expr_id` carries side effects (per
+/// [`expr_is_side_effect_free`]). Only `else if` links — an `If`
 /// expression in `otherwise` position — are followed; a final `else { .. }`
 /// block has no condition and stops the walk.
-fn if_chain_has_side_effecting_cond(package: &Package, if_expr_id: ExprId) -> bool {
+fn if_chain_has_side_effecting_cond(
+    package: &Package,
+    package_id: PackageId,
+    if_expr_id: ExprId,
+) -> bool {
     let mut current = if_expr_id;
     loop {
         let ExprKind::If(cond, _, otherwise) = &package.get_expr(current).kind else {
             return false;
         };
-        if !expr_is_side_effect_free(package, *cond) {
+        if !expr_is_side_effect_free(package, package_id, *cond) {
             return true;
         }
         match otherwise {
@@ -338,6 +358,7 @@ fn if_chain_has_side_effecting_cond(package: &Package, if_expr_id: ExprId) -> bo
 #[allow(clippy::too_many_arguments)]
 fn hoist_condition(
     package: &mut Package,
+    package_id: PackageId,
     assigner: &mut Assigner,
     root_block: BlockId,
     enclosing_block: BlockId,
@@ -355,7 +376,7 @@ fn hoist_condition(
     let mut inserted = 0;
 
     // Outer condition: unconditionally evaluated when the statement is reached.
-    if !expr_is_side_effect_free(package, cond_expr_id) {
+    if !expr_is_side_effect_free(package, package_id, cond_expr_id) {
         let cond_ty = package.get_expr(cond_expr_id).ty.clone();
         let cond_span = package.get_expr(cond_expr_id).span;
 
@@ -429,6 +450,7 @@ fn hoist_condition(
     // accumulator and conditionally assign it in its own else scope.
     inserted += hoist_else_if_chain(
         package,
+        package_id,
         assigner,
         root_block,
         enclosing_block,
@@ -454,6 +476,7 @@ fn hoist_condition(
 #[allow(clippy::too_many_arguments)]
 fn hoist_else_if_chain(
     package: &mut Package,
+    package_id: PackageId,
     assigner: &mut Assigner,
     root_block: BlockId,
     enclosing_block: BlockId,
@@ -478,7 +501,7 @@ fn hoist_else_if_chain(
             _ => return inserted,
         };
 
-        if !expr_is_side_effect_free(package, elif_cond) {
+        if !expr_is_side_effect_free(package, package_id, elif_cond) {
             let cond_ty = package.get_expr(elif_cond).ty.clone();
             let cond_span = package.get_expr(elif_cond).span;
             let if_ty = package.get_expr(elif_id).ty.clone();

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/rewrite.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/rewrite.rs
@@ -48,7 +48,9 @@ use crate::fir_builder::{
     alloc_bin_op_expr, alloc_call_expr, alloc_expr, alloc_functor_wrapped_expr, alloc_int_lit,
     alloc_local_var_expr,
 };
-use crate::walk_utils::{DirectChild, UseClass, classify_block_use, for_each_direct_child};
+use crate::walk_utils::{
+    DirectChild, UseClass, classify_block_use, expr_is_side_effect_free, for_each_direct_child,
+};
 use qsc_data_structures::functors::FunctorApp;
 use qsc_data_structures::span::Span;
 use qsc_fir::assigner::Assigner;
@@ -702,10 +704,10 @@ fn branch_split_direct_call_rewrite(
         && entries.len() > 1
         && let Some((synthetic_conditioned, default_idx)) = synthesize_direct_index_dispatch(
             package,
+            package_id,
             expr_owner_lookup,
             call_expr_id,
             entries,
-            span,
             assigner,
         )
     {
@@ -871,10 +873,10 @@ fn ty_is_callable_array(package: &Package, ty: &Ty) -> bool {
 /// resolves to multiple callables via branch-split analysis.
 fn synthesize_callsite_index_dispatch(
     package: &mut Package,
+    package_id: PackageId,
     expr_owner_lookup: &FxHashMap<ExprId, LocalItemId>,
     call_expr_id: ExprId,
     entries: &[HofDispatchTarget],
-    span: Span,
     assigner: &mut Assigner,
 ) -> Option<(Vec<(usize, ExprId)>, usize)> {
     let callables = entries
@@ -883,11 +885,10 @@ fn synthesize_callsite_index_dispatch(
         .collect::<Vec<_>>();
     synthesize_index_dispatch_plan(
         package,
+        package_id,
         expr_owner_lookup,
-        call_expr_id,
-        entries.first()?.0.arg_expr_id,
+        (call_expr_id, entries.first()?.0.arg_expr_id),
         &callables,
-        span,
         assigner,
     )
 }
@@ -896,10 +897,10 @@ fn synthesize_callsite_index_dispatch(
 /// whose callee expression resolves to multiple concrete callables.
 fn synthesize_direct_index_dispatch(
     package: &mut Package,
+    package_id: PackageId,
     expr_owner_lookup: &FxHashMap<ExprId, LocalItemId>,
     call_expr_id: ExprId,
     entries: &[&DirectCallSite],
-    span: Span,
     assigner: &mut Assigner,
 ) -> Option<(Vec<(usize, ExprId)>, usize)> {
     let ExprKind::Call(callee_id, _) = package.get_expr(call_expr_id).kind else {
@@ -911,11 +912,10 @@ fn synthesize_direct_index_dispatch(
         .collect::<Vec<_>>();
     synthesize_index_dispatch_plan(
         package,
+        package_id,
         expr_owner_lookup,
-        call_expr_id,
-        callee_id,
+        (call_expr_id, callee_id),
         &callables,
-        span,
         assigner,
     )
 }
@@ -924,19 +924,20 @@ fn synthesize_direct_index_dispatch(
 /// candidate callable with the condition expression that selects it.
 fn synthesize_index_dispatch_plan(
     package: &mut Package,
+    package_id: PackageId,
     expr_owner_lookup: &FxHashMap<ExprId, LocalItemId>,
-    owner_expr_id: ExprId,
-    dispatch_expr_id: ExprId,
+    dispatch_source: (ExprId, ExprId),
     callables: &[ConcreteCallable],
-    span: Span,
     assigner: &mut Assigner,
 ) -> Option<(Vec<(usize, ExprId)>, usize)> {
     if callables.len() < 2 {
         return None;
     }
 
+    let (owner_expr_id, dispatch_expr_id) = dispatch_source;
     let (index_expr_id, indexed_callables) =
         resolve_index_dispatch_source(package, expr_owner_lookup, owner_expr_id, dispatch_expr_id)?;
+    let span = package.get_expr(owner_expr_id).span;
 
     let mut entry_positions = Vec::with_capacity(callables.len());
     for callable in callables {
@@ -952,15 +953,10 @@ fn synthesize_index_dispatch_plan(
         .enumerate()
         .max_by_key(|(_, position)| *position)?;
 
-    // Non-trivial index expressions (not a plain local read or literal) could
-    // repeat side effects if re-evaluated per branch, so hoist into a single
-    // shared `let`; each `index == k` comparison then reads the temp. Trivial
-    // indices keep referencing the original expression so snapshots stay
-    // byte-identical.
-    let hoist_index = !matches!(
-        package.get_expr(index_expr_id).kind,
-        ExprKind::Var(_, _) | ExprKind::Lit(_)
-    );
+    // Index expressions that may have side effects or traps are hoisted into a
+    // single shared `let`; each `index == k` comparison then reads the temp.
+    // Provably side-effect-free indices can be referenced directly.
+    let hoist_index = !expr_is_side_effect_free(package, package_id, index_expr_id);
     let hoisted = if hoist_index {
         let index_ty = package.get_expr(index_expr_id).ty.clone();
         let index_span = package.get_expr(index_expr_id).span;
@@ -984,13 +980,33 @@ fn synthesize_index_dispatch_plan(
                 ty.clone(),
                 *index_span,
             ),
-            None => index_expr_id,
+            None => strip_transparent_block_expr(package, index_expr_id),
         };
         let condition = alloc_index_eq_expr(package, operand, position, span, assigner);
         conditioned.push((entry_idx, condition));
     }
 
     Some((conditioned, default_idx))
+}
+
+/// Removes nested `Block([Expr(tail)])` wrappers from an index expression used
+/// in synthesized dispatch guards.
+///
+/// This keeps pure block indices such as `ops[{ i }]` from rendering as
+/// `if { i } == 0`, while leaving blocks with locals or multiple statements
+/// untouched so they still use the normal hoist path when needed.
+fn strip_transparent_block_expr(package: &Package, expr_id: ExprId) -> ExprId {
+    let ExprKind::Block(block_id) = package.get_expr(expr_id).kind else {
+        return expr_id;
+    };
+    let block = package.get_block(block_id);
+    let [stmt_id] = block.stmts.as_slice() else {
+        return expr_id;
+    };
+    let StmtKind::Expr(tail_expr_id) = package.get_stmt(*stmt_id).kind else {
+        return expr_id;
+    };
+    strip_transparent_block_expr(package, tail_expr_id)
 }
 
 /// Locates the source of a dynamic dispatch (for example the index
@@ -5106,10 +5122,10 @@ fn branch_split_rewrite(
 
     let Some((conditioned, default_entry)) = partition_branch_split_targets(
         package,
+        package_id,
         expr_owner_lookup,
         call_expr_id,
         entries,
-        span,
         assigner,
     ) else {
         return;
@@ -5164,10 +5180,10 @@ fn branch_split_rewrite(
 /// when there is no entry to dispatch at all.
 fn partition_branch_split_targets<'a>(
     package: &mut Package,
+    package_id: PackageId,
     expr_owner_lookup: &FxHashMap<ExprId, LocalItemId>,
     call_expr_id: ExprId,
     entries: &[HofDispatchTarget<'a>],
-    span: Span,
     assigner: &mut Assigner,
 ) -> Option<(Vec<ConditionedHofTarget<'a>>, HofDispatchTarget<'a>)> {
     let mut conditioned: Vec<ConditionedHofTarget> = Vec::new();
@@ -5186,10 +5202,10 @@ fn partition_branch_split_targets<'a>(
         && entries.len() > 1
         && let Some((synthetic_conditioned, default_idx)) = synthesize_callsite_index_dispatch(
             package,
+            package_id,
             expr_owner_lookup,
             call_expr_id,
             entries,
-            span,
             assigner,
         )
     {

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/specialize.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/specialize.rs
@@ -32,18 +32,19 @@ use super::{
 };
 use crate::cloner::FirCloner;
 use crate::fir_builder::{
-    alloc_bin_op_expr, alloc_call_expr, alloc_expr, alloc_functor_wrapped_expr, alloc_int_lit,
-    alloc_item_var_expr, alloc_local_var_expr, functored_specs,
+    alloc_bin_op_expr, alloc_block, alloc_block_expr, alloc_call_expr, alloc_expr, alloc_expr_stmt,
+    alloc_functor_wrapped_expr, alloc_int_lit, alloc_item_var_expr, alloc_local_var,
+    alloc_local_var_expr, functored_specs,
 };
 use crate::package_assigners::PackageAssigners;
-use crate::walk_utils::for_each_expr_in_callable_impl;
+use crate::walk_utils::{expr_is_side_effect_free, for_each_expr_in_callable_impl};
 use qsc_data_structures::functors::FunctorApp;
 use qsc_data_structures::span::Span;
 use qsc_fir::assigner::Assigner;
 use qsc_fir::fir::{
     BinOp, Block, BlockId, CallableDecl, CallableImpl, Expr, ExprId, ExprKind, Field, FieldPath,
-    Ident, Item, ItemId, ItemKind, LocalItemId, LocalVarId, Package, PackageId, PackageLookup,
-    PackageStore, Pat, PatId, PatKind, Res, Stmt, StmtId, StoreItemId, Visibility,
+    Ident, Item, ItemId, ItemKind, LocalItemId, LocalVarId, Mutability, Package, PackageId,
+    PackageLookup, PackageStore, Pat, PatId, PatKind, Res, Stmt, StmtId, StoreItemId, Visibility,
 };
 use qsc_fir::ty::{Arrow, Prim, Ty};
 use qsc_fir::visit::{self, Visitor};
@@ -2586,6 +2587,22 @@ fn replace_indexed_callable_array_call(
     let span = package.get_expr(call_expr_id).span;
     let original_args = package.get_expr(args_id).clone();
 
+    let hoisted = if expr_is_side_effect_free(package, package_id, index_id) {
+        None
+    } else {
+        let index_ty = package.get_expr(index_id).ty.clone();
+        let index_span = package.get_expr(index_id).span;
+        let (local_var, let_stmt) = alloc_local_var(
+            package,
+            assigner,
+            "index",
+            &index_ty,
+            index_id,
+            Mutability::Immutable,
+        );
+        Some((local_var, index_ty, index_span, let_stmt))
+    };
+
     let mut branch_calls = Vec::with_capacity(branch_callables.len());
     for (position, branch_callable) in branch_callables.iter().enumerate() {
         let call_id = alloc_dispatch_branch_call(
@@ -2603,7 +2620,13 @@ fn replace_indexed_callable_array_call(
 
     let mut dispatch_id = branch_calls.last().expect("branch exists").1;
     for (position, call_id) in branch_calls.into_iter().rev().skip(1) {
-        let condition_id = alloc_index_eq_expr(package, index_id, position, span, assigner);
+        let operand = match &hoisted {
+            Some((local_var, ty, index_span, _)) => {
+                alloc_local_var_expr(package, assigner, *local_var, ty.clone(), *index_span)
+            }
+            None => index_id,
+        };
+        let condition_id = alloc_index_eq_expr(package, operand, position, span, assigner);
         dispatch_id = alloc_if_expr(
             package,
             span,
@@ -2613,6 +2636,18 @@ fn replace_indexed_callable_array_call(
             dispatch_id,
             assigner,
         );
+    }
+
+    if let Some((_, _, _, let_stmt)) = &hoisted {
+        let tail_stmt = alloc_expr_stmt(package, assigner, dispatch_id, span);
+        let block_id = alloc_block(
+            package,
+            assigner,
+            vec![*let_stmt, tail_stmt],
+            result_ty.clone(),
+            span,
+        );
+        dispatch_id = alloc_block_expr(package, assigner, block_id, result_ty.clone(), span);
     }
 
     let dispatch = package.get_expr(dispatch_id).clone();

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/analysis.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/analysis.rs
@@ -6052,13 +6052,12 @@ fn operand_block_tuple_pattern_dispatch_resolves_field_path() {
     );
 }
 
-/// When the index selecting a callable from an array is a non-trivial
-/// expression (here `i + 1`), the synthesized dispatch hoists it into a single
-/// shared `let` so it is evaluated once rather than re-evaluated in every
-/// `index == k` guard. Contrast `operand_block_tuple_pattern_dispatch_resolves_field_path`,
-/// where a bare-variable index keeps referencing the original expression.
+/// When the index selecting a callable from an array is pure arithmetic, the
+/// synthesized dispatch can reuse the original expression in each guard. This
+/// keeps "non-trivial" from being mistaken for "effectful"; the separate
+/// side-effecting index tests cover the single-evaluation hoist path.
 #[test]
-fn non_trivial_array_index_dispatch_hoists_index_once() {
+fn pure_arithmetic_array_index_dispatch_reuses_index_expression() {
     let source = r#"
         operation Main() : Unit {
             let ops = [I, X, Y];
@@ -6107,15 +6106,104 @@ fn non_trivial_array_index_dispatch_hoists_index_once() {
                     while _step_id_48 > 0 and _index_id_43 <= _end_id_53 or _step_id_48 < 0 and _index_id_43 >= _end_id_53 {
                         let i : Int = _index_id_43;
                         let q : Qubit = __quantum__rt__qubit_allocate();
-                        let index : Int = i + 1;
-                        if index == 0 {
+                        if i + 1 == 0 {
                             I(q)
-                        } else if index == 1 {
+                        } else if i + 1 == 1 {
                             X(q)
                         } else {
                             Y(q)
                         };
                         _index_id_43 += _step_id_48;
+                        __quantum__rt__qubit_release(q);
+                    }
+
+                }
+
+            }
+            // entry
+            Main()
+        "#]],
+    );
+}
+
+/// A pure, non-trivial index expression does not need the single-evaluation
+/// hoist used for side-effecting indices. Reusing the original block
+/// expression keeps index-dispatch cleanup aligned with the shared purity
+/// predicate.
+#[test]
+fn pure_array_index_dispatch_reuses_index_expression() {
+    let source = r#"
+        operation Main() : Unit {
+            let ops = [I, X, Y];
+            for i in 0..1 {
+                use q = Qubit();
+                let op = ops[{ i }];
+                op(q);
+            }
+        }
+        "#;
+
+    let (mut fir_store, fir_pkg_id) = compile_to_monomorphized_fir(source);
+    let mut assigners = PackageAssigners::new(&fir_store, fir_pkg_id);
+    let errors = defunctionalize(&mut fir_store, fir_pkg_id, &mut assigners);
+    assert_no_defunctionalization_errors("defunctionalization", &errors);
+
+    let after = crate::pretty::write_package_qsharp_parseable(&fir_store, fir_pkg_id);
+    assert!(
+        after.contains("if i == 0") && after.contains("else if i == 1"),
+        "pure index dispatch should reuse the original block index:\n{after}"
+    );
+    assert!(
+        !after.contains("let index : Int ="),
+        "pure index dispatch should not hoist a side-effect-free block:\n{after}"
+    );
+    check_rewrite(
+        source,
+        &expect![[r#"
+            BEFORE:
+            operation Main() : Unit {
+                let ops : (Qubit => Unit is Adj + Ctl)[] = [I, X, Y];
+                {
+                    let _range_id_41 : Range = 0..1;
+                    mutable _index_id_44 : Int = _range_id_41::Start;
+                    let _step_id_49 : Int = _range_id_41::Step;
+                    let _end_id_54 : Int = _range_id_41::End;
+                    while _step_id_49 > 0 and _index_id_44 <= _end_id_54 or _step_id_49 < 0 and _index_id_44 >= _end_id_54 {
+                        let i : Int = _index_id_44;
+                        let q : Qubit = __quantum__rt__qubit_allocate();
+                        let op : (Qubit => Unit is Adj + Ctl) = ops[{
+                            i
+                        }];
+                        op(q);
+                        _index_id_44 += _step_id_49;
+                        __quantum__rt__qubit_release(q);
+                    }
+
+                }
+
+            }
+            // entry
+            Main()
+
+            AFTER:
+            operation Main() : Unit {
+                let ops : (Qubit => Unit is Adj + Ctl)[] = [I, X, Y];
+                {
+                    let _range_id_41 : Range = 0..1;
+                    mutable _index_id_44 : Int = _range_id_41::Start;
+                    let _step_id_49 : Int = _range_id_41::Step;
+                    let _end_id_54 : Int = _range_id_41::End;
+                    while _step_id_49 > 0 and _index_id_44 <= _end_id_54 or _step_id_49 < 0 and _index_id_44 >= _end_id_54 {
+                        let i : Int = _index_id_44;
+                        let q : Qubit = __quantum__rt__qubit_allocate();
+                        if i == 0 {
+                            I(q)
+                        } else if i == 1 {
+                            X(q)
+                        } else {
+                            Y(q)
+                        };
+                        _index_id_44 += _step_id_49;
                         __quantum__rt__qubit_release(q);
                     }
 

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/analysis.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/analysis.rs
@@ -6216,6 +6216,102 @@ fn pure_array_index_dispatch_reuses_index_expression() {
     );
 }
 
+/// A side-effecting index expression must be evaluated once before the
+/// synthesized dispatch. Hoisting the block into an `index` local prevents
+/// its `X(q)` call from being repeated by each branch guard.
+#[test]
+fn impure_array_index_dispatch_hoists_index_expression() {
+    let source = r#"
+        operation Main() : Unit {
+            let ops = [I, X, Y];
+            for i in 0..1 {
+                use q = Qubit();
+                let op = ops[{ X(q); i }];
+                op(q);
+            }
+        }
+        "#;
+
+    let (mut fir_store, fir_pkg_id) = compile_to_monomorphized_fir(source);
+    let mut assigners = PackageAssigners::new(&fir_store, fir_pkg_id);
+    let errors = defunctionalize(&mut fir_store, fir_pkg_id, &mut assigners);
+    assert_no_defunctionalization_errors("defunctionalization", &errors);
+
+    let after = crate::pretty::write_package_qsharp_parseable(&fir_store, fir_pkg_id);
+    assert!(
+        after.contains("let index : Int = {")
+            && after.contains("if index == 0")
+            && after.contains("else if index == 1"),
+        "side-effecting index should be hoisted and reused by the dispatch:\n{after}"
+    );
+    assert!(
+        !after.contains("if i == 0") && !after.contains("else if i == 1"),
+        "dispatch guards should not re-evaluate the side-effecting index block:\n{after}"
+    );
+    check_rewrite(
+        source,
+        &expect![[r#"
+            BEFORE:
+            operation Main() : Unit {
+                let ops : (Qubit => Unit is Adj + Ctl)[] = [I, X, Y];
+                {
+                    let _range_id_45 : Range = 0..1;
+                    mutable _index_id_48 : Int = _range_id_45::Start;
+                    let _step_id_53 : Int = _range_id_45::Step;
+                    let _end_id_58 : Int = _range_id_45::End;
+                    while _step_id_53 > 0 and _index_id_48 <= _end_id_58 or _step_id_53 < 0 and _index_id_48 >= _end_id_58 {
+                        let i : Int = _index_id_48;
+                        let q : Qubit = __quantum__rt__qubit_allocate();
+                        let op : (Qubit => Unit is Adj + Ctl) = ops[{
+                            X(q);
+                            i
+                        }];
+                        op(q);
+                        _index_id_48 += _step_id_53;
+                        __quantum__rt__qubit_release(q);
+                    }
+
+                }
+
+            }
+            // entry
+            Main()
+
+            AFTER:
+            operation Main() : Unit {
+                let ops : (Qubit => Unit is Adj + Ctl)[] = [I, X, Y];
+                {
+                    let _range_id_45 : Range = 0..1;
+                    mutable _index_id_48 : Int = _range_id_45::Start;
+                    let _step_id_53 : Int = _range_id_45::Step;
+                    let _end_id_58 : Int = _range_id_45::End;
+                    while _step_id_53 > 0 and _index_id_48 <= _end_id_58 or _step_id_53 < 0 and _index_id_48 >= _end_id_58 {
+                        let i : Int = _index_id_48;
+                        let q : Qubit = __quantum__rt__qubit_allocate();
+                        let index : Int = {
+                            X(q);
+                            i
+                        };
+                        if index == 0 {
+                            I(q)
+                        } else if index == 1 {
+                            X(q)
+                        } else {
+                            Y(q)
+                        };
+                        _index_id_48 += _step_id_53;
+                        __quantum__rt__qubit_release(q);
+                    }
+
+                }
+
+            }
+            // entry
+            Main()
+        "#]],
+    );
+}
+
 /// A `set f = Bar` inside the short-circuited RHS of `false and { .. }` is not
 /// executed at runtime, so the later `f(5)` must keep the reaching definition
 /// `Foo`. The fork/join arm applies the RHS conditionally rather than

--- a/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/specialization.rs
+++ b/source/compiler/qsc_fir_transforms/src/defunctionalize/tests/specialization.rs
@@ -4757,6 +4757,96 @@ fn callable_array_loop_dispatch_with_global_sibling_preserves_length_call() {
     );
 }
 
+/// Specializing a HOF that indexes directly into a callable-array parameter
+/// must not duplicate a side-effecting index expression across synthesized
+/// branch guards. The index operation applies `X(q)`, so running it once versus
+/// once per dispatch arm is an observable semantic difference.
+#[test]
+fn indexed_callable_array_param_hoists_side_effecting_index_once() {
+    let source = r#"
+        operation ChooseIndex(q : Qubit) : Int {
+            X(q);
+            1
+        }
+        operation RunAt(ops : (Qubit => Unit)[], q : Qubit) : Unit {
+            ops[ChooseIndex(q)](q);
+        }
+        operation Main() : Unit {
+            use q = Qubit();
+            RunAt([I, X, Y], q);
+        }
+        "#;
+
+    let (mut fir_store, fir_pkg_id) = compile_to_monomorphized_fir(source);
+    let mut assigners = PackageAssigners::new(&fir_store, fir_pkg_id);
+    let errors = defunctionalize(&mut fir_store, fir_pkg_id, &mut assigners);
+    assert_no_defunctionalization_errors("defunctionalization", &errors);
+
+    let after = crate::pretty::write_package_qsharp_parseable(&fir_store, fir_pkg_id);
+    assert!(
+        after.contains("let index : Int = ChooseIndex(q);"),
+        "side-effecting index must be hoisted into a single local after specialization:\n{after}"
+    );
+    assert!(
+        !after.contains("if ChooseIndex(q)") && !after.contains("else if ChooseIndex(q)"),
+        "specialized dispatch guards must not re-evaluate the side-effecting index:\n{after}"
+    );
+    check_rewrite(
+        source,
+        &expect![[r#"
+            BEFORE:
+            operation ChooseIndex(q : Qubit) : Int {
+                X(q);
+                1
+            }
+            operation RunAt(ops : (Qubit => Unit)[], q : Qubit) : Unit {
+                ops[ChooseIndex(q)](q);
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                RunAt_AdjCtl_([I, X, Y], q);
+                __quantum__rt__qubit_release(q);
+            }
+            operation RunAt_AdjCtl_(ops : (Qubit => Unit is Adj + Ctl)[], q : Qubit) : Unit {
+                ops[ChooseIndex(q)](q);
+            }
+            // entry
+            Main()
+
+            AFTER:
+            operation ChooseIndex(q : Qubit) : Int {
+                X(q);
+                1
+            }
+            operation RunAt(ops : (Qubit => Unit)[], q : Qubit) : Unit {
+                ops[ChooseIndex(q)](q);
+            }
+            operation Main() : Unit {
+                let q : Qubit = __quantum__rt__qubit_allocate();
+                RunAt_AdjCtl__I__X__Y_(q);
+                __quantum__rt__qubit_release(q);
+            }
+            operation RunAt_AdjCtl_(ops : (Qubit => Unit is Adj + Ctl)[], q : Qubit) : Unit {
+                ops[ChooseIndex(q)](q);
+            }
+            operation RunAt_AdjCtl__I__X__Y_(q : Qubit) : Unit {
+                {
+                    let index : Int = ChooseIndex(q);
+                    if index == 0 {
+                        I(q)
+                    } else if index == 1 {
+                        X(q)
+                    } else {
+                        Y(q)
+                    }
+                };
+            }
+            // entry
+            Main()
+        "#]],
+    );
+}
+
 /// A callable array is forwarded into a higher-order function that receives it
 /// as a plain array parameter and iterates over it, mirroring the shape of the
 /// Deutsch-Jozsa sample where a list of oracles is looped over and each is run

--- a/source/compiler/qsc_fir_transforms/src/return_unify.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify.rs
@@ -612,7 +612,7 @@ fn process_callable_returns(
             return_slot_strategy,
         );
         if run_simplify {
-            simplify::run_to_fixpoint(package, assigner, block_id, errors, &slots);
+            simplify::run_to_fixpoint(package, assigner, owning_pkg, block_id, errors, &slots);
         }
     }
 }

--- a/source/compiler/qsc_fir_transforms/src/return_unify/lower.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/lower.rs
@@ -10,7 +10,7 @@ use crate::{
         alloc_expr_stmt, alloc_if_expr, alloc_local_var, alloc_local_var_expr, alloc_not_expr,
         alloc_semi_stmt, alloc_unit_expr,
     },
-    walk_utils::{expr_is_side_effect_free, for_each_expr},
+    walk_utils::{expr_is_safe_to_discard, for_each_expr},
 };
 use qsc_data_structures::span::Span;
 use qsc_fir::{
@@ -598,7 +598,7 @@ fn create_lazy_flag_continuation_expr(
                 if let Some(&last_id) = continuation_stmts.last()
                     && let StmtKind::Expr(e) = package.get_stmt(last_id).kind
                     && package.get_expr(e).ty == Ty::UNIT
-                    && expr_is_side_effect_free(package, e)
+                    && expr_is_safe_to_discard(package, flag_context.package_id, e)
                 {
                     continuation_stmts.pop();
                 }

--- a/source/compiler/qsc_fir_transforms/src/return_unify/normalize/anf/tests/snapshot.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/normalize/anf/tests/snapshot.rs
@@ -342,11 +342,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                         };
                         1
                     };
-                    let a : Int = if not __has_returned {
-                        __operand_tmp_0 + 2
-                    } else {
-                        0
-                    };
                     let __operand_tmp_1 : Int = if not __has_returned {
                         {
                             {
@@ -356,11 +351,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                             3
                         }
 
-                    } else {
-                        0
-                    };
-                    let b : Int = if not __has_returned {
-                        __operand_tmp_1 * 4
                     } else {
                         0
                     };
@@ -380,11 +370,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                         };
                         5
                     };
-                    let c : Int = if not __has_returned {
-                        __operand_tmp_0 + 6
-                    } else {
-                        0
-                    };
                     let __operand_tmp_1 : Int = if not __has_returned {
                         {
                             {
@@ -394,11 +379,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                             7
                         }
 
-                    } else {
-                        0
-                    };
-                    let d : Int = if not __has_returned {
-                        __operand_tmp_1 * 8
                     } else {
                         0
                     };
@@ -418,11 +398,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                         };
                         1
                     };
-                    let a : Int = if not __has_returned {
-                        __operand_tmp_0 + 2
-                    } else {
-                        0
-                    };
                     let __operand_tmp_1 : Int = if not __has_returned {
                         {
                             {
@@ -432,11 +407,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                             3
                         }
 
-                    } else {
-                        0
-                    };
-                    let b : Int = if not __has_returned {
-                        __operand_tmp_1 * 4
                     } else {
                         0
                     };
@@ -456,11 +426,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                         };
                         5
                     };
-                    let c : Int = if not __has_returned {
-                        __operand_tmp_0 + 6
-                    } else {
-                        0
-                    };
                     let __operand_tmp_1 : Int = if not __has_returned {
                         {
                             {
@@ -470,11 +435,6 @@ fn operand_temp_names_restart_per_specialization_body() {
                             7
                         }
 
-                    } else {
-                        0
-                    };
-                    let d : Int = if not __has_returned {
-                        __operand_tmp_1 * 8
                     } else {
                         0
                     };

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify.rs
@@ -61,8 +61,8 @@ mod tests;
 use qsc_fir::{
     assigner::Assigner,
     fir::{
-        BlockId, ExprId, ExprKind, Lit, LocalVarId, Mutability, Package, PackageLookup, PatKind,
-        Res, StmtId, StmtKind,
+        BlockId, ExprId, ExprKind, Lit, LocalVarId, Mutability, Package, PackageId, PackageLookup,
+        PatKind, Res, StmtId, StmtKind,
     },
     ty::{Prim, Ty},
 };
@@ -83,6 +83,7 @@ use crate::walk_utils;
 pub(super) fn run_to_fixpoint(
     package: &mut Package,
     assigner: &mut Assigner,
+    package_id: PackageId,
     block_id: BlockId,
     errors: &mut Vec<super::Error>,
     slots: &SynthSlots,
@@ -93,14 +94,14 @@ pub(super) fn run_to_fixpoint(
     };
     let mut prev_measure: Option<(usize, usize)> = None;
     for _ in 0..hard_cap {
-        let changed = apply_all_rules(package, assigner, block_id, slots);
+        let changed = apply_all_rules(package, assigner, package_id, block_id, slots);
         if !changed {
             return;
         }
         let block = package.get_block(block_id);
         let measure = (
             block.stmts.len(),
-            count_identical_branch_heads(package, &block.stmts),
+            count_identical_branch_heads(package, package_id, &block.stmts),
         );
         if matches!(prev_measure, Some(prev) if measure >= prev) {
             errors.push(super::Error::FixpointNotReached("simplify", block_id));
@@ -116,24 +117,29 @@ pub(super) fn run_to_fixpoint(
 fn apply_all_rules(
     package: &mut Package,
     assigner: &mut Assigner,
+    package_id: PackageId,
     block_id: BlockId,
     slots: &SynthSlots,
 ) -> bool {
     let mut changed = false;
     changed |= guard_clause::apply(package, assigner, block_id, slots);
-    changed |= run_identical_branches(package, block_id);
+    changed |= run_identical_branches(package, package_id, block_id);
     changed |= both_branches::apply(package, assigner, block_id, slots);
     changed |= single_branch::apply(package, assigner, block_id, slots);
     changed |= bare_return::apply(package, assigner, block_id, slots);
     changed |= let_folding::apply(package, assigner, block_id, slots);
     changed |= dead_flag::apply(package, assigner, block_id, slots);
-    changed |= dead_local::apply(package, assigner, block_id);
+    changed |= dead_local::apply(package, assigner, package_id, block_id);
     changed
 }
 
 /// Count how many top-level `If` statements in `stmts` have structurally
 /// equal then/else branches — the pattern [`run_identical_branches`] folds.
-fn count_identical_branch_heads(package: &Package, stmts: &[StmtId]) -> usize {
+fn count_identical_branch_heads(
+    package: &Package,
+    package_id: PackageId,
+    stmts: &[StmtId],
+) -> usize {
     stmts
         .iter()
         .filter(|&&stmt_id| {
@@ -141,7 +147,7 @@ fn count_identical_branch_heads(package: &Package, stmts: &[StmtId]) -> usize {
                 StmtKind::Expr(e) | StmtKind::Semi(e) | StmtKind::Local(_, _, e) => *e,
                 StmtKind::Item(_) => return false,
             };
-            try_fold_identical_branches(package, expr_id).is_some()
+            try_fold_identical_branches(package, package_id, expr_id).is_some()
         })
         .count()
 }
@@ -152,23 +158,27 @@ fn count_identical_branch_heads(package: &Package, stmts: &[StmtId]) -> usize {
 /// Walks each top-level statement and folds its initializer/trailing
 /// expression when the expression is `If(_, then, Some(else))` with
 /// structurally identical arms.
-fn run_identical_branches(package: &mut Package, block_id: BlockId) -> bool {
+fn run_identical_branches(package: &mut Package, package_id: PackageId, block_id: BlockId) -> bool {
     let stmts = package.get_block(block_id).stmts.clone();
     let mut changed = false;
     for stmt_id in stmts {
-        changed |= fold_identical_branches_in_stmt(package, stmt_id);
+        changed |= fold_identical_branches_in_stmt(package, package_id, stmt_id);
     }
     changed
 }
 
 /// Fold `If(c, x, Some(x))` → `x` for the expression at the head of
 /// `stmt_id`. Returns `true` when the fold fires.
-fn fold_identical_branches_in_stmt(package: &mut Package, stmt_id: StmtId) -> bool {
+fn fold_identical_branches_in_stmt(
+    package: &mut Package,
+    package_id: PackageId,
+    stmt_id: StmtId,
+) -> bool {
     let expr_id = match &package.get_stmt(stmt_id).kind {
         StmtKind::Expr(e) | StmtKind::Semi(e) | StmtKind::Local(_, _, e) => *e,
         StmtKind::Item(_) => return false,
     };
-    let Some(replacement) = try_fold_identical_branches(package, expr_id) else {
+    let Some(replacement) = try_fold_identical_branches(package, package_id, expr_id) else {
         return false;
     };
     let stmt = package.stmts.get_mut(stmt_id).expect("stmt not found");
@@ -184,13 +194,17 @@ fn fold_identical_branches_in_stmt(package: &mut Package, stmt_id: StmtId) -> bo
 /// If `expr_id` is an `If(cond, then_expr, Some(else_expr))` where the
 /// then and else branches are structurally identical, return the branch
 /// expression id to replace the if with. Returns `None` otherwise.
-pub(super) fn try_fold_identical_branches(package: &Package, expr_id: ExprId) -> Option<ExprId> {
+pub(super) fn try_fold_identical_branches(
+    package: &Package,
+    package_id: PackageId,
+    expr_id: ExprId,
+) -> Option<ExprId> {
     let expr = package.get_expr(expr_id);
     let ExprKind::If(cond_id, then_id, Some(else_id)) = &expr.kind else {
         return None;
     };
     if exprs_structurally_equal(package, *then_id, *else_id)
-        && walk_utils::expr_is_side_effect_free(package, *cond_id)
+        && walk_utils::expr_is_safe_to_discard(package, package_id, *cond_id)
     {
         Some(*then_id)
     } else {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/dead_local.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/dead_local.rs
@@ -5,7 +5,7 @@
 //!
 //! Drops single-bind `Local` declarations whose bound local has no
 //! downstream reader or writer in the block and whose initializer is
-//! provably side-effect-free.
+//! safe to discard.
 //!
 //! ```text
 //! {
@@ -28,10 +28,10 @@
 //!
 //! A `let`/`mutable` binding's only observable effect is evaluating its
 //! initializer. When the local is referenced nowhere downstream and the
-//! initializer is provably side-effect-free (see
-//! [`crate::walk_utils::expr_is_side_effect_free`]), removing the binding
-//! preserves value,
-//! evaluation order, and qubit lifetimes. The canonical `__has_returned` /
+//! initializer can be discarded without changing effects or runtime errors
+//! (see [`crate::walk_utils::expr_is_safe_to_discard`]), removing the binding
+//! preserves value, evaluation order, and qubit lifetimes. The canonical
+//! `__has_returned` /
 //! `__ret_val` slot declarations are the motivating case: their
 //! initializers are literals and become dead once the catalogue collapses
 //! the merge. The same shape arises from user code and from normalize's
@@ -43,13 +43,13 @@
 //! patterns are rejected because decomposing them would change observable
 //! shape; discard patterns (`let _ = ...`) are left alone since their
 //! initializer must keep evaluating for side effects. Mutability is
-//! unconstrained: the bar is "no downstream uses and side-effect-free
+//! unconstrained: the bar is "no downstream uses and safely discardable
 //! init".
 //!
-//! The purity check is conservative — it accepts only the shapes
-//! enumerated in [`crate::walk_utils::expr_is_side_effect_free`] and otherwise assumes
-//! effects. A misclassification can only leave an extra dead binding
-//! standing, never drop observable behavior.
+//! An initializer must be both effect-free and unable to fail before this rule
+//! can remove it. Expressions such as array indexing or division may be pure,
+//! but they can still fail at runtime, so their bindings stay in place unless a
+//! future value-sensitive proof can show the specific expression is safe.
 //!
 //! [`super::local_use_count`] counts closure captures, so a local that
 //! escapes through a downstream closure keeps its binding alive.
@@ -62,10 +62,12 @@
 
 use qsc_fir::{
     assigner::Assigner,
-    fir::{BlockId, ExprId, LocalVarId, Package, PackageLookup, PatKind, StmtId, StmtKind},
+    fir::{
+        BlockId, ExprId, LocalVarId, Package, PackageId, PackageLookup, PatKind, StmtId, StmtKind,
+    },
 };
 
-use crate::walk_utils::expr_is_side_effect_free;
+use crate::walk_utils::expr_is_safe_to_discard;
 
 use super::local_use_count;
 
@@ -73,7 +75,12 @@ use super::local_use_count;
 ///
 /// Returns `true` when at least one eligible single-bind `Local` was
 /// removed.
-pub(super) fn apply(package: &mut Package, _assigner: &mut Assigner, block_id: BlockId) -> bool {
+pub(super) fn apply(
+    package: &mut Package,
+    _assigner: &mut Assigner,
+    package_id: PackageId,
+    block_id: BlockId,
+) -> bool {
     let stmt_ids = package.get_block(block_id).stmts.clone();
     let mut to_remove = Vec::new();
 
@@ -81,7 +88,7 @@ pub(super) fn apply(package: &mut Package, _assigner: &mut Assigner, block_id: B
         let Some((local_id, init_id)) = eligible_local_binding(package, sid) else {
             continue;
         };
-        if !expr_is_side_effect_free(package, init_id) {
+        if !expr_is_safe_to_discard(package, package_id, init_id) {
             continue;
         }
         if !local_is_dead_in(package, &stmt_ids, idx, local_id) {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/bare_return.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/bare_return.rs
@@ -210,7 +210,7 @@ fn canonical_literal_bare_return_collapses() {
         "#},
         "Main",
         "bare_return",
-        bare_return::apply,
+        |p, a, _pkg_id, b, s| bare_return::apply(p, a, b, s),
         &expect![[r#"
             // before bare_return (fired=true)
             function Main() : Int {
@@ -258,7 +258,7 @@ fn bare_return_with_call_value_collapses() {
         "#},
         "Main",
         "bare_return",
-        bare_return::apply,
+        |p, a, _pkg_id, b, s| bare_return::apply(p, a, b, s),
         &expect![[r#"
             // before bare_return (fired=true)
             function Helper() : Int {
@@ -573,7 +573,7 @@ fn given_single_return_body_bare_return_collapses_to_value() {
         "#},
         "Main",
         "bare_return",
-        bare_return::apply,
+        |p, a, _pkg_id, b, s| bare_return::apply(p, a, b, s),
         &expect![[r#"
             // before bare_return (fired=true)
             function Main() : Int {
@@ -621,7 +621,7 @@ fn given_single_return_body_with_user_prefix_bare_return_collapses() {
         "#},
         "Main",
         "bare_return",
-        bare_return::apply,
+        |p, a, _pkg_id, b, s| bare_return::apply(p, a, b, s),
         &expect![[r#"
             // before bare_return (fired=true)
             function Main() : Int {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/both_branches.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/both_branches.rs
@@ -52,7 +52,7 @@ fn simple_both_branches_collapses_to_if_else() {
         "#},
         "Main",
         "both_branches",
-        both_branches::apply,
+        |p, a, _pkg_id, b, s| both_branches::apply(p, a, b, s),
         &expect![[r#"
             // before both_branches (fired=true)
             function Main() : Int {
@@ -125,7 +125,7 @@ fn nested_both_branches_collapses_recursively() {
         "#},
         "Main",
         "both_branches",
-        both_branches::apply,
+        |p, a, _pkg_id, b, s| both_branches::apply(p, a, b, s),
         &expect![[r#"
             // before both_branches (fired=false)
             function Main() : Int {
@@ -219,7 +219,7 @@ fn both_branches_with_complex_arm_expressions() {
         "#},
         "Main",
         "both_branches",
-        both_branches::apply,
+        |p, a, _pkg_id, b, s| both_branches::apply(p, a, b, s),
         &expect![[r#"
             // before both_branches (fired=true)
             function F(x : Int) : Int {
@@ -299,7 +299,7 @@ fn only_one_arm_returns_is_guard_clause_shape_not_both_branches() {
         "#},
         "Main",
         "both_branches",
-        both_branches::apply,
+        |p, a, _pkg_id, b, s| both_branches::apply(p, a, b, s),
         &expect![[r#"
             // before both_branches (fired=false)
             function Main() : Int {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/dead_flag.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/dead_flag.rs
@@ -575,7 +575,7 @@ mod q_driven {
             "#},
             "Main",
             "dead_flag",
-            dead_flag::apply,
+            |p, a, _pkg_id, b, s| dead_flag::apply(p, a, b, s),
             &expect![[r#"
                 // before dead_flag (fired=false)
                 function Main() : Int {
@@ -650,7 +650,7 @@ mod q_driven {
             "#},
             "Main",
             "dead_flag",
-            dead_flag::apply,
+            |p, a, _pkg_id, b, s| dead_flag::apply(p, a, b, s),
             &expect![[r#"
                 // before dead_flag (fired=false)
                 function Main() : Int {
@@ -721,7 +721,7 @@ mod q_driven {
             "#},
             "Main",
             "dead_flag",
-            dead_flag::apply,
+            |p, a, _pkg_id, b, s| dead_flag::apply(p, a, b, s),
             &expect![[r#"
                 // before dead_flag (fired=false)
                 function Main() : Int {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/dead_local.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/dead_local.rs
@@ -34,9 +34,11 @@
 //!
 //! 1. Tuple-bind pattern (`let (_a, _b) = (1, 2);`) — the matcher
 //!    rejects non-Bind patterns regardless of downstream use (Q#).
-//! 2. Call initializer (`let _x = Helper();`) — the side-effect-free
+//! 2. Call initializer (`let _x = Helper();`) — the discard-safety
 //!    check rejects `ExprKind::Call` (Q#).
-//! 3. Closure capture downstream — direct-FIR pin for the
+//! 3. Array-index initializer (`let _x = xs[2];`) — locally pure but
+//!    not safe to discard because it can raise `IndexOutOfRange` (Q#).
+//! 4. Closure capture downstream — direct-FIR pin for the
 //!    `ExprKind::Closure` matcher path in `local_use_count`. Mono
 //!    routinely lifts closures, so the raw Closure expression is not
 //!    reliably reachable from Q# at the simplify stage.
@@ -46,7 +48,10 @@ use indoc::indoc;
 use qsc_data_structures::span::Span;
 use qsc_fir::{
     assigner::Assigner,
-    fir::{CallableKind, ExprKind, Lit, LocalItemId, Mutability, Package, PackageLookup, StmtId},
+    fir::{
+        CallableKind, ExprKind, Lit, LocalItemId, Mutability, Package, PackageId, PackageLookup,
+        StmtId,
+    },
     ty::{Arrow, FunctorSet, FunctorSetValue, Prim, Ty},
 };
 
@@ -90,7 +95,7 @@ fn given_immutable_unused_let_with_literal_init_dead_local_drops_binding() {
         "#},
         "Main",
         "dead_local",
-        |p, a, b, _| dead_local::apply(p, a, b),
+        |p, a, pkg_id, b, _| dead_local::apply(p, a, pkg_id, b),
         &expect![[r#"
             // before dead_local (fired=true)
             function Main() : Int {
@@ -126,7 +131,7 @@ fn given_mutable_unused_let_with_literal_init_dead_local_drops_binding() {
         "#},
         "Main",
         "dead_local",
-        |p, a, b, _| dead_local::apply(p, a, b),
+        |p, a, pkg_id, b, _| dead_local::apply(p, a, pkg_id, b),
         &expect![[r#"
             // before dead_local (fired=true)
             function Main() : Int {
@@ -160,8 +165,7 @@ fn given_preserved_local_with_default_init_dead_local_drops_binding() {
     //   let result : Int = 0;     // user name preserved with default-value init
     //   42
     // The default-value init is a literal (Int's default is 0), which
-    // the side-effect-free check accepts. The rule must drop the
-    // binding.
+    // the discard-safety check accepts. The rule must drop the binding.
     let mut package = Package::default();
     let mut assigner = Assigner::default();
 
@@ -183,7 +187,7 @@ fn given_preserved_local_with_default_init_dead_local_drops_binding() {
         Span::default(),
     );
 
-    let fired = dead_local::apply(&mut package, &mut assigner, block);
+    let fired = dead_local::apply(&mut package, &mut assigner, PackageId::CORE, block);
     assert!(
         fired,
         "dead_local must drop the preserved user binding with a default-value init",
@@ -212,7 +216,7 @@ fn given_tuple_bind_dead_local_does_not_drop() {
         "#},
         "Main",
         "dead_local",
-        |p, a, b, _| dead_local::apply(p, a, b),
+        |p, a, pkg_id, b, _| dead_local::apply(p, a, pkg_id, b),
         &expect![[r#"
             // before dead_local (fired=false)
             function Main() : Int {
@@ -234,11 +238,10 @@ fn given_tuple_bind_dead_local_does_not_drop() {
 }
 
 #[test]
-fn given_call_init_dead_local_does_not_drop() {
-    // Q# input: `let _x = Helper(); 42`. The initializer is a call
-    // expression; the side-effect-free check rejects `ExprKind::Call`
-    // and the rule must not drop the binding even though `_x` is
-    // unused.
+fn given_pure_call_init_dead_local_drops_binding() {
+    // Q# input: `let _x = Helper(); 42`. The initializer is a known pure
+    // function call whose body is total, so the binding can be dropped once
+    // `_x` is unused.
     check_simplify_rule_q(
         indoc! {r#"
         namespace Test {
@@ -253,9 +256,9 @@ fn given_call_init_dead_local_does_not_drop() {
         "#},
         "Main",
         "dead_local",
-        |p, a, b, _| dead_local::apply(p, a, b),
+        |p, a, pkg_id, b, _| dead_local::apply(p, a, pkg_id, b),
         &expect![[r#"
-            // before dead_local (fired=false)
+            // before dead_local (fired=true)
             function Helper() : Int {
                 0
             }
@@ -271,7 +274,94 @@ fn given_call_init_dead_local_does_not_drop() {
                 0
             }
             function Main() : Int {
+                42
+            }
+            // entry
+            Main()
+        "#]],
+    );
+}
+
+#[test]
+fn given_effectful_call_init_dead_local_does_not_drop() {
+    // A function call whose body writes output through `Message` is not safe to
+    // discard, even when the bound local is otherwise dead.
+    check_simplify_rule_q(
+        indoc! {r#"
+        namespace Test {
+            function Helper() : Int {
+                Message("x");
+                0
+            }
+            function Main() : Int {
+                let _x = Helper();
+                42
+            }
+        }
+        "#},
+        "Main",
+        "dead_local",
+        |p, a, pkg_id, b, _| dead_local::apply(p, a, pkg_id, b),
+        &expect![[r#"
+            // before dead_local (fired=false)
+            function Helper() : Int {
+                Message($"x");
+                0
+            }
+            function Main() : Int {
                 let _x : Int = Helper();
+                42
+            }
+            // entry
+            Main()
+
+            // after dead_local
+            function Helper() : Int {
+                Message($"x");
+                0
+            }
+            function Main() : Int {
+                let _x : Int = Helper();
+                42
+            }
+            // entry
+            Main()
+        "#]],
+    );
+}
+
+#[test]
+fn given_array_index_init_dead_local_does_not_drop() {
+    // Q# input: `let _x = xs[2]; 42`. The initializer is locally
+    // side-effect-free, but evaluating it can raise IndexOutOfRange,
+    // so the dead-local rule must not erase it.
+    check_simplify_rule_q(
+        indoc! {r#"
+        namespace Test {
+            function Main() : Int {
+                let xs = [1];
+                let _x = xs[2];
+                42
+            }
+        }
+        "#},
+        "Main",
+        "dead_local",
+        |p, a, pkg_id, b, _| dead_local::apply(p, a, pkg_id, b),
+        &expect![[r#"
+            // before dead_local (fired=false)
+            function Main() : Int {
+                let xs : Int[] = [1];
+                let _x : Int = xs[2];
+                42
+            }
+            // entry
+            Main()
+
+            // after dead_local
+            function Main() : Int {
+                let xs : Int[] = [1];
+                let _x : Int = xs[2];
                 42
             }
             // entry
@@ -333,7 +423,7 @@ fn given_local_used_in_closure_capture_dead_local_does_not_drop() {
         Span::default(),
     );
 
-    let fired = dead_local::apply(&mut package, &mut assigner, block);
+    let fired = dead_local::apply(&mut package, &mut assigner, PackageId::CORE, block);
     assert!(
         !fired,
         "dead_local must not drop a binding whose local is captured by a downstream closure",

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/fixpoint.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/fixpoint.rs
@@ -38,8 +38,8 @@ use qsc_data_structures::span::Span;
 use qsc_fir::{
     assigner::Assigner,
     fir::{
-        BlockId, ExprId, ExprKind, Lit, LocalVarId, Mutability, Package, PackageLookup, Res,
-        StmtId, StmtKind,
+        BlockId, ExprId, ExprKind, Lit, LocalVarId, Mutability, Package, PackageId, PackageLookup,
+        Res, StmtId, StmtKind,
     },
     ty::{Prim, Ty},
 };
@@ -59,11 +59,12 @@ use crate::return_unify::tests::{check_simplify_rule_q, synth_slots_for_block};
 fn run_to_fixpoint_bool(
     pkg: &mut Package,
     asgn: &mut Assigner,
+    pkg_id: PackageId,
     bid: BlockId,
     slots: &crate::return_unify::lower::SynthSlots,
 ) -> bool {
     let mut errors = Vec::new();
-    simplify::run_to_fixpoint(pkg, asgn, bid, &mut errors, slots);
+    simplify::run_to_fixpoint(pkg, asgn, pkg_id, bid, &mut errors, slots);
     assert!(errors.is_empty(), "unexpected fixpoint errors: {errors:?}");
     true
 }
@@ -631,6 +632,7 @@ fn guard_clause_plus_dead_flag_via_run_to_fixpoint() {
     simplify::run_to_fixpoint(
         &mut package,
         &mut assigner,
+        PackageId::CORE,
         block_id,
         &mut Vec::new(),
         &synth_slots,

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/guard_clause.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/guard_clause.rs
@@ -53,7 +53,7 @@ fn simple_guard_clause_collapses_to_if_else() {
         "#},
         "Main",
         "guard_clause",
-        guard_clause::apply,
+        |p, a, _pkg_id, b, s| guard_clause::apply(p, a, b, s),
         &expect![[r#"
             // before guard_clause (fired=true)
             function Main() : Int {
@@ -123,7 +123,7 @@ fn guard_clause_with_let_in_rest_block() {
         "#},
         "Main",
         "guard_clause",
-        guard_clause::apply,
+        |p, a, _pkg_id, b, s| guard_clause::apply(p, a, b, s),
         &expect![[r#"
             // before guard_clause (fired=false)
             function Main() : Int {
@@ -215,7 +215,7 @@ fn multiple_guard_clauses_chain_into_nested_if_else() {
         "#},
         "Main",
         "guard_clause",
-        guard_clause::apply,
+        |p, a, _pkg_id, b, s| guard_clause::apply(p, a, b, s),
         &expect![[r#"
             // before guard_clause (fired=false)
             function Main() : Int {
@@ -304,7 +304,7 @@ fn no_returns_block_has_no_merge_so_rule_does_not_fire() {
         "#},
         "Main",
         "guard_clause",
-        guard_clause::apply,
+        |p, a, _pkg_id, b, s| guard_clause::apply(p, a, b, s),
         &expect![[r#"
             // before guard_clause (fired=false)
             function Main() : Int {
@@ -346,7 +346,7 @@ fn both_branches_return_shape_not_collapsed_by_guard_clause_rule() {
         "#},
         "Main",
         "guard_clause",
-        guard_clause::apply,
+        |p, a, _pkg_id, b, s| guard_clause::apply(p, a, b, s),
         &expect![[r#"
             // before guard_clause (fired=false)
             function Main() : Int {
@@ -793,7 +793,7 @@ mod inverted_orientation {
             "#},
             "Main",
             "guard_clause",
-            guard_clause::apply,
+            |p, a, _pkg_id, b, s| guard_clause::apply(p, a, b, s),
             &expect![[r#"
                 // before guard_clause (fired=true)
                 function Main() : Int {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/identical_branches.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/identical_branches.rs
@@ -53,8 +53,8 @@ fn pure_flag_merge_collapses_to_slot_read() {
         "#},
         "Main",
         "identical_branches",
-        |package, _assigner, block_id, _slots| {
-            super::super::run_identical_branches(package, block_id)
+        |package, _assigner, package_id, block_id, _slots| {
+            super::super::run_identical_branches(package, package_id, block_id)
         },
         &expect![[r#"
             // before identical_branches (fired=true)
@@ -131,8 +131,8 @@ fn impure_condition_refuses_to_collapse() {
         "#},
         "Main",
         "identical_branches",
-        |package, _assigner, block_id, _slots| {
-            super::super::run_identical_branches(package, block_id)
+        |package, _assigner, package_id, block_id, _slots| {
+            super::super::run_identical_branches(package, package_id, block_id)
         },
         &expect![[r#"
             // before identical_branches (fired=false)

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/let_folding.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/let_folding.rs
@@ -583,7 +583,7 @@ mod q_driven {
             "#},
             "Main",
             "let_folding",
-            let_folding::apply,
+            |p, a, _pkg_id, b, s| let_folding::apply(p, a, b, s),
             &expect![[r#"
                 // before let_folding (fired=true)
                 function Main() : Int {
@@ -659,7 +659,7 @@ mod q_driven {
             "#},
             "Main",
             "let_folding",
-            let_folding::apply,
+            |p, a, _pkg_id, b, s| let_folding::apply(p, a, b, s),
             &expect![[r#"
                 // before let_folding (fired=false)
                 function Main() : Int {
@@ -730,7 +730,7 @@ mod q_driven {
             "#},
             "Main",
             "let_folding",
-            let_folding::apply,
+            |p, a, _pkg_id, b, s| let_folding::apply(p, a, b, s),
             &expect![[r#"
                 // before let_folding (fired=false)
                 function Main() : Int {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/single_branch.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/simplify/tests/single_branch.rs
@@ -46,7 +46,7 @@ fn then_arm_return_collapses_to_if_else() {
         "#},
         "Main",
         "single_branch",
-        single_branch::apply,
+        |p, a, _pkg_id, b, s| single_branch::apply(p, a, b, s),
         &expect![[r#"
             // before single_branch (fired=true)
             function Main() : Int {
@@ -104,7 +104,7 @@ fn else_arm_return_collapses_to_if_else() {
         "#},
         "Main",
         "single_branch",
-        single_branch::apply,
+        |p, a, _pkg_id, b, s| single_branch::apply(p, a, b, s),
         &expect![[r#"
             // before single_branch (fired=true)
             function Main() : Int {

--- a/source/compiler/qsc_fir_transforms/src/return_unify/tests.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/tests.rs
@@ -437,7 +437,7 @@ pub(crate) fn check_simplify_rule_q(
     source: &str,
     callable_name: &str,
     rule_name: &str,
-    apply_rule: impl FnOnce(&mut Package, &mut Assigner, BlockId, &SynthSlots) -> bool,
+    apply_rule: impl FnOnce(&mut Package, &mut Assigner, PackageId, BlockId, &SynthSlots) -> bool,
     expect: &Expect,
 ) {
     let (mut store, pkg_id) = compile_and_run_pipeline_to(source, PipelineStage::Mono);
@@ -451,7 +451,13 @@ pub(crate) fn check_simplify_rule_q(
     let before = crate::pretty::write_package_qsharp_parseable(&store, pkg_id);
     let block_id = find_body_block_id(store.get(pkg_id), callable_name);
     let slots = synth_slots_for_block(store.get(pkg_id), block_id);
-    let fired = apply_rule(store.get_mut(pkg_id), &mut assigner, block_id, &slots);
+    let fired = apply_rule(
+        store.get_mut(pkg_id),
+        &mut assigner,
+        pkg_id,
+        block_id,
+        &slots,
+    );
     let after = crate::pretty::write_package_qsharp_parseable(&store, pkg_id);
 
     expect.assert_eq(&format!(

--- a/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
+++ b/source/compiler/qsc_fir_transforms/src/sample_pipeline_tests/shor.rs
@@ -1359,8 +1359,7 @@ fn shor_sample_full_pipeline_reachable_items() {
                 (t1, t2) = (t2, t1 - quotient * t2);
             }
 
-            let __cond_0 : Bool = r2 == 0 and AbsI(s2) <= denominatorBound;
-            if __cond_0 {
+            if r2 == 0 and AbsI(s2) <= denominatorBound {
                 (-t2 * signB, s2 * signA)
             } else {
                 (-t1 * signB, s1 * signA)
@@ -1462,8 +1461,6 @@ fn shor_sample_full_pipeline_reachable_items() {
                 let ysLen : Int = Length(ys);
                 Fact(ysLen >= xsLen, $"Register `ys` must be longer than register `xs`.");
                 Fact(xsLen >= 1, $"Registers `xs` and `ys` must contain at least one qubit.");
-                mutable __cond_0 : Bool = false;
-                mutable __cond_1 : Bool = false;
                 if xsLen == ysLen {
                     if xsLen > 1 {
                         {
@@ -1484,41 +1481,33 @@ fn shor_sample_full_pipeline_reachable_items() {
                     }
 
                     CNOT(xs[0], ys[0]);
-                } else {
-                    __cond_0 = xsLen + 1 == ysLen;
-                    if __cond_0 {
-                        if xsLen > 1 {
-                            CNOT(xs[xsLen - 1], ys[ysLen - 1]);
+                } else if xsLen + 1 == ysLen {
+                    if xsLen > 1 {
+                        CNOT(xs[xsLen - 1], ys[ysLen - 1]);
+                        {
                             {
-                                {
-                                    ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                let _apply_res : Unit = {
-                                    ApplyInnerTTKAdderWithCarry(xs, ys);
-                                };
-                                {
-                                    Adjoint ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                _apply_res
+                                ApplyOuterTTKAdder(xs, ys);
                             }
 
-                        } else {
-                            CCNOT(xs[0], ys[0], ys[1]);
+                            let _apply_res : Unit = {
+                                ApplyInnerTTKAdderWithCarry(xs, ys);
+                            };
+                            {
+                                Adjoint ApplyOuterTTKAdder(xs, ys);
+                            }
+
+                            _apply_res
                         }
 
-                        CNOT(xs[0], ys[0]);
                     } else {
-                        __cond_1 = xsLen + 2 <= ysLen;
-                        if __cond_1 {
-                            let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
-                            RippleCarryTTKIncByLE(xs + padding, ys);
-                            ReleaseQubitArray(padding);
-                        }
-
+                        CCNOT(xs[0], ys[0], ys[1]);
                     }
 
+                    CNOT(xs[0], ys[0]);
+                } else if xsLen + 2 <= ysLen {
+                    let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
+                    RippleCarryTTKIncByLE(xs + padding, ys);
+                    ReleaseQubitArray(padding);
                 }
 
             }
@@ -1527,8 +1516,6 @@ fn shor_sample_full_pipeline_reachable_items() {
                 let ysLen : Int = Length(ys);
                 Fact(ysLen >= xsLen, $"Register `ys` must be longer than register `xs`.");
                 Fact(xsLen >= 1, $"Registers `xs` and `ys` must contain at least one qubit.");
-                mutable __cond_0 : Bool = false;
-                mutable __cond_1 : Bool = false;
                 if xsLen == ysLen {
                     Adjoint CNOT(xs[0], ys[0]);
                     if xsLen > 1 {
@@ -1549,41 +1536,33 @@ fn shor_sample_full_pipeline_reachable_items() {
 
                     }
 
-                } else {
-                    __cond_0 = xsLen + 1 == ysLen;
-                    if __cond_0 {
-                        Adjoint CNOT(xs[0], ys[0]);
-                        if xsLen > 1 {
+                } else if xsLen + 1 == ysLen {
+                    Adjoint CNOT(xs[0], ys[0]);
+                    if xsLen > 1 {
+                        {
                             {
-                                {
-                                    ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                let _apply_res : Unit = {
-                                    Adjoint ApplyInnerTTKAdderWithCarry(xs, ys);
-                                };
-                                {
-                                    Adjoint ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                _apply_res
+                                ApplyOuterTTKAdder(xs, ys);
                             }
 
-                            Adjoint CNOT(xs[xsLen - 1], ys[ysLen - 1]);
-                        } else {
-                            Adjoint CCNOT(xs[0], ys[0], ys[1]);
+                            let _apply_res : Unit = {
+                                Adjoint ApplyInnerTTKAdderWithCarry(xs, ys);
+                            };
+                            {
+                                Adjoint ApplyOuterTTKAdder(xs, ys);
+                            }
+
+                            _apply_res
                         }
 
+                        Adjoint CNOT(xs[xsLen - 1], ys[ysLen - 1]);
                     } else {
-                        __cond_1 = xsLen + 2 <= ysLen;
-                        if __cond_1 {
-                            let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
-                            Adjoint RippleCarryTTKIncByLE(xs + padding, ys);
-                            ReleaseQubitArray(padding);
-                        }
-
+                        Adjoint CCNOT(xs[0], ys[0], ys[1]);
                     }
 
+                } else if xsLen + 2 <= ysLen {
+                    let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
+                    Adjoint RippleCarryTTKIncByLE(xs + padding, ys);
+                    ReleaseQubitArray(padding);
                 }
 
             }
@@ -1592,8 +1571,6 @@ fn shor_sample_full_pipeline_reachable_items() {
                 let ysLen : Int = Length(ys);
                 Fact(ysLen >= xsLen, $"Register `ys` must be longer than register `xs`.");
                 Fact(xsLen >= 1, $"Registers `xs` and `ys` must contain at least one qubit.");
-                mutable __cond_0 : Bool = false;
-                mutable __cond_1 : Bool = false;
                 if xsLen == ysLen {
                     if xsLen > 1 {
                         {
@@ -1614,41 +1591,33 @@ fn shor_sample_full_pipeline_reachable_items() {
                     }
 
                     Controlled CNOT(ctls, (xs[0], ys[0]));
-                } else {
-                    __cond_0 = xsLen + 1 == ysLen;
-                    if __cond_0 {
-                        if xsLen > 1 {
-                            Controlled CNOT(ctls, (xs[xsLen - 1], ys[ysLen - 1]));
+                } else if xsLen + 1 == ysLen {
+                    if xsLen > 1 {
+                        Controlled CNOT(ctls, (xs[xsLen - 1], ys[ysLen - 1]));
+                        {
                             {
-                                {
-                                    ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                let _apply_res : Unit = {
-                                    Controlled ApplyInnerTTKAdderWithCarry(ctls, (xs, ys));
-                                };
-                                {
-                                    Adjoint ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                _apply_res
+                                ApplyOuterTTKAdder(xs, ys);
                             }
 
-                        } else {
-                            Controlled CCNOT(ctls, (xs[0], ys[0], ys[1]));
+                            let _apply_res : Unit = {
+                                Controlled ApplyInnerTTKAdderWithCarry(ctls, (xs, ys));
+                            };
+                            {
+                                Adjoint ApplyOuterTTKAdder(xs, ys);
+                            }
+
+                            _apply_res
                         }
 
-                        Controlled CNOT(ctls, (xs[0], ys[0]));
                     } else {
-                        __cond_1 = xsLen + 2 <= ysLen;
-                        if __cond_1 {
-                            let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
-                            Controlled RippleCarryTTKIncByLE(ctls, (xs + padding, ys));
-                            ReleaseQubitArray(padding);
-                        }
-
+                        Controlled CCNOT(ctls, (xs[0], ys[0], ys[1]));
                     }
 
+                    Controlled CNOT(ctls, (xs[0], ys[0]));
+                } else if xsLen + 2 <= ysLen {
+                    let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
+                    Controlled RippleCarryTTKIncByLE(ctls, (xs + padding, ys));
+                    ReleaseQubitArray(padding);
                 }
 
             }
@@ -1657,8 +1626,6 @@ fn shor_sample_full_pipeline_reachable_items() {
                 let ysLen : Int = Length(ys);
                 Fact(ysLen >= xsLen, $"Register `ys` must be longer than register `xs`.");
                 Fact(xsLen >= 1, $"Registers `xs` and `ys` must contain at least one qubit.");
-                mutable __cond_0 : Bool = false;
-                mutable __cond_1 : Bool = false;
                 if xsLen == ysLen {
                     Controlled Adjoint CNOT(ctls, (xs[0], ys[0]));
                     if xsLen > 1 {
@@ -1679,41 +1646,33 @@ fn shor_sample_full_pipeline_reachable_items() {
 
                     }
 
-                } else {
-                    __cond_0 = xsLen + 1 == ysLen;
-                    if __cond_0 {
-                        Controlled Adjoint CNOT(ctls, (xs[0], ys[0]));
-                        if xsLen > 1 {
+                } else if xsLen + 1 == ysLen {
+                    Controlled Adjoint CNOT(ctls, (xs[0], ys[0]));
+                    if xsLen > 1 {
+                        {
                             {
-                                {
-                                    ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                let _apply_res : Unit = {
-                                    Controlled Adjoint ApplyInnerTTKAdderWithCarry(ctls, (xs, ys));
-                                };
-                                {
-                                    Adjoint ApplyOuterTTKAdder(xs, ys);
-                                }
-
-                                _apply_res
+                                ApplyOuterTTKAdder(xs, ys);
                             }
 
-                            Controlled Adjoint CNOT(ctls, (xs[xsLen - 1], ys[ysLen - 1]));
-                        } else {
-                            Controlled Adjoint CCNOT(ctls, (xs[0], ys[0], ys[1]));
+                            let _apply_res : Unit = {
+                                Controlled Adjoint ApplyInnerTTKAdderWithCarry(ctls, (xs, ys));
+                            };
+                            {
+                                Adjoint ApplyOuterTTKAdder(xs, ys);
+                            }
+
+                            _apply_res
                         }
 
+                        Controlled Adjoint CNOT(ctls, (xs[xsLen - 1], ys[ysLen - 1]));
                     } else {
-                        __cond_1 = xsLen + 2 <= ysLen;
-                        if __cond_1 {
-                            let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
-                            Controlled Adjoint RippleCarryTTKIncByLE(ctls, (xs + padding, ys));
-                            ReleaseQubitArray(padding);
-                        }
-
+                        Controlled Adjoint CCNOT(ctls, (xs[0], ys[0], ys[1]));
                     }
 
+                } else if xsLen + 2 <= ysLen {
+                    let padding : Qubit[] = AllocateQubitArray(ysLen - xsLen - 1);
+                    Controlled Adjoint RippleCarryTTKIncByLE(ctls, (xs + padding, ys));
+                    ReleaseQubitArray(padding);
                 }
 
             }
@@ -2188,11 +2147,10 @@ fn shor_sample_full_pipeline_reachable_items() {
             (a, b)
         }
         operation FactorSemiprimeInteger(number : Int) : (Int, Int) {
-            mutable __cond_1 : Bool = false;
+            mutable __cond_0 : Bool = false;
             mutable __has_returned : Bool = false;
             mutable __ret_val : (Int, Int) = (0, 0);
-            let __cond_0 : Bool = number % 2 == 0;
-            if __cond_0 {
+            if number % 2 == 0 {
                 Message($"An even number has been given; 2 is a factor.");
                 {
                     __ret_val = (number / 2, 2);
@@ -2219,8 +2177,8 @@ fn shor_sample_full_pipeline_reachable_items() {
                     while _continue_cond_1475 {
                         Message($"*** Factorizing {number}, attempt {attempt}.");
                         let generator : Int = 2;
-                        __cond_1 = GreatestCommonDivisorI(generator, number) == 1;
-                        if __cond_1 {
+                        __cond_0 = GreatestCommonDivisorI(generator, number) == 1;
+                        if __cond_0 {
                             Message($"Estimating period of {generator}.");
                             let period : Int = EstimatePeriod(generator, number);
                             (foundFactors, factors) = MaybeFactorsFromPeriod(number, generator, period);
@@ -2255,14 +2213,11 @@ fn shor_sample_full_pipeline_reachable_items() {
             __ret_val
         }
         function MaybeFactorsFromPeriod(modulus : Int, generator : Int, period : Int) : (Bool, (Int, Int)) {
-            mutable __cond_1 : Bool = false;
             mutable __has_returned : Bool = false;
             mutable __ret_val : (Bool, (Int, Int)) = (false, (0, 0));
-            let __cond_0 : Bool = period % 2 == 0;
-            if __cond_0 {
+            if period % 2 == 0 {
                 let halfPower : Int = ExpModI(generator, period / 2, modulus);
-                __cond_1 = halfPower != modulus - 1;
-                if __cond_1 {
+                if halfPower != modulus - 1 {
                     let factor : Int = MaxI(GreatestCommonDivisorI(halfPower - 1, modulus), GreatestCommonDivisorI(halfPower + 1, modulus));
                     if factor != 1 and factor != modulus {
                         Message($"Found factor={factor}");
@@ -2682,437 +2637,417 @@ fn shor_sample_full_pipeline_reachable_items() {
         operation ApplyActionIfGreaterThanOrEqualConstant_Qubit__AdjCtl__X_(invertControl : Bool, c : BigInt, x : Qubit[], target : Qubit) : Unit is Adj + Ctl {
             body ... {
                 let bitWidth : Int = Length(x);
-                mutable __cond_0 : Bool = false;
                 if c == 0L {
                     if not invertControl {
                         X(target);
                     }
 
+                } else if c >= 2L^bitWidth {
+                    if invertControl {
+                        X(target);
+                    }
+
                 } else {
-                    __cond_0 = c >= 2L^bitWidth;
-                    if __cond_0 {
-                        if invertControl {
-                            X(target);
-                        }
-
+                    let l : Int = TrailingZeroCountL(c);
+                    let cNormalized : BigInt = c >>> l;
+                    let xNormalized : Qubit[] = x[l...];
+                    let bitWidthNormalized : Int = Length(xNormalized);
+                    let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
+                    let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
+                        []
                     } else {
-                        let l : Int = TrailingZeroCountL(c);
-                        let cNormalized : BigInt = c >>> l;
-                        let xNormalized : Qubit[] = x[l...];
-                        let bitWidthNormalized : Int = Length(xNormalized);
-                        let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
-                        let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
-                            []
-                        } else {
-                            [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
-                        };
-                        Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54679 : Unit = {
+                        [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
+                    };
+                    Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
+                    let _generated_ident_54679 : Unit = {
+                        {
                             {
-                                {
-                                    let _range_id_52627 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52630 : Int = _range_id_52627::Start;
-                                    let _step_id_52635 : Int = _range_id_52627::Step;
-                                    let _end_id_52640 : Int = _range_id_52627::End;
-                                    while _step_id_52635 > 0 and _index_id_52630 <= _end_id_52640 or _step_id_52635 < 0 and _index_id_52630 >= _end_id_52640 {
-                                        let i : Int = _index_id_52630;
-                                        if cNormalized &&& 1L <<< i + 1 != 0L {
-                                            AND(cs1[i], xNormalized[i + 1], qs[i])
-                                        } else {
-                                            ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                        };
-                                        _index_id_52630 += _step_id_52635;
-                                    }
-
+                                let _range_id_52627 : Range = 0..Length(cs1) - 1;
+                                mutable _index_id_52630 : Int = _range_id_52627::Start;
+                                let _step_id_52635 : Int = _range_id_52627::Step;
+                                let _end_id_52640 : Int = _range_id_52627::End;
+                                while _step_id_52635 > 0 and _index_id_52630 <= _end_id_52640 or _step_id_52635 < 0 and _index_id_52630 >= _end_id_52640 {
+                                    let i : Int = _index_id_52630;
+                                    if cNormalized &&& 1L <<< i + 1 != 0L {
+                                        AND(cs1[i], xNormalized[i + 1], qs[i])
+                                    } else {
+                                        ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                    };
+                                    _index_id_52630 += _step_id_52635;
                                 }
 
                             }
 
-                            let _apply_res : Unit = {
-                                let control : Qubit = if IsEmpty_Qubit_(qs) {
-                                    Tail_Qubit_(x)
-                                } else {
-                                    Tail_Qubit_(qs)
-                                };
-                                {
-                                    {
-                                        if invertControl {
-                                            X(control);
-                                        }
+                        }
 
-                                    }
-
-                                    let _apply_res : Unit = {
-                                        Controlled X([control], target);
-                                    };
-                                    {
-                                        if invertControl {
-                                            Adjoint X(control);
-                                        }
-
-                                    }
-
-                                    _apply_res
-                                }
-
+                        let _apply_res : Unit = {
+                            let control : Qubit = if IsEmpty_Qubit_(qs) {
+                                Tail_Qubit_(x)
+                            } else {
+                                Tail_Qubit_(qs)
                             };
                             {
                                 {
-                                    let _range : Range = 0..Length(cs1) - 1;
-                                    {
-                                        let _range_id_52670 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52673 : Int = _range_id_52670::Start;
-                                        let _step_id_52678 : Int = _range_id_52670::Step;
-                                        let _end_id_52683 : Int = _range_id_52670::End;
-                                        while _step_id_52678 > 0 and _index_id_52673 <= _end_id_52683 or _step_id_52678 < 0 and _index_id_52673 >= _end_id_52683 {
-                                            let i : Int = _index_id_52673;
-                                            if cNormalized &&& 1L <<< i + 1 != 0L {
-                                                Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
-                                            } else {
-                                                Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                            };
-                                            _index_id_52673 += _step_id_52678;
-                                        }
+                                    if invertControl {
+                                        X(control);
+                                    }
 
+                                }
+
+                                let _apply_res : Unit = {
+                                    Controlled X([control], target);
+                                };
+                                {
+                                    if invertControl {
+                                        Adjoint X(control);
+                                    }
+
+                                }
+
+                                _apply_res
+                            }
+
+                        };
+                        {
+                            {
+                                let _range : Range = 0..Length(cs1) - 1;
+                                {
+                                    let _range_id_52670 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                    mutable _index_id_52673 : Int = _range_id_52670::Start;
+                                    let _step_id_52678 : Int = _range_id_52670::Step;
+                                    let _end_id_52683 : Int = _range_id_52670::End;
+                                    while _step_id_52678 > 0 and _index_id_52673 <= _end_id_52683 or _step_id_52678 < 0 and _index_id_52673 >= _end_id_52683 {
+                                        let i : Int = _index_id_52673;
+                                        if cNormalized &&& 1L <<< i + 1 != 0L {
+                                            Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
+                                        } else {
+                                            Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                        };
+                                        _index_id_52673 += _step_id_52678;
                                     }
 
                                 }
 
                             }
 
-                            _apply_res
-                        };
-                        ReleaseQubitArray(qs);
-                        _generated_ident_54679
-                    }
+                        }
 
+                        _apply_res
+                    };
+                    ReleaseQubitArray(qs);
+                    _generated_ident_54679
                 }
 
             }
             adjoint ... {
                 let bitWidth : Int = Length(x);
-                mutable __cond_0 : Bool = false;
                 if c == 0L {
                     if not invertControl {
                         Adjoint X(target);
                     }
 
+                } else if c >= 2L^bitWidth {
+                    if invertControl {
+                        Adjoint X(target);
+                    }
+
                 } else {
-                    __cond_0 = c >= 2L^bitWidth;
-                    if __cond_0 {
-                        if invertControl {
-                            Adjoint X(target);
-                        }
-
+                    let l : Int = TrailingZeroCountL(c);
+                    let cNormalized : BigInt = c >>> l;
+                    let xNormalized : Qubit[] = x[l...];
+                    let bitWidthNormalized : Int = Length(xNormalized);
+                    let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
+                    let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
+                        []
                     } else {
-                        let l : Int = TrailingZeroCountL(c);
-                        let cNormalized : BigInt = c >>> l;
-                        let xNormalized : Qubit[] = x[l...];
-                        let bitWidthNormalized : Int = Length(xNormalized);
-                        let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
-                        let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
-                            []
-                        } else {
-                            [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
-                        };
-                        Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54693 : Unit = {
+                        [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
+                    };
+                    Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
+                    let _generated_ident_54693 : Unit = {
+                        {
                             {
-                                {
-                                    let _range_id_52713 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52716 : Int = _range_id_52713::Start;
-                                    let _step_id_52721 : Int = _range_id_52713::Step;
-                                    let _end_id_52726 : Int = _range_id_52713::End;
-                                    while _step_id_52721 > 0 and _index_id_52716 <= _end_id_52726 or _step_id_52721 < 0 and _index_id_52716 >= _end_id_52726 {
-                                        let i : Int = _index_id_52716;
-                                        if cNormalized &&& 1L <<< i + 1 != 0L {
-                                            AND(cs1[i], xNormalized[i + 1], qs[i])
-                                        } else {
-                                            ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                        };
-                                        _index_id_52716 += _step_id_52721;
-                                    }
-
+                                let _range_id_52713 : Range = 0..Length(cs1) - 1;
+                                mutable _index_id_52716 : Int = _range_id_52713::Start;
+                                let _step_id_52721 : Int = _range_id_52713::Step;
+                                let _end_id_52726 : Int = _range_id_52713::End;
+                                while _step_id_52721 > 0 and _index_id_52716 <= _end_id_52726 or _step_id_52721 < 0 and _index_id_52716 >= _end_id_52726 {
+                                    let i : Int = _index_id_52716;
+                                    if cNormalized &&& 1L <<< i + 1 != 0L {
+                                        AND(cs1[i], xNormalized[i + 1], qs[i])
+                                    } else {
+                                        ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                    };
+                                    _index_id_52716 += _step_id_52721;
                                 }
 
                             }
 
-                            let _apply_res : Unit = {
-                                let control : Qubit = if IsEmpty_Qubit_(qs) {
-                                    Tail_Qubit_(x)
-                                } else {
-                                    Tail_Qubit_(qs)
-                                };
-                                {
-                                    {
-                                        if invertControl {
-                                            X(control);
-                                        }
+                        }
 
-                                    }
-
-                                    let _apply_res : Unit = {
-                                        Controlled Adjoint X([control], target);
-                                    };
-                                    {
-                                        if invertControl {
-                                            Adjoint X(control);
-                                        }
-
-                                    }
-
-                                    _apply_res
-                                }
-
+                        let _apply_res : Unit = {
+                            let control : Qubit = if IsEmpty_Qubit_(qs) {
+                                Tail_Qubit_(x)
+                            } else {
+                                Tail_Qubit_(qs)
                             };
                             {
                                 {
-                                    let _range : Range = 0..Length(cs1) - 1;
-                                    {
-                                        let _range_id_52756 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52759 : Int = _range_id_52756::Start;
-                                        let _step_id_52764 : Int = _range_id_52756::Step;
-                                        let _end_id_52769 : Int = _range_id_52756::End;
-                                        while _step_id_52764 > 0 and _index_id_52759 <= _end_id_52769 or _step_id_52764 < 0 and _index_id_52759 >= _end_id_52769 {
-                                            let i : Int = _index_id_52759;
-                                            if cNormalized &&& 1L <<< i + 1 != 0L {
-                                                Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
-                                            } else {
-                                                Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                            };
-                                            _index_id_52759 += _step_id_52764;
-                                        }
+                                    if invertControl {
+                                        X(control);
+                                    }
 
+                                }
+
+                                let _apply_res : Unit = {
+                                    Controlled Adjoint X([control], target);
+                                };
+                                {
+                                    if invertControl {
+                                        Adjoint X(control);
+                                    }
+
+                                }
+
+                                _apply_res
+                            }
+
+                        };
+                        {
+                            {
+                                let _range : Range = 0..Length(cs1) - 1;
+                                {
+                                    let _range_id_52756 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                    mutable _index_id_52759 : Int = _range_id_52756::Start;
+                                    let _step_id_52764 : Int = _range_id_52756::Step;
+                                    let _end_id_52769 : Int = _range_id_52756::End;
+                                    while _step_id_52764 > 0 and _index_id_52759 <= _end_id_52769 or _step_id_52764 < 0 and _index_id_52759 >= _end_id_52769 {
+                                        let i : Int = _index_id_52759;
+                                        if cNormalized &&& 1L <<< i + 1 != 0L {
+                                            Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
+                                        } else {
+                                            Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                        };
+                                        _index_id_52759 += _step_id_52764;
                                     }
 
                                 }
 
                             }
 
-                            _apply_res
-                        };
-                        ReleaseQubitArray(qs);
-                        _generated_ident_54693
-                    }
+                        }
 
+                        _apply_res
+                    };
+                    ReleaseQubitArray(qs);
+                    _generated_ident_54693
                 }
 
             }
             controlled (ctls, ...) {
                 let bitWidth : Int = Length(x);
-                mutable __cond_0 : Bool = false;
                 if c == 0L {
                     if not invertControl {
                         Controlled X(ctls, target);
                     }
 
+                } else if c >= 2L^bitWidth {
+                    if invertControl {
+                        Controlled X(ctls, target);
+                    }
+
                 } else {
-                    __cond_0 = c >= 2L^bitWidth;
-                    if __cond_0 {
-                        if invertControl {
-                            Controlled X(ctls, target);
-                        }
-
+                    let l : Int = TrailingZeroCountL(c);
+                    let cNormalized : BigInt = c >>> l;
+                    let xNormalized : Qubit[] = x[l...];
+                    let bitWidthNormalized : Int = Length(xNormalized);
+                    let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
+                    let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
+                        []
                     } else {
-                        let l : Int = TrailingZeroCountL(c);
-                        let cNormalized : BigInt = c >>> l;
-                        let xNormalized : Qubit[] = x[l...];
-                        let bitWidthNormalized : Int = Length(xNormalized);
-                        let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
-                        let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
-                            []
-                        } else {
-                            [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
-                        };
-                        Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54707 : Unit = {
+                        [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
+                    };
+                    Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
+                    let _generated_ident_54707 : Unit = {
+                        {
                             {
-                                {
-                                    let _range_id_52799 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52802 : Int = _range_id_52799::Start;
-                                    let _step_id_52807 : Int = _range_id_52799::Step;
-                                    let _end_id_52812 : Int = _range_id_52799::End;
-                                    while _step_id_52807 > 0 and _index_id_52802 <= _end_id_52812 or _step_id_52807 < 0 and _index_id_52802 >= _end_id_52812 {
-                                        let i : Int = _index_id_52802;
-                                        if cNormalized &&& 1L <<< i + 1 != 0L {
-                                            AND(cs1[i], xNormalized[i + 1], qs[i])
-                                        } else {
-                                            ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                        };
-                                        _index_id_52802 += _step_id_52807;
-                                    }
-
+                                let _range_id_52799 : Range = 0..Length(cs1) - 1;
+                                mutable _index_id_52802 : Int = _range_id_52799::Start;
+                                let _step_id_52807 : Int = _range_id_52799::Step;
+                                let _end_id_52812 : Int = _range_id_52799::End;
+                                while _step_id_52807 > 0 and _index_id_52802 <= _end_id_52812 or _step_id_52807 < 0 and _index_id_52802 >= _end_id_52812 {
+                                    let i : Int = _index_id_52802;
+                                    if cNormalized &&& 1L <<< i + 1 != 0L {
+                                        AND(cs1[i], xNormalized[i + 1], qs[i])
+                                    } else {
+                                        ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                    };
+                                    _index_id_52802 += _step_id_52807;
                                 }
 
                             }
 
-                            let _apply_res : Unit = {
-                                let control : Qubit = if IsEmpty_Qubit_(qs) {
-                                    Tail_Qubit_(x)
-                                } else {
-                                    Tail_Qubit_(qs)
-                                };
-                                {
-                                    {
-                                        if invertControl {
-                                            X(control);
-                                        }
+                        }
 
-                                    }
-
-                                    let _apply_res : Unit = {
-                                        Controlled Controlled X(ctls, ([control], target));
-                                    };
-                                    {
-                                        if invertControl {
-                                            Adjoint X(control);
-                                        }
-
-                                    }
-
-                                    _apply_res
-                                }
-
+                        let _apply_res : Unit = {
+                            let control : Qubit = if IsEmpty_Qubit_(qs) {
+                                Tail_Qubit_(x)
+                            } else {
+                                Tail_Qubit_(qs)
                             };
                             {
                                 {
-                                    let _range : Range = 0..Length(cs1) - 1;
-                                    {
-                                        let _range_id_52842 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52845 : Int = _range_id_52842::Start;
-                                        let _step_id_52850 : Int = _range_id_52842::Step;
-                                        let _end_id_52855 : Int = _range_id_52842::End;
-                                        while _step_id_52850 > 0 and _index_id_52845 <= _end_id_52855 or _step_id_52850 < 0 and _index_id_52845 >= _end_id_52855 {
-                                            let i : Int = _index_id_52845;
-                                            if cNormalized &&& 1L <<< i + 1 != 0L {
-                                                Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
-                                            } else {
-                                                Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                            };
-                                            _index_id_52845 += _step_id_52850;
-                                        }
+                                    if invertControl {
+                                        X(control);
+                                    }
 
+                                }
+
+                                let _apply_res : Unit = {
+                                    Controlled Controlled X(ctls, ([control], target));
+                                };
+                                {
+                                    if invertControl {
+                                        Adjoint X(control);
+                                    }
+
+                                }
+
+                                _apply_res
+                            }
+
+                        };
+                        {
+                            {
+                                let _range : Range = 0..Length(cs1) - 1;
+                                {
+                                    let _range_id_52842 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                    mutable _index_id_52845 : Int = _range_id_52842::Start;
+                                    let _step_id_52850 : Int = _range_id_52842::Step;
+                                    let _end_id_52855 : Int = _range_id_52842::End;
+                                    while _step_id_52850 > 0 and _index_id_52845 <= _end_id_52855 or _step_id_52850 < 0 and _index_id_52845 >= _end_id_52855 {
+                                        let i : Int = _index_id_52845;
+                                        if cNormalized &&& 1L <<< i + 1 != 0L {
+                                            Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
+                                        } else {
+                                            Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                        };
+                                        _index_id_52845 += _step_id_52850;
                                     }
 
                                 }
 
                             }
 
-                            _apply_res
-                        };
-                        ReleaseQubitArray(qs);
-                        _generated_ident_54707
-                    }
+                        }
 
+                        _apply_res
+                    };
+                    ReleaseQubitArray(qs);
+                    _generated_ident_54707
                 }
 
             }
             controlled adjoint (ctls, ...) {
                 let bitWidth : Int = Length(x);
-                mutable __cond_0 : Bool = false;
                 if c == 0L {
                     if not invertControl {
                         Controlled Adjoint X(ctls, target);
                     }
 
+                } else if c >= 2L^bitWidth {
+                    if invertControl {
+                        Controlled Adjoint X(ctls, target);
+                    }
+
                 } else {
-                    __cond_0 = c >= 2L^bitWidth;
-                    if __cond_0 {
-                        if invertControl {
-                            Controlled Adjoint X(ctls, target);
-                        }
-
+                    let l : Int = TrailingZeroCountL(c);
+                    let cNormalized : BigInt = c >>> l;
+                    let xNormalized : Qubit[] = x[l...];
+                    let bitWidthNormalized : Int = Length(xNormalized);
+                    let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
+                    let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
+                        []
                     } else {
-                        let l : Int = TrailingZeroCountL(c);
-                        let cNormalized : BigInt = c >>> l;
-                        let xNormalized : Qubit[] = x[l...];
-                        let bitWidthNormalized : Int = Length(xNormalized);
-                        let qs : Qubit[] = AllocateQubitArray(bitWidthNormalized - 1);
-                        let cs1 : Qubit[] = if IsEmpty_Qubit_(qs) {
-                            []
-                        } else {
-                            [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
-                        };
-                        Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
-                        let _generated_ident_54721 : Unit = {
+                        [Head_Qubit_(xNormalized)] + Most_Qubit_(qs)
+                    };
+                    Fact(Length(cs1) == Length(qs), $"Arrays should be of the same length.");
+                    let _generated_ident_54721 : Unit = {
+                        {
                             {
-                                {
-                                    let _range_id_52885 : Range = 0..Length(cs1) - 1;
-                                    mutable _index_id_52888 : Int = _range_id_52885::Start;
-                                    let _step_id_52893 : Int = _range_id_52885::Step;
-                                    let _end_id_52898 : Int = _range_id_52885::End;
-                                    while _step_id_52893 > 0 and _index_id_52888 <= _end_id_52898 or _step_id_52893 < 0 and _index_id_52888 >= _end_id_52898 {
-                                        let i : Int = _index_id_52888;
-                                        if cNormalized &&& 1L <<< i + 1 != 0L {
-                                            AND(cs1[i], xNormalized[i + 1], qs[i])
-                                        } else {
-                                            ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                        };
-                                        _index_id_52888 += _step_id_52893;
-                                    }
-
+                                let _range_id_52885 : Range = 0..Length(cs1) - 1;
+                                mutable _index_id_52888 : Int = _range_id_52885::Start;
+                                let _step_id_52893 : Int = _range_id_52885::Step;
+                                let _end_id_52898 : Int = _range_id_52885::End;
+                                while _step_id_52893 > 0 and _index_id_52888 <= _end_id_52898 or _step_id_52893 < 0 and _index_id_52888 >= _end_id_52898 {
+                                    let i : Int = _index_id_52888;
+                                    if cNormalized &&& 1L <<< i + 1 != 0L {
+                                        AND(cs1[i], xNormalized[i + 1], qs[i])
+                                    } else {
+                                        ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                    };
+                                    _index_id_52888 += _step_id_52893;
                                 }
 
                             }
 
-                            let _apply_res : Unit = {
-                                let control : Qubit = if IsEmpty_Qubit_(qs) {
-                                    Tail_Qubit_(x)
-                                } else {
-                                    Tail_Qubit_(qs)
-                                };
-                                {
-                                    {
-                                        if invertControl {
-                                            X(control);
-                                        }
+                        }
 
-                                    }
-
-                                    let _apply_res : Unit = {
-                                        Controlled Controlled Adjoint X(ctls, ([control], target));
-                                    };
-                                    {
-                                        if invertControl {
-                                            Adjoint X(control);
-                                        }
-
-                                    }
-
-                                    _apply_res
-                                }
-
+                        let _apply_res : Unit = {
+                            let control : Qubit = if IsEmpty_Qubit_(qs) {
+                                Tail_Qubit_(x)
+                            } else {
+                                Tail_Qubit_(qs)
                             };
                             {
                                 {
-                                    let _range : Range = 0..Length(cs1) - 1;
-                                    {
-                                        let _range_id_52928 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
-                                        mutable _index_id_52931 : Int = _range_id_52928::Start;
-                                        let _step_id_52936 : Int = _range_id_52928::Step;
-                                        let _end_id_52941 : Int = _range_id_52928::End;
-                                        while _step_id_52936 > 0 and _index_id_52931 <= _end_id_52941 or _step_id_52936 < 0 and _index_id_52931 >= _end_id_52941 {
-                                            let i : Int = _index_id_52931;
-                                            if cNormalized &&& 1L <<< i + 1 != 0L {
-                                                Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
-                                            } else {
-                                                Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
-                                            };
-                                            _index_id_52931 += _step_id_52936;
-                                        }
+                                    if invertControl {
+                                        X(control);
+                                    }
 
+                                }
+
+                                let _apply_res : Unit = {
+                                    Controlled Controlled Adjoint X(ctls, ([control], target));
+                                };
+                                {
+                                    if invertControl {
+                                        Adjoint X(control);
+                                    }
+
+                                }
+
+                                _apply_res
+                            }
+
+                        };
+                        {
+                            {
+                                let _range : Range = 0..Length(cs1) - 1;
+                                {
+                                    let _range_id_52928 : Range = _range::Start + _range::End - _range::Start / _range::Step * _range::Step..-_range::Step.._range::Start;
+                                    mutable _index_id_52931 : Int = _range_id_52928::Start;
+                                    let _step_id_52936 : Int = _range_id_52928::Step;
+                                    let _end_id_52941 : Int = _range_id_52928::End;
+                                    while _step_id_52936 > 0 and _index_id_52931 <= _end_id_52941 or _step_id_52936 < 0 and _index_id_52931 >= _end_id_52941 {
+                                        let i : Int = _index_id_52931;
+                                        if cNormalized &&& 1L <<< i + 1 != 0L {
+                                            Adjoint AND(cs1[i], xNormalized[i + 1], qs[i])
+                                        } else {
+                                            Adjoint ApplyOrAssuming0Target(cs1[i], xNormalized[i + 1], qs[i])
+                                        };
+                                        _index_id_52931 += _step_id_52936;
                                     }
 
                                 }
 
                             }
 
-                            _apply_res
-                        };
-                        ReleaseQubitArray(qs);
-                        _generated_ident_54721
-                    }
+                        }
 
+                        _apply_res
+                    };
+                    ReleaseQubitArray(qs);
+                    _generated_ident_54721
                 }
 
             }

--- a/source/compiler/qsc_fir_transforms/src/walk_utils.rs
+++ b/source/compiler/qsc_fir_transforms/src/walk_utils.rs
@@ -65,10 +65,11 @@ mod tests;
 
 use crate::fir_builder::functored_specs;
 use qsc_fir::fir::{
-    BinOp, BlockId, CallableDecl, CallableImpl, Expr, ExprId, ExprKind, Field, ItemKind,
-    LocalItemId, LocalVarId, Package, PackageLookup, PatId, PatKind, Res, SpecDecl, SpecImpl,
-    StmtId, StmtKind, StringComponent, UnOp,
+    BinOp, BlockId, CallableDecl, CallableImpl, CallableKind, Expr, ExprId, ExprKind, Field,
+    Global, ItemKind, LocalItemId, LocalVarId, Package, PackageId, PackageLookup, PatId, PatKind,
+    Res, SpecDecl, SpecImpl, StmtId, StmtKind, StringComponent, UnOp,
 };
+use qsc_fir::ty::{Prim, Ty};
 use rustc_hash::FxHashSet;
 
 /// Walks an expression tree in pre-order, invoking `visit` for each expression.
@@ -707,102 +708,183 @@ pub(crate) fn extend_expr_ids_in_local_callables(
     }
 }
 
-/// Conservatively decides whether evaluating `expr_id` has no observable side
-/// effects.
+/// Returns whether evaluating `expr_id` has no observable side effects.
 ///
-/// Returns `true` only for pure value constructors, reads, and projections:
-/// literals, holes, variable references, and closures (the body is not invoked
-/// here); compound constructors (`Tuple`, `Array`, `ArrayLit`, `ArrayRepeat`,
-/// `Range`, `String`, `Struct`) and projections (`Field`, `Index`,
-/// `UpdateField`, `UpdateIndex`) whose children are all side-effect-free; `If`
-/// with both arms and `Block` (empty or a single trailing `Expr` stmt) whose
-/// subexpressions are side-effect-free; and non-trapping operators (the
-/// `Functor`, `NotB`, `NotL`, `Pos`, and `Unwrap` unary operators and the
-/// logical, bitwise, and comparison binary operators) over side-effect-free
-/// operands.
+/// This is a local syntactic purity check: it accepts value construction,
+/// reads, projections, functional updates, and operators whose operands are
+/// themselves side-effect-free. It does not prove that evaluation is total.
+/// Pure expressions such as array indexing, array repeat, division, modulus,
+/// exponentiation, shifts, and result comparison can still raise runtime
+/// errors. Callers that remove evaluation entirely must use
+/// [`expr_is_safe_to_discard`] instead.
 ///
-/// Returns `false` for everything else, including `Call`, `Assign*`, `Return`,
-/// `Fail`, `While`, else-less `If`, the trapping arithmetic/shift operators,
-/// and `Neg`. The match is exhaustive with no wildcard arm, so a new
-/// `ExprKind` variant breaks the build here and must have its purity decided
-/// explicitly rather than defaulting to either answer.
-pub(crate) fn expr_is_side_effect_free(package: &Package, expr_id: ExprId) -> bool {
-    match &package.get_expr(expr_id).kind {
+/// Calls are accepted only when the callee resolves to a callable in
+/// `package_id`, the callable is a function with a non-intrinsic body, and that
+/// body is side-effect-free under the same rules. Opaque intrinsics,
+/// operations, dynamic callees, and foreign-package callees remain rejected.
+/// `Return`, `Fail`, `While`, assignments, and else-less `If` in the current
+/// expression are rejected because they can change caller control flow or
+/// program state. The match is exhaustive with no wildcard arm, so a new
+/// [`ExprKind`] variant breaks the build here and must have both purity
+/// properties decided explicitly.
+pub(crate) fn expr_is_side_effect_free(
+    package: &Package,
+    package_id: PackageId,
+    expr_id: ExprId,
+) -> bool {
+    expr_has_purity(
+        package,
+        package_id,
+        expr_id,
+        PurityMode::AllowFallible,
+        PurityScope::Expression,
+        &mut FxHashSet::default(),
+    )
+}
+
+/// Returns whether evaluating `expr_id` can be removed without changing
+/// observable behavior.
+///
+/// This is stronger than [`expr_is_side_effect_free`]: it requires the
+/// expression to be side-effect-free and total for all well-typed runtime
+/// values described by the FIR shape. Fallible pure expressions such as
+/// `Index`, `UpdateIndex`, `ArrayRepeat`, division, modulus, exponentiation,
+/// shifts, and result equality are rejected unless a future value-sensitive
+/// analysis proves the specific instance total. Calls must additionally
+/// resolve to a known function body that is itself safe to discard; intrinsic,
+/// dynamic, foreign, and recursive callees are rejected.
+pub(crate) fn expr_is_safe_to_discard(
+    package: &Package,
+    package_id: PackageId,
+    expr_id: ExprId,
+) -> bool {
+    expr_has_purity(
+        package,
+        package_id,
+        expr_id,
+        PurityMode::RequireTotal,
+        PurityScope::Expression,
+        &mut FxHashSet::default(),
+    )
+}
+
+/// Controls whether purity analysis accepts expressions that can fail at
+/// runtime.
+#[derive(Clone, Copy)]
+enum PurityMode {
+    /// Accepts fallible expressions as long as they do not mutate state or
+    /// perform externally observable effects.
+    AllowFallible,
+    /// Requires expressions to be both side-effect-free and total for all
+    /// values described by their FIR shape.
+    RequireTotal,
+}
+
+/// Selects the statement and expression rules for the current analysis root.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PurityScope {
+    /// Applies expression-position rules, where only transparent expression
+    /// blocks are accepted.
+    Expression,
+    /// Applies callable-body rules, where local mutation and explicit returns
+    /// are analyzed as part of the callee's implementation.
+    CallableBody,
+}
+
+/// Recursively checks whether `expr_id` satisfies the requested purity mode
+/// and scope.
+///
+/// `active_callables` tracks the functions currently being analyzed so direct
+/// recursive call graphs do not recurse forever.
+fn expr_has_purity(
+    package: &Package,
+    package_id: PackageId,
+    expr_id: ExprId,
+    mode: PurityMode,
+    scope: PurityScope,
+    active_callables: &mut FxHashSet<LocalItemId>,
+) -> bool {
+    let kind = &package.get_expr(expr_id).kind;
+    if matches!(scope, PurityScope::CallableBody)
+        && let Some(has_purity) =
+            callable_body_expr_has_purity(package, package_id, kind, mode, active_callables)
+    {
+        return has_purity;
+    }
+
+    match kind {
         ExprKind::Lit(_) | ExprKind::Hole | ExprKind::Var(_, _) | ExprKind::Closure(_, _) => true,
         ExprKind::Tuple(items) | ExprKind::Array(items) | ExprKind::ArrayLit(items) => items
             .iter()
-            .all(|&id| expr_is_side_effect_free(package, id)),
+            .all(|&id| expr_has_purity(package, package_id, id, mode, scope, active_callables)),
         ExprKind::ArrayRepeat(value, count) | ExprKind::Index(value, count) => {
-            expr_is_side_effect_free(package, *value) && expr_is_side_effect_free(package, *count)
+            matches!(mode, PurityMode::AllowFallible)
+                && expr_has_purity(package, package_id, *value, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *count, mode, scope, active_callables)
         }
-        ExprKind::Field(record, _) => expr_is_side_effect_free(package, *record),
+        ExprKind::Field(record, _) => {
+            expr_has_purity(package, package_id, *record, mode, scope, active_callables)
+        }
         ExprKind::UpdateField(record, _, value) => {
-            expr_is_side_effect_free(package, *record) && expr_is_side_effect_free(package, *value)
+            expr_has_purity(package, package_id, *record, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *value, mode, scope, active_callables)
         }
         ExprKind::UpdateIndex(arr, idx, value) => {
-            expr_is_side_effect_free(package, *arr)
-                && expr_is_side_effect_free(package, *idx)
-                && expr_is_side_effect_free(package, *value)
+            matches!(mode, PurityMode::AllowFallible)
+                && expr_has_purity(package, package_id, *arr, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *idx, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *value, mode, scope, active_callables)
         }
         ExprKind::Range(start, step, end) => [start, step, end].iter().all(|opt| match opt {
-            Some(id) => expr_is_side_effect_free(package, *id),
+            Some(id) => expr_has_purity(package, package_id, *id, mode, scope, active_callables),
             None => true,
         }),
         ExprKind::String(parts) => parts.iter().all(|p| match p {
             StringComponent::Lit(_) => true,
-            StringComponent::Expr(e) => expr_is_side_effect_free(package, *e),
+            StringComponent::Expr(e) => {
+                expr_has_purity(package, package_id, *e, mode, scope, active_callables)
+            }
         }),
         ExprKind::Struct(_, copy, fields) => {
-            copy.is_none_or(|id| expr_is_side_effect_free(package, id))
-                && fields
-                    .iter()
-                    .all(|f| expr_is_side_effect_free(package, f.value))
+            copy.is_none_or(|id| {
+                expr_has_purity(package, package_id, id, mode, scope, active_callables)
+            }) && fields.iter().all(|f| {
+                expr_has_purity(package, package_id, f.value, mode, scope, active_callables)
+            })
         }
         ExprKind::If(cond, then, Some(else_id)) => {
-            expr_is_side_effect_free(package, *cond)
-                && expr_is_side_effect_free(package, *then)
-                && expr_is_side_effect_free(package, *else_id)
+            expr_has_purity(package, package_id, *cond, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *then, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *else_id, mode, scope, active_callables)
         }
         ExprKind::UnOp(op, operand) => {
             matches!(
                 op,
-                UnOp::Functor(_) | UnOp::NotB | UnOp::NotL | UnOp::Pos | UnOp::Unwrap
-            ) && expr_is_side_effect_free(package, *operand)
+                UnOp::Functor(_) | UnOp::Neg | UnOp::NotB | UnOp::NotL | UnOp::Pos | UnOp::Unwrap
+            ) && expr_has_purity(package, package_id, *operand, mode, scope, active_callables)
         }
         ExprKind::BinOp(op, lhs, rhs) => {
-            matches!(
-                op,
-                BinOp::AndL
-                    | BinOp::OrL
-                    | BinOp::AndB
-                    | BinOp::OrB
-                    | BinOp::XorB
-                    | BinOp::Eq
-                    | BinOp::Neq
-                    | BinOp::Lt
-                    | BinOp::Lte
-                    | BinOp::Gt
-                    | BinOp::Gte
-            ) && expr_is_side_effect_free(package, *lhs)
-                && expr_is_side_effect_free(package, *rhs)
+            binop_has_purity(package, *op, *lhs, mode)
+                && expr_has_purity(package, package_id, *lhs, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *rhs, mode, scope, active_callables)
         }
         ExprKind::Block(bid) => {
-            let blk = package.get_block(*bid);
-            match blk.stmts.as_slice() {
-                [] => true,
-                [only] => match &package.get_stmt(*only).kind {
-                    StmtKind::Expr(tail) => expr_is_side_effect_free(package, *tail),
-                    _ => false,
-                },
-                _ => false,
-            }
+            block_expr_has_purity(package, package_id, *bid, mode, scope, active_callables)
         }
-        // Side-effecting or potentially-trapping variants. `If` without an
+        ExprKind::Call(callee, args) => call_has_purity(
+            package,
+            package_id,
+            *callee,
+            *args,
+            mode,
+            scope,
+            active_callables,
+        ),
+        // Effectful or caller-control-flow-changing variants. `If` without an
         // else arm is included here: it has `Unit` type but its `then` branch
-        // may run for effect. No wildcard arm — a new `ExprKind` variant
-        // breaks the build here so its purity is decided explicitly.
-        ExprKind::Call(_, _)
-        | ExprKind::Assign(_, _)
+        // may run for effect. No wildcard arm — a new `ExprKind` variant breaks
+        // the build here so its purity is decided explicitly.
+        ExprKind::Assign(_, _)
         | ExprKind::AssignOp(_, _, _)
         | ExprKind::AssignField(_, _, _)
         | ExprKind::AssignIndex(_, _, _)
@@ -810,5 +892,223 @@ pub(crate) fn expr_is_side_effect_free(package: &Package, expr_id: ExprId) -> bo
         | ExprKind::Return(_)
         | ExprKind::While(_, _)
         | ExprKind::If(_, _, None) => false,
+    }
+}
+
+/// Checks the block expression rules for the requested scope.
+///
+/// Expression-position blocks are accepted only when they are transparent
+/// value wrappers. Callable-body blocks are checked statement-by-statement so
+/// local mutation and return-like body forms can participate in call purity.
+fn block_expr_has_purity(
+    package: &Package,
+    package_id: PackageId,
+    block_id: BlockId,
+    mode: PurityMode,
+    scope: PurityScope,
+    active_callables: &mut FxHashSet<LocalItemId>,
+) -> bool {
+    if matches!(scope, PurityScope::CallableBody) {
+        return block_has_purity(package, package_id, block_id, mode, scope, active_callables);
+    }
+
+    let blk = package.get_block(block_id);
+    match blk.stmts.as_slice() {
+        [] => true,
+        [only] => match &package.get_stmt(*only).kind {
+            StmtKind::Expr(tail) => {
+                expr_has_purity(package, package_id, *tail, mode, scope, active_callables)
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// Handles expression kinds that are legal only while analyzing a callable
+/// body.
+///
+/// Returns `None` for kinds whose rules are the same in expression and
+/// callable-body scopes, letting the main expression matcher handle them.
+fn callable_body_expr_has_purity(
+    package: &Package,
+    package_id: PackageId,
+    kind: &ExprKind,
+    mode: PurityMode,
+    active_callables: &mut FxHashSet<LocalItemId>,
+) -> Option<bool> {
+    let scope = PurityScope::CallableBody;
+    Some(match kind {
+        ExprKind::Assign(lhs, rhs) => {
+            expr_has_purity(package, package_id, *lhs, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *rhs, mode, scope, active_callables)
+        }
+        ExprKind::AssignOp(op, lhs, rhs) => {
+            binop_has_purity(package, *op, *lhs, mode)
+                && expr_has_purity(package, package_id, *lhs, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *rhs, mode, scope, active_callables)
+        }
+        ExprKind::AssignField(record, _, value) => {
+            expr_has_purity(package, package_id, *record, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *value, mode, scope, active_callables)
+        }
+        ExprKind::AssignIndex(arr, idx, value) => {
+            matches!(mode, PurityMode::AllowFallible)
+                && expr_has_purity(package, package_id, *arr, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *idx, mode, scope, active_callables)
+                && expr_has_purity(package, package_id, *value, mode, scope, active_callables)
+        }
+        ExprKind::Fail(msg) => {
+            matches!(mode, PurityMode::AllowFallible)
+                && expr_has_purity(package, package_id, *msg, mode, scope, active_callables)
+        }
+        ExprKind::Return(value) => {
+            expr_has_purity(package, package_id, *value, mode, scope, active_callables)
+        }
+        _ => return None,
+    })
+}
+
+/// Checks every statement expression in a callable body block against the
+/// requested purity mode.
+fn block_has_purity(
+    package: &Package,
+    package_id: PackageId,
+    block_id: BlockId,
+    mode: PurityMode,
+    scope: PurityScope,
+    active_callables: &mut FxHashSet<LocalItemId>,
+) -> bool {
+    let block = package.get_block(block_id);
+    block
+        .stmts
+        .iter()
+        .all(|&stmt_id| match &package.get_stmt(stmt_id).kind {
+            StmtKind::Expr(expr) | StmtKind::Semi(expr) | StmtKind::Local(_, _, expr) => {
+                expr_has_purity(package, package_id, *expr, mode, scope, active_callables)
+            }
+            StmtKind::Item(_) => true,
+        })
+}
+
+/// Checks whether a call expression is pure under the requested mode.
+///
+/// The callee and argument expressions must first satisfy the same purity mode.
+/// Then the callee must resolve to a same-package function body that can be
+/// analyzed, or to a same-package UDT constructor.
+fn call_has_purity(
+    package: &Package,
+    package_id: PackageId,
+    callee: ExprId,
+    args: ExprId,
+    mode: PurityMode,
+    scope: PurityScope,
+    active_callables: &mut FxHashSet<LocalItemId>,
+) -> bool {
+    if !expr_has_purity(package, package_id, callee, mode, scope, active_callables)
+        || !expr_has_purity(package, package_id, args, mode, scope, active_callables)
+    {
+        return false;
+    }
+
+    match &package.get_expr(callee).kind {
+        ExprKind::Var(Res::Item(item_id), _) if item_id.package == package_id => {
+            match package.get_global(item_id.item) {
+                Some(Global::Callable(decl)) => callable_has_purity(
+                    package,
+                    package_id,
+                    item_id.item,
+                    decl,
+                    mode,
+                    active_callables,
+                ),
+                Some(Global::Udt) => true,
+                None => false,
+            }
+        }
+        ExprKind::Closure(_, item_id) => match package.get_global(*item_id) {
+            Some(Global::Callable(decl)) => {
+                callable_has_purity(package, package_id, *item_id, decl, mode, active_callables)
+            }
+            Some(Global::Udt) | None => false,
+        },
+        _ => false,
+    }
+}
+
+/// Checks whether a callable declaration can be treated as pure under the
+/// requested mode.
+///
+/// Only functions with explicit bodies are analyzed. Intrinsics, operations,
+/// and opaque implementations are rejected. Recursive functions are accepted
+/// only for side-effect freedom, not for discard safety.
+fn callable_has_purity(
+    package: &Package,
+    package_id: PackageId,
+    item_id: LocalItemId,
+    decl: &CallableDecl,
+    mode: PurityMode,
+    active_callables: &mut FxHashSet<LocalItemId>,
+) -> bool {
+    if decl.kind != CallableKind::Function {
+        return false;
+    }
+
+    let CallableImpl::Spec(spec_impl) = &decl.implementation else {
+        return false;
+    };
+
+    if !active_callables.insert(item_id) {
+        return matches!(mode, PurityMode::AllowFallible);
+    }
+
+    let is_pure = block_has_purity(
+        package,
+        package_id,
+        spec_impl.body.block,
+        mode,
+        PurityScope::CallableBody,
+        active_callables,
+    );
+    active_callables.remove(&item_id);
+    is_pure
+}
+
+/// Checks the operator-level portion of binary-expression purity.
+///
+/// Operand purity is checked by the caller. This helper decides only whether
+/// the operator itself can be considered total in `RequireTotal` mode.
+fn binop_has_purity(package: &Package, op: BinOp, lhs: ExprId, mode: PurityMode) -> bool {
+    match mode {
+        PurityMode::AllowFallible => true,
+        PurityMode::RequireTotal => match op {
+            BinOp::Add
+            | BinOp::AndB
+            | BinOp::AndL
+            | BinOp::Gt
+            | BinOp::Gte
+            | BinOp::Lt
+            | BinOp::Lte
+            | BinOp::Mul
+            | BinOp::OrB
+            | BinOp::OrL
+            | BinOp::Sub
+            | BinOp::XorB => true,
+            BinOp::Eq | BinOp::Neq => !ty_may_contain_runtime_result(&package.get_expr(lhs).ty),
+            BinOp::Div | BinOp::Exp | BinOp::Mod | BinOp::Shl | BinOp::Shr => false,
+        },
+    }
+}
+
+/// Returns whether `ty` may contain a runtime `Result` value.
+///
+/// Result equality can fail at runtime, so equality over any type that may
+/// contain results is not safe to discard without a more precise proof.
+fn ty_may_contain_runtime_result(ty: &Ty) -> bool {
+    match ty {
+        Ty::Prim(Prim::Result) | Ty::Param(_) | Ty::Infer(_) | Ty::Udt(_) | Ty::Err => true,
+        Ty::Array(item) => ty_may_contain_runtime_result(item),
+        Ty::Tuple(items) => items.iter().any(ty_may_contain_runtime_result),
+        Ty::Arrow(_) | Ty::Prim(_) => false,
     }
 }

--- a/source/compiler/qsc_fir_transforms/src/walk_utils/tests.rs
+++ b/source/compiler/qsc_fir_transforms/src/walk_utils/tests.rs
@@ -556,10 +556,11 @@ fn classify_local_used_only_in_struct_field_is_recorded() {
 }
 
 // ---------------------------------------------------------------------------
-// Direct unit tests for `expr_is_side_effect_free`.
+// Direct unit tests for `expr_is_side_effect_free` and
+// `expr_is_safe_to_discard`.
 //
-// At least five positive and five negative shapes are covered to pin
-// the conservative purity contract.
+// At least five positive and five negative shapes are covered to pin both
+// the duplicate-safe and discard-safe purity contracts.
 // ---------------------------------------------------------------------------
 
 /// Allocate an `Int` literal `ExprId`.
@@ -578,7 +579,8 @@ fn given_lit_is_side_effect_free() {
     let mut package = Package::default();
     let mut assigner = Assigner::default();
     let e = int_lit(&mut package, &mut assigner, 1);
-    assert!(expr_is_side_effect_free(&package, e));
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -593,7 +595,8 @@ fn given_var_is_side_effect_free() {
         Ty::Prim(Prim::Int),
         Span::default(),
     );
-    assert!(expr_is_side_effect_free(&package, e));
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -609,7 +612,8 @@ fn given_tuple_of_lits_is_side_effect_free() {
         ExprKind::Tuple(vec![a, b]),
         Span::default(),
     );
-    assert!(expr_is_side_effect_free(&package, e));
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -625,7 +629,8 @@ fn given_array_of_lits_is_side_effect_free() {
         ExprKind::Array(vec![a, b]),
         Span::default(),
     );
-    assert!(expr_is_side_effect_free(&package, e));
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -648,7 +653,8 @@ fn given_block_with_single_lit_is_side_effect_free() {
         ExprKind::Block(bid),
         Span::default(),
     );
-    assert!(expr_is_side_effect_free(&package, e));
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -671,7 +677,8 @@ fn given_closure_is_side_effect_free() {
         ExprKind::Closure(vec![some_local], LocalItemId::from(0)),
         Span::default(),
     );
-    assert!(expr_is_side_effect_free(&package, e));
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -699,7 +706,106 @@ fn given_call_is_not_side_effect_free() {
         ExprKind::Call(callee, arg),
         Span::default(),
     );
-    assert!(!expr_is_side_effect_free(&package, e));
+    assert!(!expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
+}
+
+/// Finds the first call expression whose direct callee resolves to the named
+/// callable in the same package.
+fn find_call_to_callable(package: &Package, pkg_id: PackageId, name: &str) -> ExprId {
+    package
+        .exprs
+        .iter()
+        .find_map(|(expr_id, expr)| {
+            let ExprKind::Call(callee_id, _) = expr.kind else {
+                return None;
+            };
+            let ExprKind::Var(Res::Item(item_id), _) = &package.get_expr(callee_id).kind else {
+                return None;
+            };
+            if item_id.package != pkg_id {
+                return None;
+            }
+            let ItemKind::Callable(decl) = &package.get_item(item_id.item).kind else {
+                return None;
+            };
+            (decl.name.name.as_ref() == name).then_some(expr_id)
+        })
+        .unwrap_or_else(|| panic!("call to callable '{name}' not found"))
+}
+
+#[test]
+fn given_known_pure_function_call_is_side_effect_free_and_safe_to_discard() {
+    let (store, pkg_id) = compile_to_fir(
+        "function Pure(x : Int) : Int { x + 1 }
+         function Main() : Int { Pure(41) }",
+    );
+    let package = store.get(pkg_id);
+    let call = find_call_to_callable(package, pkg_id, "Pure");
+
+    assert!(expr_is_side_effect_free(package, pkg_id, call));
+    assert!(expr_is_safe_to_discard(package, pkg_id, call));
+}
+
+#[test]
+fn given_function_call_with_local_mutation_is_side_effect_free() {
+    let (store, pkg_id) = compile_to_fir(
+        "function PureWithLocalMutation(x : Int) : Int {
+             mutable y = x;
+             set y += 1;
+             y
+         }
+         function Main() : Int { PureWithLocalMutation(41) }",
+    );
+    let package = store.get(pkg_id);
+    let call = find_call_to_callable(package, pkg_id, "PureWithLocalMutation");
+
+    assert!(expr_is_side_effect_free(package, pkg_id, call));
+    assert!(expr_is_safe_to_discard(package, pkg_id, call));
+}
+
+#[test]
+fn given_fallible_pure_function_call_is_side_effect_free_but_not_safe_to_discard() {
+    let (store, pkg_id) = compile_to_fir(
+        "function DivideBy(x : Int) : Int { 1 / x }
+         function Main() : Int { DivideBy(0) }",
+    );
+    let package = store.get(pkg_id);
+    let call = find_call_to_callable(package, pkg_id, "DivideBy");
+
+    assert!(expr_is_side_effect_free(package, pkg_id, call));
+    assert!(!expr_is_safe_to_discard(package, pkg_id, call));
+}
+
+#[test]
+fn given_function_call_that_can_fail_is_side_effect_free_but_not_safe_to_discard() {
+    let (store, pkg_id) = compile_to_fir(
+        "function FailOnZero(x : Int) : Int {
+             if x == 0 { fail \"zero\" } else { x }
+         }
+         function Main() : Int { FailOnZero(0) }",
+    );
+    let package = store.get(pkg_id);
+    let call = find_call_to_callable(package, pkg_id, "FailOnZero");
+
+    assert!(expr_is_side_effect_free(package, pkg_id, call));
+    assert!(!expr_is_safe_to_discard(package, pkg_id, call));
+}
+
+#[test]
+fn given_function_call_that_calls_message_is_not_side_effect_free() {
+    let (store, pkg_id) = compile_to_fir(
+        "function Noisy(x : Int) : Int {
+             Message(\"x\");
+             x
+         }
+         function Main() : Int { Noisy(41) }",
+    );
+    let package = store.get(pkg_id);
+    let call = find_call_to_callable(package, pkg_id, "Noisy");
+
+    assert!(!expr_is_side_effect_free(package, pkg_id, call));
+    assert!(!expr_is_safe_to_discard(package, pkg_id, call));
 }
 
 #[test]
@@ -716,7 +822,8 @@ fn given_assign_is_not_side_effect_free() {
     );
     let rhs = alloc_bool_lit(&mut package, &mut assigner, true, Span::default());
     let e = alloc_assign_expr(&mut package, &mut assigner, lhs, rhs, Span::default());
-    assert!(!expr_is_side_effect_free(&package, e));
+    assert!(!expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -731,7 +838,8 @@ fn given_return_is_not_side_effect_free() {
         ExprKind::Return(inner),
         Span::default(),
     );
-    assert!(!expr_is_side_effect_free(&package, e));
+    assert!(!expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -753,7 +861,8 @@ fn given_fail_is_not_side_effect_free() {
         ExprKind::Fail(msg),
         Span::default(),
     );
-    assert!(!expr_is_side_effect_free(&package, e));
+    assert!(!expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
@@ -775,14 +884,12 @@ fn given_while_is_not_side_effect_free() {
         ExprKind::While(cond, body),
         Span::default(),
     );
-    assert!(!expr_is_side_effect_free(&package, e));
+    assert!(!expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
-fn given_binop_is_not_side_effect_free() {
-    // BinOp::Add is rejected by the conservative default — the trapping
-    // arithmetic operators could have observable behavior, so classifying
-    // them as pure would risk silently dropping a binding.
+fn given_total_binop_is_side_effect_free_and_safe_to_discard() {
     let mut package = Package::default();
     let mut assigner = Assigner::default();
     let a = int_lit(&mut package, &mut assigner, 1);
@@ -794,13 +901,118 @@ fn given_binop_is_not_side_effect_free() {
         ExprKind::BinOp(BinOp::Add, a, b),
         Span::default(),
     );
-    assert!(!expr_is_side_effect_free(&package, e));
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
+}
+
+#[test]
+fn given_fallible_binop_is_side_effect_free_but_not_safe_to_discard() {
+    let mut package = Package::default();
+    let mut assigner = Assigner::default();
+    let a = int_lit(&mut package, &mut assigner, 1);
+    let b = int_lit(&mut package, &mut assigner, 0);
+    let e = alloc_expr(
+        &mut package,
+        &mut assigner,
+        Ty::Prim(Prim::Int),
+        ExprKind::BinOp(BinOp::Div, a, b),
+        Span::default(),
+    );
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
+}
+
+#[test]
+fn given_array_index_is_side_effect_free_but_not_safe_to_discard() {
+    let mut package = Package::default();
+    let mut assigner = Assigner::default();
+    let value = int_lit(&mut package, &mut assigner, 1);
+    let array = alloc_expr(
+        &mut package,
+        &mut assigner,
+        Ty::Array(Box::new(Ty::Prim(Prim::Int))),
+        ExprKind::Array(vec![value]),
+        Span::default(),
+    );
+    let index = int_lit(&mut package, &mut assigner, 2);
+    let e = alloc_expr(
+        &mut package,
+        &mut assigner,
+        Ty::Prim(Prim::Int),
+        ExprKind::Index(array, index),
+        Span::default(),
+    );
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
+}
+
+#[test]
+fn given_array_repeat_is_side_effect_free_but_not_safe_to_discard() {
+    let mut package = Package::default();
+    let mut assigner = Assigner::default();
+    let value = int_lit(&mut package, &mut assigner, 1);
+    let count = int_lit(&mut package, &mut assigner, -1);
+    let e = alloc_expr(
+        &mut package,
+        &mut assigner,
+        Ty::Array(Box::new(Ty::Prim(Prim::Int))),
+        ExprKind::ArrayRepeat(value, count),
+        Span::default(),
+    );
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
+}
+
+#[test]
+fn given_result_equality_is_side_effect_free_but_not_safe_to_discard() {
+    let mut package = Package::default();
+    let mut assigner = Assigner::default();
+    let some_local = assigner.next_local();
+    let lhs = alloc_local_var_expr(
+        &mut package,
+        &mut assigner,
+        some_local,
+        Ty::Prim(Prim::Result),
+        Span::default(),
+    );
+    let rhs = alloc_expr(
+        &mut package,
+        &mut assigner,
+        Ty::Prim(Prim::Result),
+        ExprKind::Lit(Lit::Result(qsc_fir::fir::Result::Zero)),
+        Span::default(),
+    );
+    let e = alloc_expr(
+        &mut package,
+        &mut assigner,
+        Ty::Prim(Prim::Bool),
+        ExprKind::BinOp(BinOp::Eq, lhs, rhs),
+        Span::default(),
+    );
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
+}
+
+#[test]
+fn given_negation_is_side_effect_free_and_safe_to_discard() {
+    let mut package = Package::default();
+    let mut assigner = Assigner::default();
+    let operand = int_lit(&mut package, &mut assigner, 1);
+    let e = alloc_expr(
+        &mut package,
+        &mut assigner,
+        Ty::Prim(Prim::Int),
+        ExprKind::UnOp(UnOp::Neg, operand),
+        Span::default(),
+    );
+    assert!(expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]
 fn given_if_then_only_is_not_side_effect_free() {
     // The predicate only accepts `If` with both arms present; the absent-else
-    // case is rejected by the conservative default.
+    // case can run its `then` branch for effect.
     let mut package = Package::default();
     let mut assigner = Assigner::default();
     let cond = alloc_bool_lit(&mut package, &mut assigner, true, Span::default());
@@ -814,7 +1026,8 @@ fn given_if_then_only_is_not_side_effect_free() {
         Ty::UNIT,
         Span::default(),
     );
-    assert!(!expr_is_side_effect_free(&package, e));
+    assert!(!expr_is_side_effect_free(&package, PackageId::CORE, e));
+    assert!(!expr_is_safe_to_discard(&package, PackageId::CORE, e));
 }
 
 #[test]

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -10,8 +10,8 @@ pub const BERNSTEINVAZIRANI_EXPECT: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 29822"];
 pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE_RIF: Expect =
-    expect!["generated QIR of length 20291"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 20218"];
+    expect!["generated QIR of length 20287"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 20214"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =
@@ -43,7 +43,7 @@ pub const DEUTSCHJOZSA_EXPECT: Expect = expect!["[true, false, true, false]"];
 pub const DEUTSCHJOZSA_EXPECT_DEBUG: Expect = expect!["[true, false, true, false]"];
 pub const DEUTSCHJOZSA_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 197703"];
 pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 82661"];
-pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 26273"];
+pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 25783"];
 pub const DEUTSCHJOZSANISQ_EXPECT: Expect =
     expect!["([One, Zero, Zero, Zero, Zero], [Zero, Zero, Zero, Zero, Zero])"];
 pub const DEUTSCHJOZSANISQ_EXPECT_DEBUG: Expect =
@@ -69,7 +69,7 @@ pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_CIRCUIT: Expect =
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 139362"];
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 22811"];
+    expect!["generated QIR of length 21726"];
 pub const GROVER_EXPECT: Expect = expect![[r#"
     Number of iterations: 4
     Reflecting about marked state...


### PR DESCRIPTION
This branch refines how the Q# compiler cleans up code during its internal optimization passes, so the programs it generates are leaner without changing what they do.

Two related improvements:

1. Stop unnecessarily pulling conditions out of if-style checks. Previously, when the compiler processed a branch, it would always move the condition (the true/false test) into its own temporary step before deciding which way to go. That's only necessary when evaluating the condition could cause something to happen. This change teaches the compiler to recognize when a condition is harmless to leave in place, so it no longer creates pointless temporary steps for those cases. The result is simpler, cleaner intermediate code.
2. Smarter removal of unused local variables. The compiler drops local variables that are never read. Deciding whether that's safe used to rely on a check called "is this expression free of side effects." This branch replaces that with a more precise check "is this expression safe to throw away", which correctly handles more situations, such as array-index lookups and calls to functions that are known to be pure. So the compiler can now safely remove more genuinely-unused code that it previously kept around out of caution, while still never removing anything that matters.

The rest of the changes are updates to the compiler's test snapshots that reflect this new, tidier output.