### PR TITLE
Send telemetry for wasm panics

### DIFF
--- a/source/npm/qsharp/src/main.ts
+++ b/source/npm/qsharp/src/main.ts
@@ -97,7 +97,15 @@ export async function instantiateWasm() {
   await wasmInstancePromise;
 
   // Once ready, set up logging and telemetry as soon as possible after instantiating
-  wasm.initLogging(log.logWithLevel, log.getLogLevel());
+  wasm.initLogging((level: number, target: string, ...args: any) => {
+    // Emit telemetry for all error-level log messages from Wasm.
+    // Only the target is included to distinguish errors; message
+    // content (including stack) is omitted for privacy.
+    if (level === 1) {
+      log.logTelemetry({ id: "wasm-error", data: { target } });
+    }
+    log.logWithLevel(level, target, ...args);
+  }, log.getLogLevel());
   log.onLevelChanged = (level) => wasm.setLogLevel(level);
 }
 

--- a/source/npm/qsharp/src/workers/worker.ts
+++ b/source/npm/qsharp/src/workers/worker.ts
@@ -216,6 +216,13 @@ function initService<
   }
 
   function postLogMessage(level: number, target: string, ...args: any) {
+    // Emit telemetry for all error-level log messages from Wasm.
+    // Only the target is included to distinguish errors; message
+    // content is omitted for privacy.
+    if (level === 1) {
+      postTelemetryMessage({ id: "wasm-error", data: { target } });
+    }
+
     if (log.getLogLevel() < level) {
       return;
     }

--- a/source/vscode/src/telemetry.ts
+++ b/source/vscode/src/telemetry.ts
@@ -64,6 +64,7 @@ export enum EventType {
   LearningSessionStarted = "Qsharp.LearningSessionStarted",
   LearningActivityAction = "Qsharp.LearningActivityAction",
   LearningExerciseCompleted = "Qsharp.LearningExerciseCompleted",
+  WasmError = "Qsharp.WasmError",
 }
 
 type Empty = { [K in any]: never };
@@ -355,6 +356,12 @@ type EventTypes = {
       totalExercises: number;
     };
   };
+  [EventType.WasmError]: {
+    properties: {
+      target: string;
+    };
+    measurements: Empty;
+  };
 };
 
 export enum QsharpDocumentType {
@@ -402,6 +409,14 @@ export function initTelemetry(context: vscode.ExtensionContext) {
   const version = context.extension?.packageJSON?.version;
   const browserAndRelease = getBrowserRelease();
   userAgentString = `VSCode/${version} ${browserAndRelease}`;
+
+  log.setTelemetryCollector((event) => {
+    if (event.id === "wasm-error") {
+      sendTelemetryEvent(EventType.WasmError, {
+        target: event.data?.target ?? "unknown",
+      });
+    }
+  });
 
   sendTelemetryEvent(EventType.InitializePlugin, {}, {});
 }

--- a/source/wasm/src/logging.rs
+++ b/source/wasm/src/logging.rs
@@ -83,6 +83,7 @@ pub fn hook(info: &std::panic::PanicHookInfo) {
     msg.push_str(&stack);
     msg.push_str("\n\n");
 
+    // The target will appear in telemetry, but nothing else will for privacy reasons
     let err_text = format!("Wasm panic occurred: {msg}");
     log::error!(target: "wasm", "{}", &err_text);
 }


### PR DESCRIPTION
For now, we're including basically no information - just that it happened.  Error messages are privacy minefields.