### PR TITLE
Fix benzene notebook

### DIFF
--- a/samples/notebooks/benzene_molecule/benzene.ipynb
+++ b/samples/notebooks/benzene_molecule/benzene.ipynb
@@ -27,7 +27,7 @@
     "src = Path(\"benzene_diradical_injected_rotation_measurement_circuit_0.qasm\").read_text(encoding=\"utf-8\")\n",
     "\n",
     "init(target_profile=TargetProfile.Base)\n",
-    "qir = compile(src)"
+    "qir = compile(src, target_profile=TargetProfile.Base)\n"
    ]
   },
   {

--- a/samples/notebooks/benzene_molecule/benzene.ipynb
+++ b/samples/notebooks/benzene_molecule/benzene.ipynb
@@ -19,14 +19,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qdk import init, TargetProfile\n",
+    "from qdk import TargetProfile\n",
     "from qdk.openqasm import circuit, compile, run\n",
     "from qdk.widgets import Circuit, Histogram\n",
     "\n",
     "from pathlib import Path\n",
     "src = Path(\"benzene_diradical_injected_rotation_measurement_circuit_0.qasm\").read_text(encoding=\"utf-8\")\n",
     "\n",
-    "init(target_profile=TargetProfile.Base)\n",
     "qir = compile(src, target_profile=TargetProfile.Base)\n"
    ]
   },

--- a/source/qdk_package/qdk/_device/_atom/__init__.py
+++ b/source/qdk_package/qdk/_device/_atom/__init__.py
@@ -227,23 +227,32 @@ class NeutralAtomDevice(Device):
         start_time = time.monotonic()
         telemetry_events.on_neutral_atom_trace()
 
-        # `show_trace` statically analyzes the program to lay it out and schedule
-        # it, which requires fully inlined, Base-profile QIR with constant gate
-        # parameters. Adaptive-profile QIR (dynamic rotation angles, branching,
-        # and non-inlined gate definitions) cannot be traced this way.
-        profile = _get_qir_profile(qir)
-        if profile is not None and profile != "base_profile":
-            raise ValueError(
-                "`show_trace` only supports Base-profile QIR, but the provided "
-                "program is compiled to the Adaptive profile."
-            )
+        # Compile, schedule, and trace the program. Tracing statically analyzes
+        # the program, so it only supports constant gate parameters and a single
+        # straight-line execution path. Most programs trace fine -- including many
+        # Adaptive-profile ones -- but those with values known only
+        # at run time (e.g. rotation angles computed from measurement results) or
+        # non-inlined gate definitions cannot be traced. In that case, surface a
+        # clear, actionable error instead of a low-level failure.
+        try:
+            compiled = self.compile(qir)
+            module = Module.from_ir(Context(), str(compiled))
+            Schedule(self).run(module)
+            tracer = Trace(self)
+            tracer.run(module)
+        except (AttributeError, IndexError) as e:
+            profile = _get_qir_profile(qir)
+            if profile is not None and profile != "base_profile":
+                raise ValueError(
+                    "`show_trace` could not trace this program. This "
+                    "Adaptive-profile program contains values known only at run "
+                    "time (for example, rotation angles computed from measurement "
+                    "results) or gate definitions that are not inlined."
+                ) from e
+            # If the program is Base profile this is a bug.
+            # Re-raise the original exception.
+            raise
 
-        # Compile and visualize the trace in one step.
-        compiled = self.compile(qir)
-        module = Module.from_ir(Context(), str(compiled))
-        Schedule(self).run(module)
-        tracer = Trace(self)
-        tracer.run(module)
         display(Atoms(machine_layout=self.get_layout(), trace_data=tracer.trace))
 
         end_time = time.monotonic()

--- a/source/qdk_package/qdk/_device/_atom/__init__.py
+++ b/source/qdk_package/qdk/_device/_atom/__init__.py
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
     from ...simulation._simulation import NoiseConfig
 
 
+def _get_qir_profile(qir: "str | QirInputData") -> Optional[str]:
+    """Return the value of the entry point's `qir_profiles` attribute
+    (e.g. `"base_profile"` or `"adaptive_profile"`), or `None` if the
+    program does not declare a profile."""
+    from pyqir import Module, Context, is_entry_point
+
+    module = Module.from_ir(Context(), str(qir))
+    for function in module.functions:
+        if is_entry_point(function):
+            attributes = function.attributes.func
+            if "qir_profiles" in attributes:
+                return attributes["qir_profiles"].string_value
+    return None
+
+
 class NeutralAtomDevice(Device):
     """
     Representation of a neutral atom device quantum computer.
@@ -211,6 +226,17 @@ class NeutralAtomDevice(Device):
 
         start_time = time.monotonic()
         telemetry_events.on_neutral_atom_trace()
+
+        # `show_trace` statically analyzes the program to lay it out and schedule
+        # it, which requires fully inlined, Base-profile QIR with constant gate
+        # parameters. Adaptive-profile QIR (dynamic rotation angles, branching,
+        # and non-inlined gate definitions) cannot be traced this way.
+        profile = _get_qir_profile(qir)
+        if profile is not None and profile != "base_profile":
+            raise ValueError(
+                "`show_trace` only supports Base-profile QIR, but the provided "
+                "program is compiled to the Adaptive profile."
+            )
 
         # Compile and visualize the trace in one step.
         compiled = self.compile(qir)

--- a/source/qdk_package/qdk/_device/_atom/__init__.py
+++ b/source/qdk_package/qdk/_device/_atom/__init__.py
@@ -220,7 +220,10 @@ class NeutralAtomDevice(Device):
                 "Please install it via 'pip install \"qdk[jupyter]\"' or 'pip install qsharp-widgets'."
             )
         from ._trace import Trace
-        from ._validate import ValidateNoConditionalBranches
+        from ._validate import (
+            ValidateNoConditionalBranches,
+            ValidateNoFunctionCalls,
+        )
         from ._scheduler import Schedule
         from pyqir import Module, Context
         from IPython.display import display
@@ -232,6 +235,7 @@ class NeutralAtomDevice(Device):
         compiled = self.compile(qir)
         module = Module.from_ir(Context(), str(compiled))
         ValidateNoConditionalBranches().run(module)
+        ValidateNoFunctionCalls().run(module)
         Schedule(self).run(module)
         tracer = Trace(self)
         tracer.run(module)

--- a/source/qdk_package/qdk/_device/_atom/__init__.py
+++ b/source/qdk_package/qdk/_device/_atom/__init__.py
@@ -15,21 +15,6 @@ if TYPE_CHECKING:
     from ...simulation._simulation import NoiseConfig
 
 
-def _get_qir_profile(qir: "str | QirInputData") -> Optional[str]:
-    """Return the value of the entry point's `qir_profiles` attribute
-    (e.g. `"base_profile"` or `"adaptive_profile"`), or `None` if the
-    program does not declare a profile."""
-    from pyqir import Module, Context, is_entry_point
-
-    module = Module.from_ir(Context(), str(qir))
-    for function in module.functions:
-        if is_entry_point(function):
-            attributes = function.attributes.func
-            if "qir_profiles" in attributes:
-                return attributes["qir_profiles"].string_value
-    return None
-
-
 class NeutralAtomDevice(Device):
     """
     Representation of a neutral atom device quantum computer.

--- a/source/qdk_package/qdk/_device/_atom/__init__.py
+++ b/source/qdk_package/qdk/_device/_atom/__init__.py
@@ -220,6 +220,7 @@ class NeutralAtomDevice(Device):
                 "Please install it via 'pip install \"qdk[jupyter]\"' or 'pip install qsharp-widgets'."
             )
         from ._trace import Trace
+        from ._validate import ValidateNoConditionalBranches
         from ._scheduler import Schedule
         from pyqir import Module, Context
         from IPython.display import display
@@ -227,32 +228,13 @@ class NeutralAtomDevice(Device):
         start_time = time.monotonic()
         telemetry_events.on_neutral_atom_trace()
 
-        # Compile, schedule, and trace the program. Tracing statically analyzes
-        # the program, so it only supports constant gate parameters and a single
-        # straight-line execution path. Most programs trace fine -- including many
-        # Adaptive-profile ones -- but those with values known only
-        # at run time (e.g. rotation angles computed from measurement results) or
-        # non-inlined gate definitions cannot be traced. In that case, surface a
-        # clear, actionable error instead of a low-level failure.
-        try:
-            compiled = self.compile(qir)
-            module = Module.from_ir(Context(), str(compiled))
-            Schedule(self).run(module)
-            tracer = Trace(self)
-            tracer.run(module)
-        except (AttributeError, IndexError) as e:
-            profile = _get_qir_profile(qir)
-            if profile is not None and profile != "base_profile":
-                raise ValueError(
-                    "`show_trace` could not trace this program. This "
-                    "Adaptive-profile program contains values known only at run "
-                    "time (for example, rotation angles computed from measurement "
-                    "results) or gate definitions that are not inlined."
-                ) from e
-            # If the program is Base profile this is a bug.
-            # Re-raise the original exception.
-            raise
-
+        # Compile and visualize the trace in one step.
+        compiled = self.compile(qir)
+        module = Module.from_ir(Context(), str(compiled))
+        ValidateNoConditionalBranches().run(module)
+        Schedule(self).run(module)
+        tracer = Trace(self)
+        tracer.run(module)
         display(Atoms(machine_layout=self.get_layout(), trace_data=tracer.trace))
 
         end_time = time.monotonic()

--- a/source/qdk_package/qdk/_device/_atom/_reorder.py
+++ b/source/qdk_package/qdk/_device/_atom/_reorder.py
@@ -35,7 +35,7 @@ class Reorder(QirModuleVisitor):
 
     def instr_key(self, instr: Instruction):
         gate = as_qis_gate(instr)
-        if gate != {}:
+        if gate != {} and gate["qubit_args"]:
             qubits = sorted(map(self.device.get_ordering, gate["qubit_args"]))
             return qubits[0]
         return 0
@@ -70,7 +70,7 @@ class Reorder(QirModuleVisitor):
                 # depends on. We want to insert the current instruction on the earliest possible
                 # step without violating dependencies.
                 last_dependent_step_idx = len(steps) - 1
-                (used_values, used_results) = get_used_values(instr)
+                used_values, used_results = get_used_values(instr)
                 while last_dependent_step_idx >= 0:
                     if uses_any_value(
                         used_values, values_used_in_step[last_dependent_step_idx]

--- a/source/qdk_package/qdk/_device/_atom/_validate.py
+++ b/source/qdk_package/qdk/_device/_atom/_validate.py
@@ -43,3 +43,18 @@ class ValidateNoConditionalBranches(QirModuleVisitor):
         ):
             raise ValueError("programs with branching control flow are not supported")
         super()._on_block(block)
+
+
+class ValidateNoFunctionCalls(QirModuleVisitor):
+    """
+    Ensure the program does not call non-inlined functions (such as gate
+    definitions emitted as separate functions). Tracing renders the program as a
+    single, straight-line schedule and cannot follow a call into another function
+    body, so the operations defined there would be dropped and mis-visualized. A
+    non-entry function with a body is such a definition (declarations of the
+    supported intrinsics have no body).
+    """
+
+    def _on_function(self, function):
+        if not is_entry_point(function) and len(function.basic_blocks) > 0:
+            raise ValueError("programs with function calls are not supported")

--- a/source/qdk_package/qdk/_device/_atom/_validate.py
+++ b/source/qdk_package/qdk/_device/_atom/_validate.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from pyqir import QirModuleVisitor, is_entry_point
+from pyqir import QirModuleVisitor, is_entry_point, Opcode
 
 
 class ValidateAllowedIntrinsics(QirModuleVisitor):
@@ -28,3 +28,18 @@ class ValidateAllowedIntrinsics(QirModuleVisitor):
             ]
         ):
             raise ValueError(f"{name} is not a supported intrinsic")
+
+
+class ValidateNoConditionalBranches(QirModuleVisitor):
+    """
+    Ensure that the function(s) only use unconditional branches.
+    """
+
+    def _on_block(self, block):
+        if (
+            block.terminator
+            and block.terminator.opcode == Opcode.BR
+            and len(block.terminator.operands) > 1
+        ):
+            raise ValueError("programs with branching control flow are not supported")
+        super()._on_block(block)

--- a/source/qdk_package/tests-integration/devices/test_atom_e2e.py
+++ b/source/qdk_package/tests-integration/devices/test_atom_e2e.py
@@ -17,20 +17,27 @@ except ImportError:
 
 SKIP_REASON = "PyQIR is not available"
 
+try:
+    import qsharp_widgets  # noqa: F401
+
+    QSHARP_WIDGETS_AVAILABLE = True
+except ImportError:
+    QSHARP_WIDGETS_AVAILABLE = False
+
+WIDGETS_SKIP_REASON = "qsharp-widgets is not available"
+
 
 @pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
 def test_device_compile() -> None:
     qsharp.init(target_profile=qsharp.TargetProfile.Base)
-    qir = qsharp.compile(
-        """
+    qir = qsharp.compile("""
         {
             use qs = Qubit[2];
             H(qs[0]);
             CNOT(qs[0], qs[1]);
             MResetEachZ(qs)
         }
-        """
-    )
+        """)
 
     device = NeutralAtomDevice()
     compiled = device.compile(qir)
@@ -91,16 +98,14 @@ attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_pr
 @pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
 def test_device_simulate_with_cpu() -> None:
     qsharp.init(target_profile=qsharp.TargetProfile.Base)
-    qir = qsharp.compile(
-        """
+    qir = qsharp.compile("""
         {
             use qs = Qubit[2];
             H(qs[0]);
             CNOT(qs[0], qs[1]);
             MResetEachZ(qs)
         }
-        """
-    )
+        """)
 
     device = NeutralAtomDevice()
     compiled = device.compile(qir)
@@ -114,16 +119,14 @@ def test_device_simulate_with_cpu() -> None:
 @pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
 def test_device_simlate_with_clifford() -> None:
     qsharp.init(target_profile=qsharp.TargetProfile.Base)
-    qir = qsharp.compile(
-        """
+    qir = qsharp.compile("""
         {
             use qs = Qubit[2];
             H(qs[0]);
             CNOT(qs[0], qs[1]);
             MResetEachZ(qs)
         }
-        """
-    )
+        """)
 
     device = NeutralAtomDevice()
     compiled = device.compile(qir)
@@ -137,16 +140,14 @@ def test_device_simlate_with_clifford() -> None:
 @pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
 def test_device_simulate_with_loss() -> None:
     qsharp.init(target_profile=qsharp.TargetProfile.Base)
-    qir = qsharp.compile(
-        """
+    qir = qsharp.compile("""
         {
             use qs = Qubit[2];
             H(qs[0]);
             CNOT(qs[0], qs[1]);
             MResetEachZ(qs)
         }
-        """
-    )
+        """)
 
     device = NeutralAtomDevice()
     noise = NoiseConfig()
@@ -191,3 +192,25 @@ def test_s_adj_noise_inherits_from_rz():
     device = NeutralAtomDevice()
     output = device.simulate(ir, 1, noise)
     assert output == [qsharp.Result.One]
+
+
+@pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
+@pytest.mark.skipif(not QSHARP_WIDGETS_AVAILABLE, reason=WIDGETS_SKIP_REASON)
+def test_show_trace_rejects_adaptive_profile() -> None:
+    # `show_trace` statically analyzes the program to lay it out and schedule it,
+    # which only works for Base-profile QIR. Adaptive-profile QIR must be
+    # rejected up front with a clear, actionable error rather than failing deep
+    # inside the trace pass.
+    qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
+    qir = qsharp.compile("""
+        {
+            use qs = Qubit[2];
+            H(qs[0]);
+            CNOT(qs[0], qs[1]);
+            MResetEachZ(qs)
+        }
+        """)
+
+    device = NeutralAtomDevice()
+    with pytest.raises(ValueError, match="only supports Base-profile QIR"):
+        device.show_trace(qir)

--- a/source/qdk_package/tests-integration/devices/test_atom_e2e.py
+++ b/source/qdk_package/tests-integration/devices/test_atom_e2e.py
@@ -196,11 +196,34 @@ def test_s_adj_noise_inherits_from_rz():
 
 @pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
 @pytest.mark.skipif(not QSHARP_WIDGETS_AVAILABLE, reason=WIDGETS_SKIP_REASON)
-def test_show_trace_rejects_adaptive_profile() -> None:
-    # `show_trace` statically analyzes the program to lay it out and schedule it,
-    # which only works for Base-profile QIR. Adaptive-profile QIR must be
-    # rejected up front with a clear, actionable error rather than failing deep
-    # inside the trace pass.
+def test_show_trace_rejects_untraceable_adaptive_program() -> None:
+    # An Adaptive-profile program with a runtime-computed rotation angle (here
+    # derived from a measurement result) cannot be traced, since tracing
+    # statically analyzes the program. It must surface a clear, actionable error
+    # rather than a low-level failure deep inside the trace pass.
+    qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
+    qir = qsharp.compile("""
+        {
+            use q = Qubit();
+            H(q);
+            let r = MResetZ(q);
+            let angle = if r == One { 1.0 } else { 2.0 };
+            Rz(angle, q);
+            MResetZ(q)
+        }
+        """)
+
+    device = NeutralAtomDevice()
+    with pytest.raises(ValueError, match="could not trace this program"):
+        device.show_trace(qir)
+
+
+@pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
+@pytest.mark.skipif(not QSHARP_WIDGETS_AVAILABLE, reason=WIDGETS_SKIP_REASON)
+def test_show_trace_allows_traceable_adaptive_program() -> None:
+    # An Adaptive-profile program with only constant gate parameters and a
+    # single execution path can still be traced; `show_trace` must not reject it
+    # just because it is compiled to the Adaptive profile.
     qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
     qir = qsharp.compile("""
         {
@@ -212,5 +235,5 @@ def test_show_trace_rejects_adaptive_profile() -> None:
         """)
 
     device = NeutralAtomDevice()
-    with pytest.raises(ValueError, match="only supports Base-profile QIR"):
-        device.show_trace(qir)
+    # Must not raise: this Adaptive-profile program is fully traceable.
+    device.show_trace(qir)

--- a/source/qdk_package/tests-integration/devices/test_atom_e2e.py
+++ b/source/qdk_package/tests-integration/devices/test_atom_e2e.py
@@ -196,11 +196,35 @@ def test_s_adj_noise_inherits_from_rz():
 
 @pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
 @pytest.mark.skipif(not QSHARP_WIDGETS_AVAILABLE, reason=WIDGETS_SKIP_REASON)
-def test_show_trace_rejects_untraceable_adaptive_program() -> None:
-    # An Adaptive-profile program with a runtime-computed rotation angle (here
-    # derived from a measurement result) cannot be traced, since tracing
-    # statically analyzes the program. It must surface a clear, actionable error
-    # rather than a low-level failure deep inside the trace pass.
+def test_show_trace_rejects_branching_control_flow() -> None:
+    # Tracing renders the program as a single, straight-line schedule, so it
+    # cannot represent control flow. A program that branches on a measurement
+    # result must be rejected rather than silently mis-visualized -- even when
+    # every gate has constant parameters.
+    qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
+    qir = qsharp.compile("""
+        {
+            use q = Qubit();
+            H(q);
+            let r = MResetZ(q);
+            if r == One {
+                X(q);
+            }
+            MResetZ(q)
+        }
+        """)
+
+    device = NeutralAtomDevice()
+    with pytest.raises(ValueError, match="programs with branching control flow"):
+        device.show_trace(qir)
+
+
+@pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
+@pytest.mark.skipif(not QSHARP_WIDGETS_AVAILABLE, reason=WIDGETS_SKIP_REASON)
+def test_show_trace_rejects_runtime_computed_values() -> None:
+    # A program whose behavior depends on runtime-computed values (here a
+    # rotation angle derived from a measurement result) cannot be traced and
+    # must surface a clear, actionable error rather than a low-level failure.
     qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
     qir = qsharp.compile("""
         {
@@ -214,7 +238,7 @@ def test_show_trace_rejects_untraceable_adaptive_program() -> None:
         """)
 
     device = NeutralAtomDevice()
-    with pytest.raises(ValueError, match="could not trace this program"):
+    with pytest.raises(ValueError, match="programs with branching control flow"):
         device.show_trace(qir)
 
 

--- a/source/qdk_package/tests-integration/devices/test_atom_e2e.py
+++ b/source/qdk_package/tests-integration/devices/test_atom_e2e.py
@@ -261,3 +261,25 @@ def test_show_trace_allows_traceable_adaptive_program() -> None:
     device = NeutralAtomDevice()
     # Must not raise: this Adaptive-profile program is fully traceable.
     device.show_trace(qir)
+
+
+@pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
+@pytest.mark.skipif(not QSHARP_WIDGETS_AVAILABLE, reason=WIDGETS_SKIP_REASON)
+def test_show_trace_rejects_function_calls() -> None:
+    # In some Adaptive-profile builds, gate definitions (e.g. `H`) are emitted as
+    # separate, non-inlined functions. Tracing renders a single, straight-line
+    # schedule and cannot follow a call into another function body, so those
+    # operations would be silently dropped from the visualization. Such programs
+    # must be rejected rather than mis-visualized.
+    qsharp.init(target_profile=qsharp.TargetProfile.Adaptive)
+    qir = qsharp.compile("""
+        {
+            use q = Qubit();
+            H(q);
+            MResetZ(q)
+        }
+        """)
+
+    device = NeutralAtomDevice()
+    with pytest.raises(ValueError, match="programs with function calls"):
+        device.show_trace(qir)

--- a/source/qdk_package/tests-integration/devices/test_atom_reorder.py
+++ b/source/qdk_package/tests-integration/devices/test_atom_reorder.py
@@ -972,3 +972,74 @@ attributes #1 = { "irreversible" }
 !7 = !{!"double"}
 """,
     )
+
+
+@pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
+def test_reorder_tolerates_qis_call_without_qubit_args() -> None:
+    # Regression: a recognized `__quantum__qis__*` call may have no qubit
+    # operands (here `read_result`, whose only operand is a Result). The reorder
+    # pass sorts instructions within a step by their first qubit id, so such a
+    # call previously triggered `IndexError: list index out of range` in
+    # `Reorder.instr_key`. It must now be tolerated and must remain ordered
+    # after the measurement that produced the result it reads.
+    ir = """
+define i64 @ENTRYPOINT__main() #0 {
+block_0:
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr inttoptr (i64 1 to ptr))
+  %0 = call i1 @__quantum__qis__read_result__body(ptr inttoptr (i64 1 to ptr))
+  ret i64 0
+}
+
+declare void @__quantum__rt__initialize(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr) #1
+declare i1 @__quantum__qis__read_result__body(ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="2" }
+attributes #1 = { "irreversible" }
+"""
+
+    module = pyqir.Module.from_ir(pyqir.Context(), ir)
+    # Must not raise: previously failed with `IndexError: list index out of range`.
+    Reorder(NeutralAtomDevice()).run(module)
+    check_module_verifies(module)
+
+    text = str(module)
+    mz_pos = text.index("call void @__quantum__qis__mz__body")
+    read_pos = text.index("call i1 @__quantum__qis__read_result__body")
+    assert mz_pos < read_pos, "read_result must remain ordered after its measurement"
+
+
+@pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
+def test_reorder_tolerates_qis_gate_on_dynamic_qubit_pointer() -> None:
+    # Regression: Adaptive-profile QIR may keep gate definitions as separate
+    # functions whose body applies a `__quantum__qis__*` gate to a qubit
+    # *parameter* (a dynamic pointer whose `ptr_id` is None). The reorder pass
+    # visits every function with a body, so `Reorder.instr_key` must tolerate a
+    # recognized QIS gate whose qubit operand has no constant id instead of
+    # raising `IndexError`.
+    ir = """
+define void @my_gate(ptr %q) {
+block_0:
+  call void @__quantum__qis__h__body(ptr %q)
+  ret void
+}
+
+define i64 @ENTRYPOINT__main() #0 {
+block_0:
+  call void @__quantum__rt__initialize(ptr null)
+  call void @my_gate(ptr null)
+  ret i64 0
+}
+
+declare void @__quantum__rt__initialize(ptr)
+declare void @__quantum__qis__h__body(ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
+"""
+
+    module = pyqir.Module.from_ir(pyqir.Context(), ir)
+    # Must not raise: previously failed with `IndexError` while visiting
+    # `@my_gate`, whose `h` operand `%q` has no constant qubit id.
+    Reorder(NeutralAtomDevice()).run(module)
+    check_module_verifies(module)


### PR DESCRIPTION
This PR:
1. Fixes the `benzene.ipynb` notebook by explicitly passing `Profile.Base` to `qdk.openqasm.compile`.
2. Fixes the `Reorder` pass so that it can handle zero-qubit qis instructions, so that `NeutralAtomDevice.simulate` works with adaptive QIR.
3. Raises an exception when running `NeutralAtomDevice.show_trace` with adaptive QIR that cannot be traced, i.e.: QIR with dynamic angles or qubit IDs that cannot be resolved by the visualizer.