### PR TITLE
Update prepare/select scoping rules in stim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,6 +3059,7 @@ version = "0.0.0"
 dependencies = [
  "enum-iterator",
  "expect-test",
+ "indoc",
  "miette",
  "qdk_simulators",
  "qsc_data_structures",

--- a/samples/notebooks/stim_select.ipynb
+++ b/samples/notebooks/stim_select.ipynb
@@ -5,7 +5,7 @@
    "id": "24104626",
    "metadata": {},
    "source": [
-    "# Stim `PREPARE` blocks"
+    "# Stim `SELECT` blocks"
    ]
   },
   {
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "preselect_zero = \"\"\"\n",
-    "PREPARE {\n",
+    "SELECT {\n",
     "    H 0\n",
     "    M 0\n",
     "    REQUIRE rec[-1]\n",
@@ -62,7 +62,7 @@
    "outputs": [],
    "source": [
     "preselect_one = \"\"\"\n",
-    "PREPARE {\n",
+    "SELECT {\n",
     "    H 0\n",
     "    M 0\n",
     "    REQUIRE !rec[-1]\n",
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "multi_require = \"\"\"\n",
-    "PREPARE {\n",
+    "SELECT {\n",
     "    H 0\n",
     "    M 0\n",
     "    REQUIRE rec[-1]\n",
@@ -119,7 +119,7 @@
    "outputs": [],
    "source": [
     "parity_check = \"\"\"\n",
-    "PREPARE {\n",
+    "SELECT {\n",
     "    R 0\n",
     "    R 1\n",
     "    H 0\n",
@@ -139,7 +139,7 @@
    "id": "13032af8",
    "metadata": {},
    "source": [
-    "## Nested `PREPARE` blocks"
+    "## Nested `SELECT` blocks"
    ]
   },
   {
@@ -150,9 +150,9 @@
    "outputs": [],
    "source": [
     "nested = \"\"\"\n",
-    "PREPARE {\n",
+    "SELECT {\n",
     "    R 1\n",
-    "    PREPARE {\n",
+    "    SELECT {\n",
     "        R 0\n",
     "        H 0\n",
     "        M 0\n",
@@ -173,7 +173,7 @@
    "id": "534a0b65",
    "metadata": {},
    "source": [
-    "## An empty `PREPARE` block is a no-op"
+    "## An empty `SELECT` block is a no-op"
    ]
   },
   {
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "empty = \"\"\"\n",
-    "PREPARE {\n",
+    "SELECT {\n",
     "    H 0\n",
     "    MR 0\n",
     "}\n",

--- a/source/compiler/stim_compiler/Cargo.toml
+++ b/source/compiler/stim_compiler/Cargo.toml
@@ -13,4 +13,5 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 expect-test = { workspace = true }
+indoc = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-syscall"] }

--- a/source/compiler/stim_compiler/src/parser/tests/blocks.rs
+++ b/source/compiler/stim_compiler/src/parser/tests/blocks.rs
@@ -3,68 +3,83 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn repeat_block_with_body() {
     // The repeat count (3) is parsed as a Qubit target on the block instruction.
     check(
-        "REPEAT 3 {\n    H 0\n    X 1\n}",
+        indoc! {"
+            REPEAT 3 {
+              H 0
+              X 1
+            }
+        "},
         &expect![[r#"
-        Circuit [0-28]:
-            items:
-                Block [0-28]:
-                    block_instruction: Instruction [0-8]:
-                        name: REPEAT
-                        tag: <none>
-                        args: <empty>
-                        targets:
-                            Target [7-8]:
-                                kind: Qubit(3)
-                    items:
-                        Instruction [15-18]:
-                            name: H
+            Circuit [0-25]:
+                items:
+                    Block [0-24]:
+                        block_instruction: Instruction [0-8]:
+                            name: REPEAT
                             tag: <none>
                             args: <empty>
                             targets:
-                                Target [17-18]:
-                                    kind: Qubit(0)
-                        Instruction [23-26]:
-                            name: X
-                            tag: <none>
-                            args: <empty>
-                            targets:
-                                Target [25-26]:
-                                    kind: Qubit(1)"#]],
+                                Target [7-8]:
+                                    kind: Qubit(3)
+                        items:
+                            Instruction [13-16]:
+                                name: H
+                                tag: <none>
+                                args: <empty>
+                                targets:
+                                    Target [15-16]:
+                                        kind: Qubit(0)
+                            Instruction [19-22]:
+                                name: X
+                                tag: <none>
+                                args: <empty>
+                                targets:
+                                    Target [21-22]:
+                                        kind: Qubit(1)"#]],
     );
 }
 
 #[test]
 fn empty_repeat_block() {
     check(
-        "REPEAT 5 {\n}",
+        indoc! {"
+            REPEAT 5 {
+            }
+        "},
         &expect![[r#"
-        Circuit [0-12]:
-            items:
-                Block [0-12]:
-                    block_instruction: Instruction [0-8]:
-                        name: REPEAT
-                        tag: <none>
-                        args: <empty>
-                        targets:
-                            Target [7-8]:
-                                kind: Qubit(5)
-                    items: <empty>"#]],
+            Circuit [0-13]:
+                items:
+                    Block [0-12]:
+                        block_instruction: Instruction [0-8]:
+                            name: REPEAT
+                            tag: <none>
+                            args: <empty>
+                            targets:
+                                Target [7-8]:
+                                    kind: Qubit(5)
+                        items: <empty>"#]],
     );
 }
 
 #[test]
 fn nested_repeat_blocks() {
     check(
-        "REPEAT 2 {\n    REPEAT 3 {\n        H 0\n    }\n}",
+        indoc! {"
+            REPEAT 2 {
+              REPEAT 3 {
+                H 0
+              }
+            }
+        "},
         &expect![[r#"
-            Circuit [0-45]:
+            Circuit [0-38]:
                 items:
-                    Block [0-45]:
+                    Block [0-37]:
                         block_instruction: Instruction [0-8]:
                             name: REPEAT
                             tag: <none>
@@ -73,21 +88,21 @@ fn nested_repeat_blocks() {
                                 Target [7-8]:
                                     kind: Qubit(2)
                         items:
-                            Block [15-43]:
-                                block_instruction: Instruction [15-23]:
+                            Block [13-35]:
+                                block_instruction: Instruction [13-21]:
                                     name: REPEAT
                                     tag: <none>
                                     args: <empty>
                                     targets:
-                                        Target [22-23]:
+                                        Target [20-21]:
                                             kind: Qubit(3)
                                 items:
-                                    Instruction [34-37]:
+                                    Instruction [28-31]:
                                         name: H
                                         tag: <none>
                                         args: <empty>
                                         targets:
-                                            Target [36-37]:
+                                            Target [30-31]:
                                                 kind: Qubit(0)"#]],
     );
 }
@@ -111,14 +126,16 @@ fn missing_newline_after_open_brace_is_error() {
 #[test]
 fn unclosed_block_is_error() {
     check(
-        "REPEAT 5 {\n    H 0",
+        indoc! {"
+            REPEAT 5 {
+              H 0"},
         &expect![[r#"
             Qdk.Stim.Parser.UnexpectedEof
 
               x unexpected end of input
-               ,-[2:8]
+               ,-[2:6]
              1 | REPEAT 5 {
-             2 |     H 0
+             2 |   H 0
                `----
         "#]],
     );
@@ -127,7 +144,10 @@ fn unclosed_block_is_error() {
 #[test]
 fn content_after_close_brace_is_error() {
     check(
-        "REPEAT 5 {\n} H 0",
+        indoc! {"
+            REPEAT 5 {
+            } H 0
+        "},
         &expect![[r#"
             Qdk.Stim.Parser.ExpectedToken
 
@@ -161,18 +181,21 @@ fn stray_close_brace_is_error() {
 fn non_repeat_instruction_with_block() {
     // This should be parsed correctly, although it doesn't generate any meaningful code
     check(
-        "H 0 {\n}",
+        indoc! {"
+            H 0 {
+            }
+        "},
         &expect![[r#"
-        Circuit [0-7]:
-            items:
-                Block [0-7]:
-                    block_instruction: Instruction [0-3]:
-                        name: H
-                        tag: <none>
-                        args: <empty>
-                        targets:
-                            Target [2-3]:
-                                kind: Qubit(0)
-                    items: <empty>"#]],
+            Circuit [0-8]:
+                items:
+                    Block [0-7]:
+                        block_instruction: Instruction [0-3]:
+                            name: H
+                            tag: <none>
+                            args: <empty>
+                            targets:
+                                Target [2-3]:
+                                    kind: Qubit(0)
+                        items: <empty>"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/parser/tests/edge_cases.rs
+++ b/source/compiler/stim_compiler/src/parser/tests/edge_cases.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn only_newlines() {
@@ -67,25 +68,30 @@ fn blank_lines_and_comments_only() {
 #[test]
 fn comment_inside_block() {
     check(
-        "REPEAT 2 {\n    # inner\n    H 0\n}",
+        indoc! {"
+            REPEAT 2 {
+              # inner
+              H 0
+            }
+        "},
         &expect![[r#"
-        Circuit [0-32]:
-            items:
-                Block [0-32]:
-                    block_instruction: Instruction [0-8]:
-                        name: REPEAT
-                        tag: <none>
-                        args: <empty>
-                        targets:
-                            Target [7-8]:
-                                kind: Qubit(2)
-                    items:
-                        Instruction [27-30]:
-                            name: H
+            Circuit [0-29]:
+                items:
+                    Block [0-28]:
+                        block_instruction: Instruction [0-8]:
+                            name: REPEAT
                             tag: <none>
                             args: <empty>
                             targets:
-                                Target [29-30]:
-                                    kind: Qubit(0)"#]],
+                                Target [7-8]:
+                                    kind: Qubit(2)
+                        items:
+                            Instruction [23-26]:
+                                name: H
+                                tag: <none>
+                                args: <empty>
+                                targets:
+                                    Target [25-26]:
+                                        kind: Qubit(0)"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/parser/tests/errors.rs
+++ b/source/compiler/stim_compiler/src/parser/tests/errors.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn line_not_starting_with_instruction_name_is_error() {
@@ -50,7 +51,10 @@ fn parser_recovers_to_next_line_after_error() {
     // The first line is invalid, but the parser recovers and the second line
     // parses cleanly, so only one error is reported.
     check(
-        "0 1\nH 2",
+        indoc! {"
+            0 1
+            H 2
+        "},
         &expect![[r#"
             Qdk.Stim.Parser.ExpectedToken
 
@@ -61,7 +65,7 @@ fn parser_recovers_to_next_line_after_error() {
              2 | H 2
                `----
 
-            Circuit [0-7]:
+            Circuit [0-8]:
                 items:
                     Instruction [4-7]:
                         name: H
@@ -76,7 +80,11 @@ fn parser_recovers_to_next_line_after_error() {
 #[test]
 fn multiple_errors_are_collected() {
     check(
-        "0\n1\n2",
+        indoc! {"
+            0
+            1
+            2
+        "},
         &expect![[r#"
             Qdk.Stim.Parser.ExpectedToken
 
@@ -146,7 +154,11 @@ fn recovery_preserves_surrounding_instructions() {
     // The bad middle line is dropped; the valid lines before and after it
     // are both kept in the AST.
     check(
-        "H 0\n0 1\nX 2",
+        indoc! {"
+            H 0
+            0 1
+            X 2
+        "},
         &expect![[r#"
             Qdk.Stim.Parser.ExpectedToken
 
@@ -158,7 +170,7 @@ fn recovery_preserves_surrounding_instructions() {
              3 | X 2
                `----
 
-            Circuit [0-11]:
+            Circuit [0-12]:
                 items:
                     Instruction [0-3]:
                         name: H
@@ -182,21 +194,26 @@ fn recovery_inside_repeat_block() {
     // Recovery also happens within a block: the bad line is skipped and the
     // following instruction is still added to the block.
     check(
-        "REPEAT 2 {\n0 1\nH 0\n}",
+        indoc! {"
+            REPEAT 2 {
+              0 1
+              H 0
+            }
+        "},
         &expect![[r#"
             Qdk.Stim.Parser.ExpectedToken
 
               x expected instruction_name, found uint
-               ,-[2:1]
+               ,-[2:3]
              1 | REPEAT 2 {
-             2 | 0 1
-               : ^
-             3 | H 0
+             2 |   0 1
+               :   ^
+             3 |   H 0
                `----
 
-            Circuit [0-20]:
+            Circuit [0-25]:
                 items:
-                    Block [0-20]:
+                    Block [0-24]:
                         block_instruction: Instruction [0-8]:
                             name: REPEAT
                             tag: <none>
@@ -205,12 +222,12 @@ fn recovery_inside_repeat_block() {
                                 Target [7-8]:
                                     kind: Qubit(2)
                         items:
-                            Instruction [15-18]:
+                            Instruction [19-22]:
                                 name: H
                                 tag: <none>
                                 args: <empty>
                                 targets:
-                                    Target [17-18]:
+                                    Target [21-22]:
                                         kind: Qubit(0)"#]],
     );
 }
@@ -220,7 +237,10 @@ fn malformed_line_is_discarded_during_recovery() {
     // A line that starts validly but has trailing garbage is discarded whole
     // (the "H 0" prefix is not kept); parsing resumes on the next line.
     check(
-        "H 0 )\nX 1",
+        indoc! {"
+            H 0 )
+            X 1
+        "},
         &expect![[r#"
             Qdk.Stim.Parser.ExpectedToken
 
@@ -231,7 +251,7 @@ fn malformed_line_is_discarded_during_recovery() {
              2 | X 1
                `----
 
-            Circuit [0-9]:
+            Circuit [0-10]:
                 items:
                     Instruction [6-9]:
                         name: X

--- a/source/compiler/stim_compiler/src/parser/tests/instruction_shapes.rs
+++ b/source/compiler/stim_compiler/src/parser/tests/instruction_shapes.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn no_args_no_targets() {
@@ -79,26 +80,30 @@ fn args_with_targets() {
 #[test]
 fn block_instruction() {
     check(
-        "REPEAT 5 {\n    H 0\n}",
+        indoc! {"
+            REPEAT 5 {
+              H 0
+            }
+        "},
         &expect![[r#"
-        Circuit [0-20]:
-            items:
-                Block [0-20]:
-                    block_instruction: Instruction [0-8]:
-                        name: REPEAT
-                        tag: <none>
-                        args: <empty>
-                        targets:
-                            Target [7-8]:
-                                kind: Qubit(5)
-                    items:
-                        Instruction [15-18]:
-                            name: H
+            Circuit [0-19]:
+                items:
+                    Block [0-18]:
+                        block_instruction: Instruction [0-8]:
+                            name: REPEAT
                             tag: <none>
                             args: <empty>
                             targets:
-                                Target [17-18]:
-                                    kind: Qubit(0)"#]],
+                                Target [7-8]:
+                                    kind: Qubit(5)
+                        items:
+                            Instruction [13-16]:
+                                name: H
+                                tag: <none>
+                                args: <empty>
+                                targets:
+                                    Target [15-16]:
+                                        kind: Qubit(0)"#]],
     );
 }
 

--- a/source/compiler/stim_compiler/src/parser/tests/spans.rs
+++ b/source/compiler/stim_compiler/src/parser/tests/spans.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn instruction_span_with_no_targets() {
@@ -61,24 +62,28 @@ fn negated_target_span_includes_the_bang() {
 #[test]
 fn block_span_covers_through_closing_brace() {
     check(
-        "REPEAT 2 {\n    TICK\n}\n",
+        indoc! {"
+            REPEAT 2 {
+              TICK
+            }
+        "},
         &expect![[r#"
-        Circuit [0-22]:
-            items:
-                Block [0-21]:
-                    block_instruction: Instruction [0-8]:
-                        name: REPEAT
-                        tag: <none>
-                        args: <empty>
-                        targets:
-                            Target [7-8]:
-                                kind: Qubit(2)
-                    items:
-                        Instruction [15-19]:
-                            name: TICK
+            Circuit [0-20]:
+                items:
+                    Block [0-19]:
+                        block_instruction: Instruction [0-8]:
+                            name: REPEAT
                             tag: <none>
                             args: <empty>
-                            targets: <empty>"#]],
+                            targets:
+                                Target [7-8]:
+                                    kind: Qubit(2)
+                        items:
+                            Instruction [13-17]:
+                                name: TICK
+                                tag: <none>
+                                args: <empty>
+                                targets: <empty>"#]],
     );
 }
 

--- a/source/compiler/stim_compiler/src/parser/tests/tags.rs
+++ b/source/compiler/stim_compiler/src/parser/tests/tags.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn instruction_with_tag() {
@@ -74,26 +75,30 @@ fn tag_with_args_and_targets() {
 #[test]
 fn tag_on_block_instruction() {
     check(
-        "REPEAT[t] 5 {\n    H 0\n}",
+        indoc! {"
+            REPEAT[t] 5 {
+              H 0
+            }
+        "},
         &expect![[r#"
-        Circuit [0-23]:
-            items:
-                Block [0-23]:
-                    block_instruction: Instruction [0-11]:
-                        name: REPEAT
-                        tag: t
-                        args: <empty>
-                        targets:
-                            Target [10-11]:
-                                kind: Qubit(5)
-                    items:
-                        Instruction [18-21]:
-                            name: H
-                            tag: <none>
+            Circuit [0-22]:
+                items:
+                    Block [0-21]:
+                        block_instruction: Instruction [0-11]:
+                            name: REPEAT
+                            tag: t
                             args: <empty>
                             targets:
-                                Target [20-21]:
-                                    kind: Qubit(0)"#]],
+                                Target [10-11]:
+                                    kind: Qubit(5)
+                        items:
+                            Instruction [16-19]:
+                                name: H
+                                tag: <none>
+                                args: <empty>
+                                targets:
+                                    Target [18-19]:
+                                        kind: Qubit(0)"#]],
     );
 }
 

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -417,10 +417,16 @@ impl AllowedRecPosition {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    TopLevel,
+    Prepare(u32), // The u32 is a unique id for the prepare scope
+}
+
 struct IdMap {
     qubit_map: FxHashMap<u32, u32>,
-    record_map: Vec<Option<u32>>, // index = result id, value = owning scope (if none then the result is not in a block)
-    scope_stack: Vec<u32>,        // active nested scopes; last() = current
+    record_scopes: Vec<Scope>,                   // indexed by result id
+    scope_stack: Vec<Scope>, // active nested scopes; last() = current, empty = top level
     name_counters: FxHashMap<&'static str, u32>, // prefix -> next index
 }
 
@@ -428,7 +434,7 @@ impl IdMap {
     fn new() -> Self {
         Self {
             qubit_map: FxHashMap::default(),
-            record_map: Vec::new(),
+            record_scopes: Vec::new(),
             scope_stack: Vec::new(),
             name_counters: FxHashMap::default(),
         }
@@ -441,36 +447,32 @@ impl IdMap {
         format!("{prefix}_{id}")
     }
 
-    fn enter_scope(&mut self) {
-        let counter = self.name_counters.entry("scope").or_insert(0);
+    fn enter_prepare_scope(&mut self) {
+        let counter = self.name_counters.entry("prepare_scope").or_insert(0);
         let id = *counter;
         *counter += 1;
-        self.scope_stack.push(id);
+        self.scope_stack.push(Scope::Prepare(id));
     }
 
-    fn exit_scope(&mut self) {
+    fn exit_prepare_scope(&mut self) {
         self.scope_stack.pop();
     }
 
-    fn current_scope(&self) -> Option<u32> {
-        self.scope_stack.last().copied()
+    fn current_scope(&self) -> Scope {
+        self.scope_stack.last().copied().unwrap_or(Scope::TopLevel)
     }
 
-    fn in_prepare_block(&self) -> bool {
-        !self.scope_stack.is_empty()
-    }
-
-    fn scope_of(&self, id: u32) -> Option<u32> {
-        match self.record_map.get(id as usize) {
+    fn scope_of_record(&self, id: u32) -> Scope {
+        match self.record_scopes.get(id as usize) {
             Some(&scope) => scope,
             None => unreachable!("record id not found"), // this is a compiler invariant
         }
     }
 
     fn allocate_record(&mut self) -> u32 {
-        let id = self.record_map.len() as u32;
-        let current_scope = self.current_scope();
-        self.record_map.push(current_scope);
+        let id = self.record_scopes.len() as u32;
+        let scope = self.current_scope();
+        self.record_scopes.push(scope);
         id
     }
 
@@ -480,7 +482,7 @@ impl IdMap {
     }
 
     fn num_results(&self) -> u32 {
-        self.record_map.len() as u32
+        self.record_scopes.len() as u32
     }
 
     fn num_qubits(&self) -> u32 {
@@ -533,12 +535,12 @@ impl<'noise> Compiler<'noise> {
             ..
         } = block;
 
-        self.id_map.enter_scope();
+        self.id_map.enter_prepare_scope();
         self.compile_instruction(block_instruction);
         for item in items {
             self.compile_item(item);
         }
-        self.id_map.exit_scope();
+        self.id_map.exit_prepare_scope();
     }
 
     fn compile_line(&mut self, line: &Line) {
@@ -1104,7 +1106,7 @@ impl<'noise> Compiler<'noise> {
             return;
         }
 
-        let Some(scope) = self.id_map.current_scope() else {
+        let Scope::Prepare(scope) = self.id_map.current_scope() else {
             self.push_error(Error::PrepareWithoutBlock {
                 span: instruction.span,
             });
@@ -1117,7 +1119,7 @@ impl<'noise> Compiler<'noise> {
     }
 
     fn compile_require(&mut self, instruction: &Instruction) {
-        if !self.id_map.in_prepare_block() {
+        if matches!(self.id_map.current_scope(), Scope::TopLevel) {
             self.push_error(Error::RequireOutsidePrepareBlock {
                 span: instruction.span,
             });
@@ -1165,7 +1167,7 @@ impl<'noise> Compiler<'noise> {
             parity = temp;
         }
 
-        let Some(scope) = self.id_map.current_scope() else {
+        let Scope::Prepare(scope) = self.id_map.current_scope() else {
             unreachable!("REQUIRE runs inside a prepare block");
         };
         let restart_label = prepare_label(scope);
@@ -1182,7 +1184,7 @@ impl<'noise> Compiler<'noise> {
             return None;
         };
 
-        if self.id_map.scope_of(result_id) != self.id_map.current_scope() {
+        if self.id_map.scope_of_record(result_id) != self.id_map.current_scope() {
             self.push_error(Error::MeasurementRecordOutOfScope { span: target.span });
             return None;
         }

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -7,6 +7,7 @@ mod tests;
 use qdk_simulators::noise_config::{LossPolicy, NoiseConfig, NoiseTable, encode_pauli};
 
 use crate::parser::*;
+use crate::qir::Scope::{Prepare, TopLevel};
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
 use rustc_hash::FxHashMap;
@@ -426,7 +427,8 @@ enum Scope {
 struct IdMap {
     qubit_map: FxHashMap<u32, u32>,
     record_scopes: Vec<Scope>,                   // indexed by result id
-    scope_stack: Vec<Scope>, // active nested scopes; last() = current, empty = top level
+    scope_parents: Vec<Scope>, // indexed by prepare scope id, value = parent scope
+    scope_stack: Vec<Scope>,   // active nested scopes; last() = current, empty = top level
     name_counters: FxHashMap<&'static str, u32>, // prefix -> next index
 }
 
@@ -435,6 +437,7 @@ impl IdMap {
         Self {
             qubit_map: FxHashMap::default(),
             record_scopes: Vec::new(),
+            scope_parents: Vec::new(),
             scope_stack: Vec::new(),
             name_counters: FxHashMap::default(),
         }
@@ -448,9 +451,9 @@ impl IdMap {
     }
 
     fn enter_prepare_scope(&mut self) {
-        let counter = self.name_counters.entry("prepare_scope").or_insert(0);
-        let id = *counter;
-        *counter += 1;
+        let parent = self.current_scope();
+        let id = self.scope_parents.len() as u32;
+        self.scope_parents.push(parent);
         self.scope_stack.push(Scope::Prepare(id));
     }
 
@@ -467,6 +470,28 @@ impl IdMap {
             Some(&scope) => scope,
             None => unreachable!("record id not found"), // this is a compiler invariant
         }
+    }
+
+    fn parent_of(&self, scope: Scope) -> Scope {
+        let Prepare(id) = scope else { return TopLevel };
+        self.scope_parents
+            .get(id as usize)
+            .copied()
+            .expect("cannot get the parent of a scope that has not been entered")
+    }
+
+    fn is_descendant_or_equal(&self, scope: Scope, ancestor: Scope) -> bool {
+        if scope == ancestor {
+            return true;
+        }
+        match scope {
+            Prepare(_) => self.is_descendant_or_equal(self.parent_of(scope), ancestor),
+            TopLevel => false,
+        }
+    }
+
+    fn record_in_scope(&self, record_id: u32) -> bool {
+        self.is_descendant_or_equal(self.scope_of_record(record_id), self.current_scope())
     }
 
     fn allocate_record(&mut self) -> u32 {
@@ -1184,7 +1209,7 @@ impl<'noise> Compiler<'noise> {
             return None;
         };
 
-        if self.id_map.scope_of_record(result_id) != self.id_map.current_scope() {
+        if !self.id_map.record_in_scope(result_id) {
             self.push_error(Error::MeasurementRecordOutOfScope { span: target.span });
             return None;
         }

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -376,21 +376,21 @@ pub enum Error {
         #[label]
         span: Span,
     },
-    #[error("measurement record refers to a measurement outside the enclosing PREPARE block")]
+    #[error("measurement record refers to a measurement outside the enclosing SELECT block")]
     #[diagnostic(code("Qdk.Stim.Compiler.MeasurementRecordOutOfScope"))]
     MeasurementRecordOutOfScope {
         #[label]
         span: Span,
     },
-    #[error("require must appear inside a PREPARE block")]
-    #[diagnostic(code("Qdk.Stim.Compiler.RequireOutsidePrepareBlock"))]
-    RequireOutsidePrepareBlock {
+    #[error("require must appear inside a SELECT block")]
+    #[diagnostic(code("Qdk.Stim.Compiler.RequireOutsideSelectBlock"))]
+    RequireOutsideSelectBlock {
         #[label]
         span: Span,
     },
-    #[error("prepare instruction must start a block")]
-    #[diagnostic(code("Qdk.Stim.Compiler.PrepareWithoutBlock"))]
-    PrepareWithoutBlock {
+    #[error("select instruction must start a block")]
+    #[diagnostic(code("Qdk.Stim.Compiler.SelectWithoutBlock"))]
+    SelectWithoutBlock {
         #[label]
         span: Span,
     },
@@ -420,14 +420,14 @@ impl AllowedRecPosition {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Scope {
     TopLevel,
-    Prepare(u32), // The u32 is a unique id for the prepare scope
+    Select(u32), // The u32 is a unique id for the select scope
 }
 
 struct IdMap {
     qubit_map: FxHashMap<u32, u32>,
     record_scopes: Vec<Scope>,                   // indexed by result id
-    scope_parents: Vec<Scope>, // indexed by prepare scope id, value = parent scope
-    scope_stack: Vec<Scope>,   // active nested scopes; last() = current, empty = top level
+    scope_parents: Vec<Scope>,                   // indexed by select scope id, value = parent scope
+    scope_stack: Vec<Scope>, // active nested scopes; last() = current, empty = top level
     name_counters: FxHashMap<&'static str, u32>, // prefix -> next index
 }
 
@@ -449,14 +449,14 @@ impl IdMap {
         format!("{prefix}_{id}")
     }
 
-    fn enter_prepare_scope(&mut self) {
+    fn enter_select_scope(&mut self) {
         let parent = self.current_scope();
         let id = self.scope_parents.len() as u32;
         self.scope_parents.push(parent);
-        self.scope_stack.push(Scope::Prepare(id));
+        self.scope_stack.push(Scope::Select(id));
     }
 
-    fn exit_prepare_scope(&mut self) {
+    fn exit_select_scope(&mut self) {
         self.scope_stack.pop();
     }
 
@@ -472,7 +472,7 @@ impl IdMap {
     }
 
     fn parent_of(&self, scope: Scope) -> Scope {
-        let Scope::Prepare(id) = scope else {
+        let Scope::Select(id) = scope else {
             return Scope::TopLevel;
         };
         self.scope_parents
@@ -486,7 +486,7 @@ impl IdMap {
             return true;
         }
         match scope {
-            Scope::Prepare(_) => self.is_descendant_or_equal(self.parent_of(scope), ancestor),
+            Scope::Select(_) => self.is_descendant_or_equal(self.parent_of(scope), ancestor),
             Scope::TopLevel => false,
         }
     }
@@ -516,8 +516,8 @@ impl IdMap {
     }
 }
 
-fn prepare_label(scope: u32) -> String {
-    format!("prepare_{scope}")
+fn select_label(scope: u32) -> String {
+    format!("select_{scope}")
 }
 
 struct Compiler<'noise> {
@@ -561,12 +561,12 @@ impl<'noise> Compiler<'noise> {
             ..
         } = block;
 
-        self.id_map.enter_prepare_scope();
+        self.id_map.enter_select_scope();
         self.compile_instruction(block_instruction);
         for item in items {
             self.compile_item(item);
         }
-        self.id_map.exit_prepare_scope();
+        self.id_map.exit_select_scope();
     }
 
     fn compile_line(&mut self, line: &Line) {
@@ -958,7 +958,7 @@ impl<'noise> Compiler<'noise> {
 
             // Control Flow
             "REPEAT" => self.unsupported(instruction),
-            "PREPARE" => self.compile_prepare(instruction),
+            "SELECT" => self.compile_select(instruction),
             "REQUIRE" => self.compile_require(instruction),
 
             // Annotations
@@ -1111,7 +1111,7 @@ impl<'noise> Compiler<'noise> {
         self.writer.write_qis_call(intrinsic, &[q0, q1]);
     }
 
-    fn compile_prepare(&mut self, instruction: &Instruction) {
+    fn compile_select(&mut self, instruction: &Instruction) {
         if !instruction.targets.is_empty() {
             self.push_error(Error::UnsupportedTarget {
                 instruction: instruction.name.clone(),
@@ -1132,21 +1132,21 @@ impl<'noise> Compiler<'noise> {
             return;
         }
 
-        let Scope::Prepare(scope) = self.id_map.current_scope() else {
-            self.push_error(Error::PrepareWithoutBlock {
+        let Scope::Select(scope) = self.id_map.current_scope() else {
+            self.push_error(Error::SelectWithoutBlock {
                 span: instruction.span,
             });
             return;
         };
 
-        let label = prepare_label(scope);
+        let label = select_label(scope);
         self.writer.write_jump(&label); // terminate the previous block
         self.writer.write_label(&label); // start the new block
     }
 
     fn compile_require(&mut self, instruction: &Instruction) {
         if matches!(self.id_map.current_scope(), Scope::TopLevel) {
-            self.push_error(Error::RequireOutsidePrepareBlock {
+            self.push_error(Error::RequireOutsideSelectBlock {
                 span: instruction.span,
             });
             return;
@@ -1193,10 +1193,10 @@ impl<'noise> Compiler<'noise> {
             parity = temp;
         }
 
-        let Scope::Prepare(scope) = self.id_map.current_scope() else {
-            unreachable!("REQUIRE runs inside a prepare block");
+        let Scope::Select(scope) = self.id_map.current_scope() else {
+            unreachable!("REQUIRE runs inside a select block");
         };
-        let restart_label = prepare_label(scope);
+        let restart_label = select_label(scope);
         let continue_label = self.id_map.fresh_name("continue");
         self.writer
             .write_branch(&parity, &restart_label, &continue_label);

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -7,7 +7,6 @@ mod tests;
 use qdk_simulators::noise_config::{LossPolicy, NoiseConfig, NoiseTable, encode_pauli};
 
 use crate::parser::*;
-use crate::qir::Scope::{Prepare, TopLevel};
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
 use rustc_hash::FxHashMap;
@@ -454,7 +453,7 @@ impl IdMap {
         let parent = self.current_scope();
         let id = self.scope_parents.len() as u32;
         self.scope_parents.push(parent);
-        self.scope_stack.push(Prepare(id));
+        self.scope_stack.push(Scope::Prepare(id));
     }
 
     fn exit_prepare_scope(&mut self) {
@@ -462,7 +461,7 @@ impl IdMap {
     }
 
     fn current_scope(&self) -> Scope {
-        self.scope_stack.last().copied().unwrap_or(TopLevel)
+        self.scope_stack.last().copied().unwrap_or(Scope::TopLevel)
     }
 
     fn scope_of_record(&self, id: u32) -> Scope {
@@ -473,7 +472,9 @@ impl IdMap {
     }
 
     fn parent_of(&self, scope: Scope) -> Scope {
-        let Prepare(id) = scope else { return TopLevel };
+        let Scope::Prepare(id) = scope else {
+            return Scope::TopLevel;
+        };
         self.scope_parents
             .get(id as usize)
             .copied()
@@ -485,8 +486,8 @@ impl IdMap {
             return true;
         }
         match scope {
-            Prepare(_) => self.is_descendant_or_equal(self.parent_of(scope), ancestor),
-            TopLevel => false,
+            Scope::Prepare(_) => self.is_descendant_or_equal(self.parent_of(scope), ancestor),
+            Scope::TopLevel => false,
         }
     }
 
@@ -1131,7 +1132,7 @@ impl<'noise> Compiler<'noise> {
             return;
         }
 
-        let Prepare(scope) = self.id_map.current_scope() else {
+        let Scope::Prepare(scope) = self.id_map.current_scope() else {
             self.push_error(Error::PrepareWithoutBlock {
                 span: instruction.span,
             });
@@ -1144,7 +1145,7 @@ impl<'noise> Compiler<'noise> {
     }
 
     fn compile_require(&mut self, instruction: &Instruction) {
-        if matches!(self.id_map.current_scope(), TopLevel) {
+        if matches!(self.id_map.current_scope(), Scope::TopLevel) {
             self.push_error(Error::RequireOutsidePrepareBlock {
                 span: instruction.span,
             });
@@ -1192,7 +1193,7 @@ impl<'noise> Compiler<'noise> {
             parity = temp;
         }
 
-        let Prepare(scope) = self.id_map.current_scope() else {
+        let Scope::Prepare(scope) = self.id_map.current_scope() else {
             unreachable!("REQUIRE runs inside a prepare block");
         };
         let restart_label = prepare_label(scope);

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -454,7 +454,7 @@ impl IdMap {
         let parent = self.current_scope();
         let id = self.scope_parents.len() as u32;
         self.scope_parents.push(parent);
-        self.scope_stack.push(Scope::Prepare(id));
+        self.scope_stack.push(Prepare(id));
     }
 
     fn exit_prepare_scope(&mut self) {
@@ -462,7 +462,7 @@ impl IdMap {
     }
 
     fn current_scope(&self) -> Scope {
-        self.scope_stack.last().copied().unwrap_or(Scope::TopLevel)
+        self.scope_stack.last().copied().unwrap_or(TopLevel)
     }
 
     fn scope_of_record(&self, id: u32) -> Scope {
@@ -1131,7 +1131,7 @@ impl<'noise> Compiler<'noise> {
             return;
         }
 
-        let Scope::Prepare(scope) = self.id_map.current_scope() else {
+        let Prepare(scope) = self.id_map.current_scope() else {
             self.push_error(Error::PrepareWithoutBlock {
                 span: instruction.span,
             });
@@ -1144,7 +1144,7 @@ impl<'noise> Compiler<'noise> {
     }
 
     fn compile_require(&mut self, instruction: &Instruction) {
-        if matches!(self.id_map.current_scope(), Scope::TopLevel) {
+        if matches!(self.id_map.current_scope(), TopLevel) {
             self.push_error(Error::RequireOutsidePrepareBlock {
                 span: instruction.span,
             });
@@ -1192,7 +1192,7 @@ impl<'noise> Compiler<'noise> {
             parity = temp;
         }
 
-        let Scope::Prepare(scope) = self.id_map.current_scope() else {
+        let Prepare(scope) = self.id_map.current_scope() else {
             unreachable!("REQUIRE runs inside a prepare block");
         };
         let restart_label = prepare_label(scope);

--- a/source/compiler/stim_compiler/src/qir/tests.rs
+++ b/source/compiler/stim_compiler/src/qir/tests.rs
@@ -10,7 +10,7 @@ mod noise_channels;
 mod noise_channels_broadcasting;
 mod pair_measurements;
 mod pair_measurements_broadcasting;
-mod prepare_block;
+mod select_block;
 mod single_qubit_gates;
 mod single_qubit_gates_broadcasting;
 mod two_qubit_gates;

--- a/source/compiler/stim_compiler/src/qir/tests/control_flow.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/control_flow.rs
@@ -3,16 +3,17 @@
 
 use crate::qir::tests::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 #[ignore = "unsupported instruction"]
 fn repeat() {
-    let source = "
-REPEAT 10 {
-    CNOT 0 1
-    CNOT 2 1
-    M 1
-}
-";
+    let source = indoc! {"
+        REPEAT 10 {
+          CNOT 0 1
+          CNOT 2 1
+          M 1
+        }
+    "};
     check(source, &expect![[""]]);
 }

--- a/source/compiler/stim_compiler/src/qir/tests/generalize_pauli_product_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/generalize_pauli_product_gates.rs
@@ -3,72 +3,73 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 #[ignore = "unsupported instruction"]
 fn mpp_yields_expected_qir() {
-    let source = "
-# Measure the two-body +X1*Y2 observable.
-MPP X1*Y2
+    let source = indoc! {"
+        # Measure the two-body +X1*Y2 observable.
+        MPP X1*Y2
 
-# Measure the one-body -Z5 observable.
-MPP !Z5
+        # Measure the one-body -Z5 observable.
+        MPP !Z5
 
-# Measure the two-body +X1*Y2 observable and also the three-body -Z3*Z4*Z5 observable.
-MPP X1*Y2 !Z3*Z4*Z5
+        # Measure the two-body +X1*Y2 observable and also the three-body -Z3*Z4*Z5 observable.
+        MPP X1*Y2 !Z3*Z4*Z5
 
-# Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
-MPP(0.001) Z1*Z2 X1*X2
-";
+        # Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
+        MPP(0.001) Z1*Z2 X1*X2
+    "};
     check(source, &expect![[""]]);
 }
 
 #[test]
 #[ignore = "unsupported instruction"]
 fn spp_yields_expected_qir() {
-    let source = "
-# Perform an S gate on qubit 1.
-SPP Z1
+    let source = indoc! {"
+        # Perform an S gate on qubit 1.
+        SPP Z1
 
-# Perform a SQRT_X gate on qubit 1.
-SPP X1
+        # Perform a SQRT_X gate on qubit 1.
+        SPP X1
 
-# Perform a SQRT_X_DAG gate on qubit 1.
-SPP !X1
+        # Perform a SQRT_X_DAG gate on qubit 1.
+        SPP !X1
 
-# Perform a SQRT_XX gate between qubit 1 and qubit 2.
-SPP X1*X2
+        # Perform a SQRT_XX gate between qubit 1 and qubit 2.
+        SPP X1*X2
 
-# Perform a SQRT_YY gate between qubit 1 and 2, and a SQRT_ZZ_DAG between qubit 3 and 4.
-SPP Y1*Y2 !Z1*Z2
+        # Perform a SQRT_YY gate between qubit 1 and 2, and a SQRT_ZZ_DAG between qubit 3 and 4.
+        SPP Y1*Y2 !Z1*Z2
 
-# Phase the -1 eigenspace of -X1*Y2*Z3 by i.
-SPP !X1*Y2*Z3
-";
+        # Phase the -1 eigenspace of -X1*Y2*Z3 by i.
+        SPP !X1*Y2*Z3
+    "};
     check(source, &expect![[""]]);
 }
 
 #[test]
 #[ignore = "unsupported instruction"]
 fn spp_dag_yields_expected_qir() {
-    let source = "
-# Perform an S_DAG gate on qubit 1.
-SPP_DAG Z1
+    let source = indoc! {"
+        # Perform an S_DAG gate on qubit 1.
+        SPP_DAG Z1
 
-# Perform a SQRT_X_DAG gate on qubit 1.
-SPP_DAG X1
+        # Perform a SQRT_X_DAG gate on qubit 1.
+        SPP_DAG X1
 
-# Perform a SQRT_X gate on qubit 1.
-SPP_DAG !X1
+        # Perform a SQRT_X gate on qubit 1.
+        SPP_DAG !X1
 
-# Perform a SQRT_XX_DAG gate between qubit 1 and qubit 2.
-SPP_DAG X1*X2
+        # Perform a SQRT_XX_DAG gate between qubit 1 and qubit 2.
+        SPP_DAG X1*X2
 
-# Perform a SQRT_YY_DAG gate between qubit 1 and 2, and a SQRT_ZZ between qubit 3 and 4.
-SPP_DAG Y1*Y2 !Z1*Z2
+        # Perform a SQRT_YY_DAG gate between qubit 1 and 2, and a SQRT_ZZ between qubit 3 and 4.
+        SPP_DAG Y1*Y2 !Z1*Z2
 
-# Phase the -1 eigenspace of -X1*Y2*Z3 by -i.
-SPP_DAG !X1*Y2*Z3
-";
+        # Phase the -1 eigenspace of -X1*Y2*Z3 by -i.
+        SPP_DAG !X1*Y2*Z3
+    "};
     check(source, &expect![[""]]);
 }

--- a/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
@@ -1079,10 +1079,10 @@ fn ycz_with_negated_rec_on_second_target_yields_error() {
 }
 
 #[test]
-fn cx_with_rec_control_crossing_prepare_boundary_yields_error() {
+fn cx_with_rec_control_crossing_select_boundary_yields_error() {
     let source = indoc! {"
         M 0
-        PREPARE {
+        SELECT {
           CX rec[-1] 1
         }
     "};
@@ -1091,10 +1091,10 @@ fn cx_with_rec_control_crossing_prepare_boundary_yields_error() {
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfScope
 
-              x measurement record refers to a measurement outside the enclosing PREPARE
+              x measurement record refers to a measurement outside the enclosing SELECT
               | block
                ,-[3:6]
-             2 | PREPARE {
+             2 | SELECT {
              3 |   CX rec[-1] 1
                :      ^^^^^^^
              4 | }
@@ -1104,9 +1104,9 @@ fn cx_with_rec_control_crossing_prepare_boundary_yields_error() {
 }
 
 #[test]
-fn top_level_classical_control_reaches_into_prepare() {
+fn top_level_classical_control_reaches_into_select() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
         }
         CX rec[-1] 1
@@ -1116,8 +1116,8 @@ fn top_level_classical_control_reaches_into_prepare() {
         &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
-          br label %prepare_0
-        prepare_0:
+          br label %select_0
+        select_0:
           call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
           call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
           call void @__quantum__rt__array_record_output(i64 1, ptr null)

--- a/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
@@ -3,10 +3,14 @@
 
 use crate::qir::tests::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn cx_with_rec_control_yields_expected_qir() {
-    let source = "M 0\nCX rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        CX rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -58,7 +62,10 @@ fn cx_with_rec_control_yields_expected_qir() {
 
 #[test]
 fn cnot_with_rec_control_yields_expected_qir() {
-    let source = "M 0\nCNOT rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        CNOT rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -110,7 +117,10 @@ fn cnot_with_rec_control_yields_expected_qir() {
 
 #[test]
 fn zcx_with_rec_control_yields_expected_qir() {
-    let source = "M 0\nZCX rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        ZCX rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -162,7 +172,11 @@ fn zcx_with_rec_control_yields_expected_qir() {
 
 #[test]
 fn cx_with_older_rec_control_yields_expected_qir() {
-    let source = "M 0\nM 1\nCX rec[-2] 2";
+    let source = indoc! {"
+        M 0
+        M 1
+        CX rec[-2] 2
+    "};
     check(
         source,
         &expect![[r#"
@@ -216,7 +230,10 @@ fn cx_with_older_rec_control_yields_expected_qir() {
 
 #[test]
 fn cx_with_mixed_quantum_and_classical_pairs_yields_expected_qir() {
-    let source = "M 0\nCX rec[-1] 1 2 3";
+    let source = indoc! {"
+        M 0
+        CX rec[-1] 1 2 3
+    "};
     check(
         source,
         &expect![[r#"
@@ -270,7 +287,11 @@ fn cx_with_mixed_quantum_and_classical_pairs_yields_expected_qir() {
 
 #[test]
 fn cx_with_multiple_classical_pairs_yields_expected_qir() {
-    let source = "M 0\nM 1\nCX rec[-1] 2 rec[-2] 3";
+    let source = indoc! {"
+        M 0
+        M 1
+        CX rec[-1] 2 rec[-2] 3
+    "};
     check(
         source,
         &expect![[r#"
@@ -325,7 +346,10 @@ fn cx_with_multiple_classical_pairs_yields_expected_qir() {
 
 #[test]
 fn cx_with_rec_on_second_target_yields_error() {
-    let source = "M 0\nCX 0 rec[-1]";
+    let source = indoc! {"
+        M 0
+        CX 0 rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -343,7 +367,10 @@ fn cx_with_rec_on_second_target_yields_error() {
 
 #[test]
 fn cx_with_negated_rec_control_yields_error() {
-    let source = "M 0\nCX !rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        CX !rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -378,7 +405,11 @@ fn cx_with_rec_control_out_of_bounds_yields_error() {
 
 #[test]
 fn cx_with_two_rec_targets_yields_error() {
-    let source = "M 0\nM 1\nCX rec[-1] rec[-2]";
+    let source = indoc! {"
+        M 0
+        M 1
+        CX rec[-1] rec[-2]
+    "};
     check(
         source,
         &expect![[r#"
@@ -397,7 +428,10 @@ fn cx_with_two_rec_targets_yields_error() {
 
 #[test]
 fn cx_with_odd_targets_including_rec_yields_error() {
-    let source = "M 0\nCX rec[-1]";
+    let source = indoc! {"
+        M 0
+        CX rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -415,7 +449,10 @@ fn cx_with_odd_targets_including_rec_yields_error() {
 
 #[test]
 fn cy_with_rec_control_yields_expected_qir() {
-    let source = "M 0\nCY rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        CY rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -467,7 +504,10 @@ fn cy_with_rec_control_yields_expected_qir() {
 
 #[test]
 fn zcy_with_rec_control_yields_expected_qir() {
-    let source = "M 0\nZCY rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        ZCY rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -519,7 +559,10 @@ fn zcy_with_rec_control_yields_expected_qir() {
 
 #[test]
 fn cy_with_rec_on_second_target_yields_error() {
-    let source = "M 0\nCY 0 rec[-1]";
+    let source = indoc! {"
+        M 0
+        CY 0 rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -537,7 +580,10 @@ fn cy_with_rec_on_second_target_yields_error() {
 
 #[test]
 fn cy_with_negated_rec_control_yields_error() {
-    let source = "M 0\nCY !rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        CY !rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -555,7 +601,10 @@ fn cy_with_negated_rec_control_yields_error() {
 
 #[test]
 fn cz_with_rec_on_first_target_yields_expected_qir() {
-    let source = "M 0\nCZ rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        CZ rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -607,7 +656,10 @@ fn cz_with_rec_on_first_target_yields_expected_qir() {
 
 #[test]
 fn cz_with_rec_on_second_target_yields_expected_qir() {
-    let source = "M 0\nCZ 0 rec[-1]";
+    let source = indoc! {"
+        M 0
+        CZ 0 rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -659,7 +711,10 @@ fn cz_with_rec_on_second_target_yields_expected_qir() {
 
 #[test]
 fn zcz_with_rec_on_first_target_yields_expected_qir() {
-    let source = "M 0\nZCZ rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        ZCZ rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -711,7 +766,10 @@ fn zcz_with_rec_on_first_target_yields_expected_qir() {
 
 #[test]
 fn zcz_with_rec_on_second_target_yields_expected_qir() {
-    let source = "M 0\nZCZ 0 rec[-1]";
+    let source = indoc! {"
+        M 0
+        ZCZ 0 rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -763,7 +821,11 @@ fn zcz_with_rec_on_second_target_yields_expected_qir() {
 
 #[test]
 fn cz_with_two_rec_targets_yields_error() {
-    let source = "M 0\nM 1\nCZ rec[-1] rec[-2]";
+    let source = indoc! {"
+        M 0
+        M 1
+        CZ rec[-1] rec[-2]
+    "};
     check(
         source,
         &expect![[r#"
@@ -782,7 +844,10 @@ fn cz_with_two_rec_targets_yields_error() {
 
 #[test]
 fn cz_with_negated_rec_on_first_target_yields_error() {
-    let source = "M 0\nCZ !rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        CZ !rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -800,7 +865,10 @@ fn cz_with_negated_rec_on_first_target_yields_error() {
 
 #[test]
 fn cz_with_negated_rec_on_second_target_yields_error() {
-    let source = "M 0\nCZ 0 !rec[-1]";
+    let source = indoc! {"
+        M 0
+        CZ 0 !rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -818,7 +886,10 @@ fn cz_with_negated_rec_on_second_target_yields_error() {
 
 #[test]
 fn xcz_with_rec_on_second_target_yields_expected_qir() {
-    let source = "M 0\nXCZ 1 rec[-1]";
+    let source = indoc! {"
+        M 0
+        XCZ 1 rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -870,7 +941,10 @@ fn xcz_with_rec_on_second_target_yields_expected_qir() {
 
 #[test]
 fn xcz_with_rec_on_first_target_yields_error() {
-    let source = "M 0\nXCZ rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        XCZ rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -888,7 +962,10 @@ fn xcz_with_rec_on_first_target_yields_error() {
 
 #[test]
 fn xcz_with_negated_rec_on_second_target_yields_error() {
-    let source = "M 0\nXCZ 1 !rec[-1]";
+    let source = indoc! {"
+        M 0
+        XCZ 1 !rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -906,7 +983,10 @@ fn xcz_with_negated_rec_on_second_target_yields_error() {
 
 #[test]
 fn ycz_with_rec_on_second_target_yields_expected_qir() {
-    let source = "M 0\nYCZ 1 rec[-1]";
+    let source = indoc! {"
+        M 0
+        YCZ 1 rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -958,7 +1038,10 @@ fn ycz_with_rec_on_second_target_yields_expected_qir() {
 
 #[test]
 fn ycz_with_rec_on_first_target_yields_error() {
-    let source = "M 0\nYCZ rec[-1] 1";
+    let source = indoc! {"
+        M 0
+        YCZ rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"
@@ -976,7 +1059,10 @@ fn ycz_with_rec_on_first_target_yields_error() {
 
 #[test]
 fn ycz_with_negated_rec_on_second_target_yields_error() {
-    let source = "M 0\nYCZ 1 !rec[-1]";
+    let source = indoc! {"
+        M 0
+        YCZ 1 !rec[-1]
+    "};
     check(
         source,
         &expect![[r#"
@@ -994,7 +1080,12 @@ fn ycz_with_negated_rec_on_second_target_yields_error() {
 
 #[test]
 fn cx_with_rec_control_crossing_prepare_boundary_yields_error() {
-    let source = "M 0\nPREPARE {\n    CX rec[-1] 1\n}";
+    let source = indoc! {"
+        M 0
+        PREPARE {
+          CX rec[-1] 1
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -1002,10 +1093,10 @@ fn cx_with_rec_control_crossing_prepare_boundary_yields_error() {
 
               x measurement record refers to a measurement outside the enclosing PREPARE
               | block
-               ,-[3:8]
+               ,-[3:6]
              2 | PREPARE {
-             3 |     CX rec[-1] 1
-               :        ^^^^^^^
+             3 |   CX rec[-1] 1
+               :      ^^^^^^^
              4 | }
                `----
         "#]],
@@ -1014,7 +1105,12 @@ fn cx_with_rec_control_crossing_prepare_boundary_yields_error() {
 
 #[test]
 fn top_level_classical_control_reaches_into_prepare() {
-    let source = "PREPARE {\n    M 0\n}\nCX rec[-1] 1";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+        }
+        CX rec[-1] 1
+    "};
     check(
         source,
         &expect![[r#"

--- a/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
@@ -1011,3 +1011,57 @@ fn cx_with_rec_control_crossing_prepare_boundary_yields_error() {
         "#]],
     );
 }
+
+#[test]
+fn top_level_classical_control_reaches_into_prepare() {
+    let source = "PREPARE {\n    M 0\n}\nCX rec[-1] 1";
+    check(
+        source,
+        &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          br label %prepare_0
+        prepare_0:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        define void @classical_control_cx(ptr %result, ptr %qubit) {
+        block_cx_entry:
+          %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+          br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+        block_cx_apply:
+          call void @__quantum__qis__x__body(ptr %qubit)
+          br label %block_cx_exit
+        block_cx_exit:
+          ret void
+        }
+
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__qis__x__body(ptr)
+        declare i1 @__quantum__rt__read_result(ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__m__body(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]],
+    );
+}

--- a/source/compiler/stim_compiler/src/qir/tests/noise_channels.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/noise_channels.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn e_yields_expected_qir() {
@@ -115,10 +116,10 @@ fn correlated_error_without_probability_yields_error() {
 
 #[test]
 fn else_correlated_error_with_preceding_correlated_error_yields_expected_qir() {
-    let source = "
-CORRELATED_ERROR(0.01) X0
-ELSE_CORRELATED_ERROR(0.02) Z0
-";
+    let source = indoc! {"
+        CORRELATED_ERROR(0.01) X0
+        ELSE_CORRELATED_ERROR(0.02) Z0
+    "};
     check(
         source,
         &expect![[r#"
@@ -165,11 +166,11 @@ ELSE_CORRELATED_ERROR(0.02) Z0
 
 #[test]
 fn correlated_error_chain_with_common_qubit_yields_expected_qir() {
-    let source = "
-CORRELATED_ERROR(0.01) X0
-ELSE_CORRELATED_ERROR(0.02) Z0 L1
-ELSE_CORRELATED_ERROR(0.03) X0 Z1 Y2
-";
+    let source = indoc! {"
+        CORRELATED_ERROR(0.01) X0
+        ELSE_CORRELATED_ERROR(0.02) Z0 L1
+        ELSE_CORRELATED_ERROR(0.03) X0 Z1 Y2
+    "};
     check(
         source,
         &expect![[r#"
@@ -217,11 +218,11 @@ ELSE_CORRELATED_ERROR(0.03) X0 Z1 Y2
 
 #[test]
 fn correlated_error_chain_with_disjoint_qubits_yields_expected_qir() {
-    let source = "
-CORRELATED_ERROR(0.01) X0
-ELSE_CORRELATED_ERROR(0.02) Z1 L2
-ELSE_CORRELATED_ERROR(0.03) Y3 Z4
-";
+    let source = indoc! {"
+        CORRELATED_ERROR(0.01) X0
+        ELSE_CORRELATED_ERROR(0.02) Z1 L2
+        ELSE_CORRELATED_ERROR(0.03) Y3 Z4
+    "};
     check(
         source,
         &expect![[r#"
@@ -269,11 +270,11 @@ ELSE_CORRELATED_ERROR(0.03) Y3 Z4
 
 #[test]
 fn else_correlated_error_with_preceding_else_correlated_error_yields_expected_qir() {
-    let source = "
-CORRELATED_ERROR(0.01) X0
-ELSE_CORRELATED_ERROR(0.02) Y0
-ELSE_CORRELATED_ERROR(0.03) Z0
-";
+    let source = indoc! {"
+        CORRELATED_ERROR(0.01) X0
+        ELSE_CORRELATED_ERROR(0.02) Y0
+        ELSE_CORRELATED_ERROR(0.03) Z0
+    "};
     check(
         source,
         &expect![[r#"
@@ -339,11 +340,35 @@ fn else_correlated_error_by_itself_yields_error() {
 
 #[test]
 fn else_correlated_error_without_preceding_correlated_error_yields_error() {
-    let source = "
-CORRELATED_ERROR(0.01) X0
-I 0
-ELSE_CORRELATED_ERROR(0.02) X0
-";
+    let source = indoc! {"
+        CORRELATED_ERROR(0.01) X0
+        I 0
+        ELSE_CORRELATED_ERROR(0.02) X0
+    "};
+    check(
+        source,
+        &expect![[r#"
+            Qdk.Stim.Compiler.OrphanedElseCorrelatedError
+
+              x else_correlated_error must be preceded by a correlated_error or
+              | else_correlated_error instruction
+               ,-[3:1]
+             2 | I 0
+             3 | ELSE_CORRELATED_ERROR(0.02) X0
+               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn else_correlated_error_without_preceding_else_correlated_error_yields_error() {
+    let source = indoc! {"
+        CORRELATED_ERROR(0.01) X0
+        ELSE_CORRELATED_ERROR(0.02) Y0
+        I 0
+        ELSE_CORRELATED_ERROR(0.02) Z0
+    "};
     check(
         source,
         &expect![[r#"
@@ -353,31 +378,7 @@ ELSE_CORRELATED_ERROR(0.02) X0
               | else_correlated_error instruction
                ,-[4:1]
              3 | I 0
-             4 | ELSE_CORRELATED_ERROR(0.02) X0
-               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-               `----
-        "#]],
-    );
-}
-
-#[test]
-fn else_correlated_error_without_preceding_else_correlated_error_yields_error() {
-    let source = "
-CORRELATED_ERROR(0.01) X0
-ELSE_CORRELATED_ERROR(0.02) Y0
-I 0
-ELSE_CORRELATED_ERROR(0.02) Z0
-";
-    check(
-        source,
-        &expect![[r#"
-            Qdk.Stim.Compiler.OrphanedElseCorrelatedError
-
-              x else_correlated_error must be preceded by a correlated_error or
-              | else_correlated_error instruction
-               ,-[5:1]
-             4 | I 0
-             5 | ELSE_CORRELATED_ERROR(0.02) Z0
+             4 | ELSE_CORRELATED_ERROR(0.02) Z0
                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                `----
         "#]],
@@ -560,38 +561,38 @@ fn heralded_pauli_channel_1_yields_expected_qir() {
 #[test]
 #[ignore = "unsupported instruction"]
 fn i_error_yields_expected_qir() {
-    let source = "
-# does nothing
-I_ERROR 0
+    let source = indoc! {"
+        # does nothing
+        I_ERROR 0
 
-# does nothing with probability 0.1, else does nothing
-I_ERROR(0.1) 0
+        # does nothing with probability 0.1, else does nothing
+        I_ERROR(0.1) 0
 
-# doesn't require a probability argument
-I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0
+        # doesn't require a probability argument
+        I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0
 
-# checks for you that the disjoint probabilities in the arguments are legal
-I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0
-";
+        # checks for you that the disjoint probabilities in the arguments are legal
+        I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0
+    "};
     check(source, &expect![[""]]);
 }
 
 #[test]
 #[ignore = "unsupported instruction"]
 fn ii_error_yields_expected_qir() {
-    let source = "
-# does nothing
-II_ERROR 0 1
+    let source = indoc! {"
+        # does nothing
+        II_ERROR 0 1
 
-# does nothing with probability 0.1, else does nothing
-II_ERROR(0.1) 0 1
+        # does nothing with probability 0.1, else does nothing
+        II_ERROR(0.1) 0 1
 
-# checks for you that the targets are two-qubit pairs
-II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
+        # checks for you that the targets are two-qubit pairs
+        II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
 
-# checks for you that the disjoint probabilities in the arguments are legal
-II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
-";
+        # checks for you that the disjoint probabilities in the arguments are legal
+        II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
+    "};
     check(source, &expect![[""]]);
 }
 

--- a/source/compiler/stim_compiler/src/qir/tests/noise_channels_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/noise_channels_broadcasting.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn depolarize1_yields_expected_qir() {
@@ -208,38 +209,38 @@ fn heralded_pauli_channel_1_yields_error() {
 #[test]
 #[ignore = "unsupported instruction"]
 fn i_error_yields_expected_qir() {
-    let source = "
-# does nothing
-I_ERROR 0 1
+    let source = indoc! {"
+        # does nothing
+        I_ERROR 0 1
 
-# does nothing with probability 0.1, else does nothing
-I_ERROR(0.1) 0 1
+        # does nothing with probability 0.1, else does nothing
+        I_ERROR(0.1) 0 1
 
-# doesn't require a probability argument
-I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4
+        # doesn't require a probability argument
+        I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4
 
-# checks for you that the disjoint probabilities in the arguments are legal
-I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0 2 4
-";
+        # checks for you that the disjoint probabilities in the arguments are legal
+        I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0 2 4
+    "};
     check(source, &expect![[""]]);
 }
 
 #[test]
 #[ignore = "unsupported instruction"]
 fn ii_error_yields_expected_qir() {
-    let source = "
-# does nothing
-II_ERROR 0 1
+    let source = indoc! {"
+        # does nothing
+        II_ERROR 0 1
 
-# does nothing with probability 0.1, else does nothing
-II_ERROR(0.1) 0 1
+        # does nothing with probability 0.1, else does nothing
+        II_ERROR(0.1) 0 1
 
-# checks for you that the targets are two-qubit pairs
-II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
+        # checks for you that the targets are two-qubit pairs
+        II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
 
-# checks for you that the disjoint probabilities in the arguments are legal
-II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
-";
+        # checks for you that the disjoint probabilities in the arguments are legal
+        II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
+    "};
     check(source, &expect![[""]]);
 }
 

--- a/source/compiler/stim_compiler/src/qir/tests/prepare_block.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/prepare_block.rs
@@ -3,17 +3,17 @@
 
 use crate::qir::tests::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn simple_prepare_block() {
     // should require result of M 0 == 0
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE rec[-1]
-}
-";
-
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -57,17 +57,17 @@ PREPARE {
 
 #[test]
 fn long_prepare_block() {
-    let source = "
-PREPARE {
-    X 0
-    M 0
-    H 1
-    X 1
-    M 1
-    M 2
-    REQUIRE rec[-1] rec[-2] rec[-3]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          X 0
+          M 0
+          H 1
+          X 1
+          M 1
+          M 2
+          REQUIRE rec[-1] rec[-2] rec[-3]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -124,14 +124,14 @@ PREPARE {
 
 #[test]
 fn multiple_requires_in_block() {
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE rec[-1]
-    M 1
-    REQUIRE rec[-1] rec[-2]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE rec[-1]
+          M 1
+          REQUIRE rec[-1] rec[-2]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -183,13 +183,13 @@ PREPARE {
 #[test]
 fn prepare_block_no_require() {
     // should compile to a QIR that works as if there was no prepare
-    let source = "
-PREPARE {
-    M 0
-    M 1
-    M 2
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          M 1
+          M 2
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -233,10 +233,10 @@ PREPARE {
 
 #[test]
 fn empty_prepare_block() {
-    let source = "
-PREPARE {
-}
-";
+    let source = indoc! {"
+        PREPARE {
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -273,23 +273,22 @@ PREPARE {
 
 #[test]
 fn prepare_block_with_args_yields_error() {
-    let source = "
-PREPARE(0.5) {
-    M 0
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE(0.5) {
+          M 0
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedArgument
 
               x unsupported argument in instruction: PREPARE
-               ,-[2:1]
-             1 | 
-             2 | PREPARE(0.5) {
+               ,-[1:1]
+             1 | PREPARE(0.5) {
                : ^^^^^^^^^^^^
-             3 |     M 0
+             2 |   M 0
                `----
         "#]],
     );
@@ -297,23 +296,22 @@ PREPARE(0.5) {
 
 #[test]
 fn prepare_block_with_targets_yields_error() {
-    let source = "
-PREPARE 0 1 {
-    M 0
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE 0 1 {
+          M 0
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedTarget
 
               x unsupported target in instruction: PREPARE
-               ,-[2:9]
-             1 | 
-             2 | PREPARE 0 1 {
+               ,-[1:9]
+             1 | PREPARE 0 1 {
                :         ^
-             3 |     M 0
+             2 |   M 0
                `----
         "#]],
     );
@@ -321,12 +319,12 @@ PREPARE 0 1 {
 
 #[test]
 fn prepare_block_with_tag() {
-    let source = "
-PREPARE[some_tag] {
-    M 0
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE[some_tag] {
+          M 0
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -370,12 +368,12 @@ PREPARE[some_tag] {
 
 #[test]
 fn require_with_negated_target() {
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE !rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE !rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -420,23 +418,23 @@ PREPARE {
 
 #[test]
 fn require_with_integer_target_yields_error() {
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE 0
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE 0
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedTarget
 
               x unsupported target in instruction: REQUIRE
-               ,-[4:13]
-             3 |     M 0
-             4 |     REQUIRE 0
-               :             ^
-             5 | }
+               ,-[3:11]
+             2 |   M 0
+             3 |   REQUIRE 0
+               :           ^
+             4 | }
                `----
         "#]],
     );
@@ -444,23 +442,23 @@ PREPARE {
 
 #[test]
 fn require_with_pauli_target_yields_error() {
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE X0
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE X0
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedTarget
 
               x unsupported target in instruction: REQUIRE
-               ,-[4:13]
-             3 |     M 0
-             4 |     REQUIRE X0
-               :             ^^
-             5 | }
+               ,-[3:11]
+             2 |   M 0
+             3 |   REQUIRE X0
+               :           ^^
+             4 | }
                `----
         "#]],
     );
@@ -468,23 +466,23 @@ PREPARE {
 
 #[test]
 fn require_with_no_targets_yields_error() {
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedTarget
 
               x unsupported target in instruction: REQUIRE
-               ,-[4:5]
-             3 |     M 0
-             4 |     REQUIRE
-               :     ^^^^^^^
-             5 | }
+               ,-[3:3]
+             2 |   M 0
+             3 |   REQUIRE
+               :   ^^^^^^^
+             4 | }
                `----
         "#]],
     );
@@ -492,18 +490,15 @@ PREPARE {
 
 #[test]
 fn require_no_prepare_block_yields_error() {
-    let source = "
-REQUIRE rec[-1]
-";
+    let source = "REQUIRE rec[-1]";
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.RequireOutsidePrepareBlock
 
               x require must appear inside a PREPARE block
-               ,-[2:1]
-             1 | 
-             2 | REQUIRE rec[-1]
+               ,----
+             1 | REQUIRE rec[-1]
                : ^^^^^^^^^^^^^^^
                `----
         "#]],
@@ -512,22 +507,22 @@ REQUIRE rec[-1]
 
 #[test]
 fn require_with_no_measurements_yields_error() {
-    let source = "
-PREPARE {
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfBounds
 
               x measurement record is out of bounds
-               ,-[3:13]
-             2 | PREPARE {
-             3 |     REQUIRE rec[-1]
-               :             ^^^^^^^
-             4 | }
+               ,-[2:11]
+             1 | PREPARE {
+             2 |   REQUIRE rec[-1]
+               :           ^^^^^^^
+             3 | }
                `----
         "#]],
     );
@@ -535,23 +530,23 @@ PREPARE {
 
 #[test]
 fn require_before_measurement_yields_error() {
-    let source = "
-PREPARE {
-    REQUIRE rec[-1]
-    M 0
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          REQUIRE rec[-1]
+          M 0
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfBounds
 
               x measurement record is out of bounds
-               ,-[3:13]
-             2 | PREPARE {
-             3 |     REQUIRE rec[-1]
-               :             ^^^^^^^
-             4 |     M 0
+               ,-[2:11]
+             1 | PREPARE {
+             2 |   REQUIRE rec[-1]
+               :           ^^^^^^^
+             3 |   M 0
                `----
         "#]],
     );
@@ -559,23 +554,23 @@ PREPARE {
 
 #[test]
 fn rec_index_out_of_bounds() {
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE rec[-2]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE rec[-2]
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfBounds
 
               x measurement record is out of bounds
-               ,-[4:13]
-             3 |     M 0
-             4 |     REQUIRE rec[-2]
-               :             ^^^^^^^
-             5 | }
+               ,-[3:11]
+             2 |   M 0
+             3 |   REQUIRE rec[-2]
+               :           ^^^^^^^
+             4 | }
                `----
         "#]],
     );
@@ -583,13 +578,13 @@ PREPARE {
 
 #[test]
 fn rec_index_out_of_scope() {
-    let source = "
-M 0
-PREPARE {
-    M 1
-    REQUIRE rec[-2]
-}
-";
+    let source = indoc! {"
+        M 0
+        PREPARE {
+          M 1
+          REQUIRE rec[-2]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -597,11 +592,11 @@ PREPARE {
 
               x measurement record refers to a measurement outside the enclosing PREPARE
               | block
-               ,-[5:13]
-             4 |     M 1
-             5 |     REQUIRE rec[-2]
-               :             ^^^^^^^
-             6 | }
+               ,-[4:11]
+             3 |   M 1
+             4 |   REQUIRE rec[-2]
+               :           ^^^^^^^
+             5 | }
                `----
         "#]],
     );
@@ -610,23 +605,23 @@ PREPARE {
 #[test]
 fn reset_does_not_count_as_measurement() {
     // R does not produce a measurement record, so rec[-1] should be out of bounds.
-    let source = "
-PREPARE {
-    R 0
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          R 0
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfBounds
 
               x measurement record is out of bounds
-               ,-[4:13]
-             3 |     R 0
-             4 |     REQUIRE rec[-1]
-               :             ^^^^^^^
-             5 | }
+               ,-[3:11]
+             2 |   R 0
+             3 |   REQUIRE rec[-1]
+               :           ^^^^^^^
+             4 | }
                `----
         "#]],
     );
@@ -635,12 +630,12 @@ PREPARE {
 #[test]
 fn measure_reset_counts_as_measurement() {
     // MR produces a measurement record.
-    let source = "
-PREPARE {
-    MR 0
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          MR 0
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -684,12 +679,12 @@ PREPARE {
 
 #[test]
 fn pair_measurement_record_in_prepare() {
-    let source = "
-PREPARE {
-    MZZ 0 1
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          MZZ 0 1
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -738,23 +733,23 @@ PREPARE {
 fn pair_measurement_record_in_prepare_out_of_bounds() {
     // A two-qubit measurement produces a single measurement record.
     // So this should not be valid
-    let source = "
-PREPARE {
-    MZZ 0 1
-    REQUIRE rec[-1] rec[-2]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          MZZ 0 1
+          REQUIRE rec[-1] rec[-2]
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfBounds
 
               x measurement record is out of bounds
-               ,-[4:21]
-             3 |     MZZ 0 1
-             4 |     REQUIRE rec[-1] rec[-2]
-               :                     ^^^^^^^
-             5 | }
+               ,-[3:19]
+             2 |   MZZ 0 1
+             3 |   REQUIRE rec[-1] rec[-2]
+               :                   ^^^^^^^
+             4 | }
                `----
         "#]],
     );
@@ -762,16 +757,16 @@ PREPARE {
 
 #[test]
 fn nested_prepare_blocks() {
-    let source = "
-PREPARE {
-    PREPARE {
-        M 0
-        REQUIRE rec[-1]
-    }
-    M 1
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          PREPARE {
+            M 0
+            REQUIRE rec[-1]
+          }
+          M 1
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -822,20 +817,20 @@ PREPARE {
 
 #[test]
 fn deeply_nested_prepare_blocks() {
-    let source = "
-PREPARE {
-    PREPARE {
+    let source = indoc! {"
         PREPARE {
-            M 0
+          PREPARE {
+            PREPARE {
+              M 0
+              REQUIRE rec[-1]
+            }
+            M 1
             REQUIRE rec[-1]
+          }
+          M 2
+          REQUIRE rec[-1]
         }
-        M 1
-        REQUIRE rec[-1]
-    }
-    M 2
-    REQUIRE rec[-1]
-}
-";
+    "};
     check(
         source,
         &expect![[r#"
@@ -893,14 +888,14 @@ PREPARE {
 
 #[test]
 fn outer_prepare_reaches_into_inner_prepare() {
-    let source = "
-PREPARE {
-    PREPARE {
-        M 0
-    }
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          PREPARE {
+            M 0
+          }
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -946,16 +941,16 @@ PREPARE {
 
 #[test]
 fn outer_prepare_reaches_into_deeply_nested_inner_prepare() {
-    let source = "
-PREPARE {
-    PREPARE {
+    let source = indoc! {"
         PREPARE {
-            M 0
+          PREPARE {
+            PREPARE {
+              M 0
+            }
+          }
+          REQUIRE rec[-1]
         }
-    }
-    REQUIRE rec[-1]
-}
-";
+    "};
     check(
         source,
         &expect![[r#"
@@ -1003,14 +998,14 @@ PREPARE {
 
 #[test]
 fn inner_prepare_reaches_into_outer_prepare_yields_error() {
-    let source = "
-PREPARE {
-    M 0
-    PREPARE {
-        REQUIRE rec[-1]
-    }
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          PREPARE {
+            REQUIRE rec[-1]
+          }
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -1018,11 +1013,11 @@ PREPARE {
 
               x measurement record refers to a measurement outside the enclosing PREPARE
               | block
-               ,-[5:17]
-             4 |     PREPARE {
-             5 |         REQUIRE rec[-1]
-               :                 ^^^^^^^
-             6 |     }
+               ,-[4:13]
+             3 |   PREPARE {
+             4 |     REQUIRE rec[-1]
+               :             ^^^^^^^
+             5 |   }
                `----
         "#]],
     );
@@ -1030,16 +1025,16 @@ PREPARE {
 
 #[test]
 fn sibling_prepare_blocks() {
-    let source = "
-PREPARE {
-    M 0
-    REQUIRE rec[-1]
-}
-PREPARE {
-    M 1
-    REQUIRE rec[-1]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+          REQUIRE rec[-1]
+        }
+        PREPARE {
+          M 1
+          REQUIRE rec[-1]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -1090,15 +1085,15 @@ PREPARE {
 
 #[test]
 fn sibling_prepare_block_cannot_require_previous_block_measurement_yields_error() {
-    let source = "
-PREPARE {
-    M 0
-}
-PREPARE {
-    M 1
-    REQUIRE rec[-2]
-}
-";
+    let source = indoc! {"
+        PREPARE {
+          M 0
+        }
+        PREPARE {
+          M 1
+          REQUIRE rec[-2]
+        }
+    "};
     check(
         source,
         &expect![[r#"
@@ -1106,11 +1101,11 @@ PREPARE {
 
               x measurement record refers to a measurement outside the enclosing PREPARE
               | block
-               ,-[7:13]
-             6 |     M 1
-             7 |     REQUIRE rec[-2]
-               :             ^^^^^^^
-             8 | }
+               ,-[6:11]
+             5 |   M 1
+             6 |   REQUIRE rec[-2]
+               :           ^^^^^^^
+             7 | }
                `----
         "#]],
     );
@@ -1118,22 +1113,22 @@ PREPARE {
 
 #[test]
 fn blockless_prepare_yields_error() {
-    let source = "
-X 0
-PREPARE
-M 0
-";
+    let source = indoc! {"
+        X 0
+        PREPARE
+        M 0
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.PrepareWithoutBlock
 
               x prepare instruction must start a block
-               ,-[3:1]
-             2 | X 0
-             3 | PREPARE
+               ,-[2:1]
+             1 | X 0
+             2 | PREPARE
                : ^^^^^^^
-             4 | M 0
+             3 | M 0
                `----
         "#]],
     );

--- a/source/compiler/stim_compiler/src/qir/tests/prepare_block.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/prepare_block.rs
@@ -892,7 +892,7 @@ PREPARE {
 }
 
 #[test]
-fn outer_prepare_reaches_into_inner_prepare_yields_error() {
+fn outer_prepare_reaches_into_inner_prepare() {
     let source = "
 PREPARE {
     PREPARE {
@@ -904,17 +904,100 @@ PREPARE {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.MeasurementRecordOutOfScope
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          br label %prepare_0
+        prepare_0:
+          br label %prepare_1
+        prepare_1:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+          br i1 %r_0, label %prepare_0, label %continue_0
+        continue_0:
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
 
-              x measurement record refers to a measurement outside the enclosing PREPARE
-              | block
-               ,-[6:13]
-             5 |     }
-             6 |     REQUIRE rec[-1]
-               :             ^^^^^^^
-             7 | }
-               `----
-        "#]],
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare i1 @__quantum__rt__read_result(ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__m__body(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]],
+    );
+}
+
+#[test]
+fn outer_prepare_reaches_into_deeply_nested_inner_prepare() {
+    let source = "
+PREPARE {
+    PREPARE {
+        PREPARE {
+            M 0
+        }
+    }
+    REQUIRE rec[-1]
+}
+";
+    check(
+        source,
+        &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          br label %prepare_0
+        prepare_0:
+          br label %prepare_1
+        prepare_1:
+          br label %prepare_2
+        prepare_2:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+          br i1 %r_0, label %prepare_0, label %continue_0
+        continue_0:
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare i1 @__quantum__rt__read_result(ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__m__body(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]],
     );
 }
 

--- a/source/compiler/stim_compiler/src/qir/tests/select_block.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/select_block.rs
@@ -6,10 +6,10 @@ use expect_test::expect;
 use indoc::indoc;
 
 #[test]
-fn simple_prepare_block() {
+fn simple_select_block() {
     // should require result of M 0 == 0
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE rec[-1]
         }
@@ -19,11 +19,11 @@ fn simple_prepare_block() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %prepare_0, label %continue_0
+              br i1 %r_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -56,9 +56,9 @@ fn simple_prepare_block() {
 }
 
 #[test]
-fn long_prepare_block() {
+fn long_select_block() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           X 0
           M 0
           H 1
@@ -73,8 +73,8 @@ fn long_prepare_block() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
@@ -86,7 +86,7 @@ fn long_prepare_block() {
               %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
               %x_0 = xor i1 %r_0, %r_1
               %x_1 = xor i1 %x_0, %r_2
-              br i1 %x_1, label %prepare_0, label %continue_0
+              br i1 %x_1, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 3, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -125,7 +125,7 @@ fn long_prepare_block() {
 #[test]
 fn multiple_requires_in_block() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE rec[-1]
           M 1
@@ -137,17 +137,17 @@ fn multiple_requires_in_block() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %prepare_0, label %continue_0
+              br i1 %r_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
               %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
               %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
               %x_0 = xor i1 %r_1, %r_2
-              br i1 %x_0, label %prepare_0, label %continue_1
+              br i1 %x_0, label %select_0, label %continue_1
             continue_1:
               call void @__quantum__rt__array_record_output(i64 2, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -181,10 +181,10 @@ fn multiple_requires_in_block() {
 }
 
 #[test]
-fn prepare_block_no_require() {
-    // should compile to a QIR that works as if there was no prepare
+fn select_block_no_require() {
+    // should compile to a QIR that works as if there was no select
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           M 1
           M 2
@@ -195,8 +195,8 @@ fn prepare_block_no_require() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
               call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
@@ -232,9 +232,9 @@ fn prepare_block_no_require() {
 }
 
 #[test]
-fn empty_prepare_block() {
+fn empty_select_block() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
         }
     "};
     check(
@@ -242,8 +242,8 @@ fn empty_prepare_block() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__rt__array_record_output(i64 0, ptr null)
               ret i64 0
             }
@@ -272,9 +272,9 @@ fn empty_prepare_block() {
 }
 
 #[test]
-fn prepare_block_with_args_yields_error() {
+fn select_block_with_args_yields_error() {
     let source = indoc! {"
-        PREPARE(0.5) {
+        SELECT(0.5) {
           M 0
           REQUIRE rec[-1]
         }
@@ -284,10 +284,10 @@ fn prepare_block_with_args_yields_error() {
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedArgument
 
-              x unsupported argument in instruction: PREPARE
+              x unsupported argument in instruction: SELECT
                ,-[1:1]
-             1 | PREPARE(0.5) {
-               : ^^^^^^^^^^^^
+             1 | SELECT(0.5) {
+               : ^^^^^^^^^^^
              2 |   M 0
                `----
         "#]],
@@ -295,9 +295,9 @@ fn prepare_block_with_args_yields_error() {
 }
 
 #[test]
-fn prepare_block_with_targets_yields_error() {
+fn select_block_with_targets_yields_error() {
     let source = indoc! {"
-        PREPARE 0 1 {
+        SELECT 0 1 {
           M 0
           REQUIRE rec[-1]
         }
@@ -307,10 +307,10 @@ fn prepare_block_with_targets_yields_error() {
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedTarget
 
-              x unsupported target in instruction: PREPARE
-               ,-[1:9]
-             1 | PREPARE 0 1 {
-               :         ^
+              x unsupported target in instruction: SELECT
+               ,-[1:8]
+             1 | SELECT 0 1 {
+               :        ^
              2 |   M 0
                `----
         "#]],
@@ -318,9 +318,9 @@ fn prepare_block_with_targets_yields_error() {
 }
 
 #[test]
-fn prepare_block_with_tag() {
+fn select_block_with_tag() {
     let source = indoc! {"
-        PREPARE[some_tag] {
+        SELECT[some_tag] {
           M 0
           REQUIRE rec[-1]
         }
@@ -330,11 +330,11 @@ fn prepare_block_with_tag() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %prepare_0, label %continue_0
+              br i1 %r_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -369,7 +369,7 @@ fn prepare_block_with_tag() {
 #[test]
 fn require_with_negated_target() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE !rec[-1]
         }
@@ -379,12 +379,12 @@ fn require_with_negated_target() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
               %r_1 = xor i1 %r_0, true
-              br i1 %r_1, label %prepare_0, label %continue_0
+              br i1 %r_1, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -419,7 +419,7 @@ fn require_with_negated_target() {
 #[test]
 fn require_with_integer_target_yields_error() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE 0
         }
@@ -443,7 +443,7 @@ fn require_with_integer_target_yields_error() {
 #[test]
 fn require_with_pauli_target_yields_error() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE X0
         }
@@ -467,7 +467,7 @@ fn require_with_pauli_target_yields_error() {
 #[test]
 fn require_with_no_targets_yields_error() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE
         }
@@ -489,14 +489,14 @@ fn require_with_no_targets_yields_error() {
 }
 
 #[test]
-fn require_no_prepare_block_yields_error() {
+fn require_no_select_block_yields_error() {
     let source = "REQUIRE rec[-1]";
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.RequireOutsidePrepareBlock
+            Qdk.Stim.Compiler.RequireOutsideSelectBlock
 
-              x require must appear inside a PREPARE block
+              x require must appear inside a SELECT block
                ,----
              1 | REQUIRE rec[-1]
                : ^^^^^^^^^^^^^^^
@@ -508,7 +508,7 @@ fn require_no_prepare_block_yields_error() {
 #[test]
 fn require_with_no_measurements_yields_error() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           REQUIRE rec[-1]
         }
     "};
@@ -519,7 +519,7 @@ fn require_with_no_measurements_yields_error() {
 
               x measurement record is out of bounds
                ,-[2:11]
-             1 | PREPARE {
+             1 | SELECT {
              2 |   REQUIRE rec[-1]
                :           ^^^^^^^
              3 | }
@@ -531,7 +531,7 @@ fn require_with_no_measurements_yields_error() {
 #[test]
 fn require_before_measurement_yields_error() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           REQUIRE rec[-1]
           M 0
         }
@@ -543,7 +543,7 @@ fn require_before_measurement_yields_error() {
 
               x measurement record is out of bounds
                ,-[2:11]
-             1 | PREPARE {
+             1 | SELECT {
              2 |   REQUIRE rec[-1]
                :           ^^^^^^^
              3 |   M 0
@@ -555,7 +555,7 @@ fn require_before_measurement_yields_error() {
 #[test]
 fn rec_index_out_of_bounds() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE rec[-2]
         }
@@ -580,7 +580,7 @@ fn rec_index_out_of_bounds() {
 fn rec_index_out_of_scope() {
     let source = indoc! {"
         M 0
-        PREPARE {
+        SELECT {
           M 1
           REQUIRE rec[-2]
         }
@@ -590,7 +590,7 @@ fn rec_index_out_of_scope() {
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfScope
 
-              x measurement record refers to a measurement outside the enclosing PREPARE
+              x measurement record refers to a measurement outside the enclosing SELECT
               | block
                ,-[4:11]
              3 |   M 1
@@ -606,7 +606,7 @@ fn rec_index_out_of_scope() {
 fn reset_does_not_count_as_measurement() {
     // R does not produce a measurement record, so rec[-1] should be out of bounds.
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           R 0
           REQUIRE rec[-1]
         }
@@ -631,7 +631,7 @@ fn reset_does_not_count_as_measurement() {
 fn measure_reset_counts_as_measurement() {
     // MR produces a measurement record.
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           MR 0
           REQUIRE rec[-1]
         }
@@ -641,11 +641,11 @@ fn measure_reset_counts_as_measurement() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %prepare_0, label %continue_0
+              br i1 %r_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -678,9 +678,9 @@ fn measure_reset_counts_as_measurement() {
 }
 
 #[test]
-fn pair_measurement_record_in_prepare() {
+fn pair_measurement_record_in_select() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           MZZ 0 1
           REQUIRE rec[-1]
         }
@@ -690,13 +690,13 @@ fn pair_measurement_record_in_prepare() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
+              br label %select_0
+            select_0:
               call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
               call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %prepare_0, label %continue_0
+              br i1 %r_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -730,11 +730,11 @@ fn pair_measurement_record_in_prepare() {
 }
 
 #[test]
-fn pair_measurement_record_in_prepare_out_of_bounds() {
+fn pair_measurement_record_in_select_out_of_bounds() {
     // A two-qubit measurement produces a single measurement record.
     // So this should not be valid
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           MZZ 0 1
           REQUIRE rec[-1] rec[-2]
         }
@@ -756,10 +756,10 @@ fn pair_measurement_record_in_prepare_out_of_bounds() {
 }
 
 #[test]
-fn nested_prepare_blocks() {
+fn nested_select_blocks() {
     let source = indoc! {"
-        PREPARE {
-          PREPARE {
+        SELECT {
+          SELECT {
             M 0
             REQUIRE rec[-1]
           }
@@ -772,17 +772,17 @@ fn nested_prepare_blocks() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
-              br label %prepare_1
-            prepare_1:
+              br label %select_0
+            select_0:
+              br label %select_1
+            select_1:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %prepare_1, label %continue_0
+              br i1 %r_0, label %select_1, label %continue_0
             continue_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
               %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              br i1 %r_1, label %prepare_0, label %continue_1
+              br i1 %r_1, label %select_0, label %continue_1
             continue_1:
               call void @__quantum__rt__array_record_output(i64 2, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -816,11 +816,11 @@ fn nested_prepare_blocks() {
 }
 
 #[test]
-fn deeply_nested_prepare_blocks() {
+fn deeply_nested_select_blocks() {
     let source = indoc! {"
-        PREPARE {
-          PREPARE {
-            PREPARE {
+        SELECT {
+          SELECT {
+            SELECT {
               M 0
               REQUIRE rec[-1]
             }
@@ -836,23 +836,23 @@ fn deeply_nested_prepare_blocks() {
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              br label %prepare_0
-            prepare_0:
-              br label %prepare_1
-            prepare_1:
-              br label %prepare_2
-            prepare_2:
+              br label %select_0
+            select_0:
+              br label %select_1
+            select_1:
+              br label %select_2
+            select_2:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %prepare_2, label %continue_0
+              br i1 %r_0, label %select_2, label %continue_0
             continue_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
               %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              br i1 %r_1, label %prepare_1, label %continue_1
+              br i1 %r_1, label %select_1, label %continue_1
             continue_1:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
               %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-              br i1 %r_2, label %prepare_0, label %continue_2
+              br i1 %r_2, label %select_0, label %continue_2
             continue_2:
               call void @__quantum__rt__array_record_output(i64 3, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -887,10 +887,10 @@ fn deeply_nested_prepare_blocks() {
 }
 
 #[test]
-fn outer_prepare_reaches_into_inner_prepare() {
+fn outer_select_reaches_into_inner_select() {
     let source = indoc! {"
-        PREPARE {
-          PREPARE {
+        SELECT {
+          SELECT {
             M 0
           }
           REQUIRE rec[-1]
@@ -901,13 +901,13 @@ fn outer_prepare_reaches_into_inner_prepare() {
         &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
-          br label %prepare_0
-        prepare_0:
-          br label %prepare_1
-        prepare_1:
+          br label %select_0
+        select_0:
+          br label %select_1
+        select_1:
           call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
           %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          br i1 %r_0, label %prepare_0, label %continue_0
+          br i1 %r_0, label %select_0, label %continue_0
         continue_0:
           call void @__quantum__rt__array_record_output(i64 1, ptr null)
           call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -940,11 +940,11 @@ fn outer_prepare_reaches_into_inner_prepare() {
 }
 
 #[test]
-fn outer_prepare_reaches_into_deeply_nested_inner_prepare() {
+fn outer_select_reaches_into_deeply_nested_inner_select() {
     let source = indoc! {"
-        PREPARE {
-          PREPARE {
-            PREPARE {
+        SELECT {
+          SELECT {
+            SELECT {
               M 0
             }
           }
@@ -956,15 +956,15 @@ fn outer_prepare_reaches_into_deeply_nested_inner_prepare() {
         &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
-          br label %prepare_0
-        prepare_0:
-          br label %prepare_1
-        prepare_1:
-          br label %prepare_2
-        prepare_2:
+          br label %select_0
+        select_0:
+          br label %select_1
+        select_1:
+          br label %select_2
+        select_2:
           call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
           %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          br i1 %r_0, label %prepare_0, label %continue_0
+          br i1 %r_0, label %select_0, label %continue_0
         continue_0:
           call void @__quantum__rt__array_record_output(i64 1, ptr null)
           call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -997,11 +997,11 @@ fn outer_prepare_reaches_into_deeply_nested_inner_prepare() {
 }
 
 #[test]
-fn inner_prepare_reaches_into_outer_prepare_yields_error() {
+fn inner_select_reaches_into_outer_select_yields_error() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
-          PREPARE {
+          SELECT {
             REQUIRE rec[-1]
           }
         }
@@ -1011,10 +1011,10 @@ fn inner_prepare_reaches_into_outer_prepare_yields_error() {
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfScope
 
-              x measurement record refers to a measurement outside the enclosing PREPARE
+              x measurement record refers to a measurement outside the enclosing SELECT
               | block
                ,-[4:13]
-             3 |   PREPARE {
+             3 |   SELECT {
              4 |     REQUIRE rec[-1]
                :             ^^^^^^^
              5 |   }
@@ -1024,13 +1024,13 @@ fn inner_prepare_reaches_into_outer_prepare_yields_error() {
 }
 
 #[test]
-fn sibling_prepare_blocks() {
+fn sibling_select_blocks() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
           REQUIRE rec[-1]
         }
-        PREPARE {
+        SELECT {
           M 1
           REQUIRE rec[-1]
         }
@@ -1040,17 +1040,17 @@ fn sibling_prepare_blocks() {
         &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
-          br label %prepare_0
-        prepare_0:
+          br label %select_0
+        select_0:
           call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
           %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          br i1 %r_0, label %prepare_0, label %continue_0
+          br i1 %r_0, label %select_0, label %continue_0
         continue_0:
-          br label %prepare_1
-        prepare_1:
+          br label %select_1
+        select_1:
           call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
           %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-          br i1 %r_1, label %prepare_1, label %continue_1
+          br i1 %r_1, label %select_1, label %continue_1
         continue_1:
           call void @__quantum__rt__array_record_output(i64 2, ptr null)
           call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -1084,12 +1084,12 @@ fn sibling_prepare_blocks() {
 }
 
 #[test]
-fn sibling_prepare_block_cannot_require_previous_block_measurement_yields_error() {
+fn sibling_select_block_cannot_require_previous_block_measurement_yields_error() {
     let source = indoc! {"
-        PREPARE {
+        SELECT {
           M 0
         }
-        PREPARE {
+        SELECT {
           M 1
           REQUIRE rec[-2]
         }
@@ -1099,7 +1099,7 @@ fn sibling_prepare_block_cannot_require_previous_block_measurement_yields_error(
         &expect![[r#"
             Qdk.Stim.Compiler.MeasurementRecordOutOfScope
 
-              x measurement record refers to a measurement outside the enclosing PREPARE
+              x measurement record refers to a measurement outside the enclosing SELECT
               | block
                ,-[6:11]
              5 |   M 1
@@ -1112,22 +1112,22 @@ fn sibling_prepare_block_cannot_require_previous_block_measurement_yields_error(
 }
 
 #[test]
-fn blockless_prepare_yields_error() {
+fn blockless_select_yields_error() {
     let source = indoc! {"
         X 0
-        PREPARE
+        SELECT
         M 0
     "};
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.PrepareWithoutBlock
+            Qdk.Stim.Compiler.SelectWithoutBlock
 
-              x prepare instruction must start a block
+              x select instruction must start a block
                ,-[2:1]
              1 | X 0
-             2 | PREPARE
-               : ^^^^^^^
+             2 | SELECT
+               : ^^^^^^
              3 | M 0
                `----
         "#]],

--- a/source/compiler/stim_compiler/src/qir/tests/unsupported_instructions.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/unsupported_instructions.rs
@@ -3,6 +3,7 @@
 
 use super::check;
 use expect_test::expect;
+use indoc::indoc;
 
 #[test]
 fn heralded_erase_yields_unsupported_error() {
@@ -40,58 +41,58 @@ fn heralded_pauli_channel_1_yields_unsupported_error() {
 
 #[test]
 fn i_error_yields_unsupported_error() {
-    let source = "
-# does nothing
-I_ERROR 0
+    let source = indoc! {"
+        # does nothing
+        I_ERROR 0
 
-# does nothing with probability 0.1, else does nothing
-I_ERROR(0.1) 0
+        # does nothing with probability 0.1, else does nothing
+        I_ERROR(0.1) 0
 
-# doesn't require a probability argument
-I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0
+        # doesn't require a probability argument
+        I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0
 
-# checks for you that the disjoint probabilities in the arguments are legal
-I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0
-";
+        # checks for you that the disjoint probabilities in the arguments are legal
+        I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: I_ERROR
-               ,-[3:1]
-             2 | # does nothing
-             3 | I_ERROR 0
+               ,-[2:1]
+             1 | # does nothing
+             2 | I_ERROR 0
                : ^^^^^^^^^
-             4 | 
+             3 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: I_ERROR
-               ,-[6:1]
-             5 | # does nothing with probability 0.1, else does nothing
-             6 | I_ERROR(0.1) 0
+               ,-[5:1]
+             4 | # does nothing with probability 0.1, else does nothing
+             5 | I_ERROR(0.1) 0
                : ^^^^^^^^^^^^^^
-             7 | 
+             6 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: I_ERROR
-                ,-[9:1]
-              8 | # doesn't require a probability argument
-              9 | I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0
-                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             10 | 
-                `----
+               ,-[8:1]
+             7 | # doesn't require a probability argument
+             8 | I_ERROR[LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0
+               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             9 | 
+               `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: I_ERROR
-                ,-[12:1]
-             11 | # checks for you that the disjoint probabilities in the arguments are legal
-             12 | I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0
+                ,-[11:1]
+             10 | # checks for you that the disjoint probabilities in the arguments are legal
+             11 | I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0
                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 `----
         "#]],
@@ -100,58 +101,58 @@ I_ERROR[MULTIPLE_NOISE_MECHANISMS](0.1, 0.2) 0
 
 #[test]
 fn ii_error_yields_unsupported_error() {
-    let source = "
-# does nothing
-II_ERROR 0 1
+    let source = indoc! {"
+        # does nothing
+        II_ERROR 0 1
 
-# does nothing with probability 0.1, else does nothing
-II_ERROR(0.1) 0 1
+        # does nothing with probability 0.1, else does nothing
+        II_ERROR(0.1) 0 1
 
-# checks for you that the targets are two-qubit pairs
-II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
+        # checks for you that the targets are two-qubit pairs
+        II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
 
-# checks for you that the disjoint probabilities in the arguments are legal
-II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
-";
+        # checks for you that the disjoint probabilities in the arguments are legal
+        II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: II_ERROR
-               ,-[3:1]
-             2 | # does nothing
-             3 | II_ERROR 0 1
+               ,-[2:1]
+             1 | # does nothing
+             2 | II_ERROR 0 1
                : ^^^^^^^^^^^^
-             4 | 
+             3 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: II_ERROR
-               ,-[6:1]
-             5 | # does nothing with probability 0.1, else does nothing
-             6 | II_ERROR(0.1) 0 1
+               ,-[5:1]
+             4 | # does nothing with probability 0.1, else does nothing
+             5 | II_ERROR(0.1) 0 1
                : ^^^^^^^^^^^^^^^^^
-             7 | 
+             6 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: II_ERROR
-                ,-[9:1]
-              8 | # checks for you that the targets are two-qubit pairs
-              9 | II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
-                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             10 | 
-                `----
+               ,-[8:1]
+             7 | # checks for you that the targets are two-qubit pairs
+             8 | II_ERROR[TWO_QUBIT_LEAKAGE_NOISE_FOR_AN_ADVANCED_SIMULATOR:0.1] 0 2 4 6
+               : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             9 | 
+               `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: II_ERROR
-                ,-[12:1]
-             11 | # checks for you that the disjoint probabilities in the arguments are legal
-             12 | II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
+                ,-[11:1]
+             10 | # checks for you that the disjoint probabilities in the arguments are legal
+             11 | II_ERROR[MULTIPLE_TWO_QUBIT_NOISE_MECHANISMS](0.1, 0.2) 0 2 4 6
                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 `----
         "#]],
@@ -194,58 +195,58 @@ fn pauli_channel_2_yields_unsupported_error() {
 
 #[test]
 fn mpp_yields_unsupported_error() {
-    let source = "
-# Measure the two-body +X1*Y2 observable.
-MPP X1*Y2
+    let source = indoc! {"
+        # Measure the two-body +X1*Y2 observable.
+        MPP X1*Y2
 
-# Measure the one-body -Z5 observable.
-MPP !Z5
+        # Measure the one-body -Z5 observable.
+        MPP !Z5
 
-# Measure the two-body +X1*Y2 observable and also the three-body -Z3*Z4*Z5 observable.
-MPP X1*Y2 !Z3*Z4*Z5
+        # Measure the two-body +X1*Y2 observable and also the three-body -Z3*Z4*Z5 observable.
+        MPP X1*Y2 !Z3*Z4*Z5
 
-# Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
-MPP(0.001) Z1*Z2 X1*X2
-";
+        # Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
+        MPP(0.001) Z1*Z2 X1*X2
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: MPP
-               ,-[3:1]
-             2 | # Measure the two-body +X1*Y2 observable.
-             3 | MPP X1*Y2
+               ,-[2:1]
+             1 | # Measure the two-body +X1*Y2 observable.
+             2 | MPP X1*Y2
                : ^^^^^^^^^
-             4 | 
+             3 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: MPP
-               ,-[6:1]
-             5 | # Measure the one-body -Z5 observable.
-             6 | MPP !Z5
+               ,-[5:1]
+             4 | # Measure the one-body -Z5 observable.
+             5 | MPP !Z5
                : ^^^^^^^
-             7 | 
+             6 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: MPP
-                ,-[9:1]
-              8 | # Measure the two-body +X1*Y2 observable and also the three-body -Z3*Z4*Z5 observable.
-              9 | MPP X1*Y2 !Z3*Z4*Z5
-                : ^^^^^^^^^^^^^^^^^^^
-             10 | 
-                `----
+               ,-[8:1]
+             7 | # Measure the two-body +X1*Y2 observable and also the three-body -Z3*Z4*Z5 observable.
+             8 | MPP X1*Y2 !Z3*Z4*Z5
+               : ^^^^^^^^^^^^^^^^^^^
+             9 | 
+               `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: MPP
-                ,-[12:1]
-             11 | # Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
-             12 | MPP(0.001) Z1*Z2 X1*X2
+                ,-[11:1]
+             10 | # Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
+             11 | MPP(0.001) Z1*Z2 X1*X2
                 : ^^^^^^^^^^^^^^^^^^^^^^
                 `----
         "#]],
@@ -254,84 +255,84 @@ MPP(0.001) Z1*Z2 X1*X2
 
 #[test]
 fn spp_yields_unsupported_error() {
-    let source = "
-# Perform an S gate on qubit 1.
-SPP Z1
+    let source = indoc! {"
+        # Perform an S gate on qubit 1.
+        SPP Z1
 
-# Perform a SQRT_X gate on qubit 1.
-SPP X1
+        # Perform a SQRT_X gate on qubit 1.
+        SPP X1
 
-# Perform a SQRT_X_DAG gate on qubit 1.
-SPP !X1
+        # Perform a SQRT_X_DAG gate on qubit 1.
+        SPP !X1
 
-# Perform a SQRT_XX gate between qubit 1 and qubit 2.
-SPP X1*X2
+        # Perform a SQRT_XX gate between qubit 1 and qubit 2.
+        SPP X1*X2
 
-# Perform a SQRT_YY gate between qubit 1 and 2, and a SQRT_ZZ_DAG between qubit 3 and 4.
-SPP Y1*Y2 !Z1*Z2
+        # Perform a SQRT_YY gate between qubit 1 and 2, and a SQRT_ZZ_DAG between qubit 3 and 4.
+        SPP Y1*Y2 !Z1*Z2
 
-# Phase the -1 eigenspace of -X1*Y2*Z3 by i.
-SPP !X1*Y2*Z3
-";
+        # Phase the -1 eigenspace of -X1*Y2*Z3 by i.
+        SPP !X1*Y2*Z3
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP
-               ,-[3:1]
-             2 | # Perform an S gate on qubit 1.
-             3 | SPP Z1
+               ,-[2:1]
+             1 | # Perform an S gate on qubit 1.
+             2 | SPP Z1
                : ^^^^^^
-             4 | 
+             3 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP
-               ,-[6:1]
-             5 | # Perform a SQRT_X gate on qubit 1.
-             6 | SPP X1
+               ,-[5:1]
+             4 | # Perform a SQRT_X gate on qubit 1.
+             5 | SPP X1
                : ^^^^^^
-             7 | 
+             6 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP
-                ,-[9:1]
-              8 | # Perform a SQRT_X_DAG gate on qubit 1.
-              9 | SPP !X1
-                : ^^^^^^^
-             10 | 
-                `----
+               ,-[8:1]
+             7 | # Perform a SQRT_X_DAG gate on qubit 1.
+             8 | SPP !X1
+               : ^^^^^^^
+             9 | 
+               `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP
-                ,-[12:1]
-             11 | # Perform a SQRT_XX gate between qubit 1 and qubit 2.
-             12 | SPP X1*X2
+                ,-[11:1]
+             10 | # Perform a SQRT_XX gate between qubit 1 and qubit 2.
+             11 | SPP X1*X2
                 : ^^^^^^^^^
-             13 | 
+             12 | 
                 `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP
-                ,-[15:1]
-             14 | # Perform a SQRT_YY gate between qubit 1 and 2, and a SQRT_ZZ_DAG between qubit 3 and 4.
-             15 | SPP Y1*Y2 !Z1*Z2
+                ,-[14:1]
+             13 | # Perform a SQRT_YY gate between qubit 1 and 2, and a SQRT_ZZ_DAG between qubit 3 and 4.
+             14 | SPP Y1*Y2 !Z1*Z2
                 : ^^^^^^^^^^^^^^^^
-             16 | 
+             15 | 
                 `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP
-                ,-[18:1]
-             17 | # Phase the -1 eigenspace of -X1*Y2*Z3 by i.
-             18 | SPP !X1*Y2*Z3
+                ,-[17:1]
+             16 | # Phase the -1 eigenspace of -X1*Y2*Z3 by i.
+             17 | SPP !X1*Y2*Z3
                 : ^^^^^^^^^^^^^
                 `----
         "#]],
@@ -340,84 +341,84 @@ SPP !X1*Y2*Z3
 
 #[test]
 fn spp_dag_yields_unsupported_error() {
-    let source = "
-# Perform an S_DAG gate on qubit 1.
-SPP_DAG Z1
+    let source = indoc! {"
+        # Perform an S_DAG gate on qubit 1.
+        SPP_DAG Z1
 
-# Perform a SQRT_X_DAG gate on qubit 1.
-SPP_DAG X1
+        # Perform a SQRT_X_DAG gate on qubit 1.
+        SPP_DAG X1
 
-# Perform a SQRT_X gate on qubit 1.
-SPP_DAG !X1
+        # Perform a SQRT_X gate on qubit 1.
+        SPP_DAG !X1
 
-# Perform a SQRT_XX_DAG gate between qubit 1 and qubit 2.
-SPP_DAG X1*X2
+        # Perform a SQRT_XX_DAG gate between qubit 1 and qubit 2.
+        SPP_DAG X1*X2
 
-# Perform a SQRT_YY_DAG gate between qubit 1 and 2, and a SQRT_ZZ between qubit 3 and 4.
-SPP_DAG Y1*Y2 !Z1*Z2
+        # Perform a SQRT_YY_DAG gate between qubit 1 and 2, and a SQRT_ZZ between qubit 3 and 4.
+        SPP_DAG Y1*Y2 !Z1*Z2
 
-# Phase the -1 eigenspace of -X1*Y2*Z3 by -i.
-SPP_DAG !X1*Y2*Z3
-";
+        # Phase the -1 eigenspace of -X1*Y2*Z3 by -i.
+        SPP_DAG !X1*Y2*Z3
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP_DAG
-               ,-[3:1]
-             2 | # Perform an S_DAG gate on qubit 1.
-             3 | SPP_DAG Z1
+               ,-[2:1]
+             1 | # Perform an S_DAG gate on qubit 1.
+             2 | SPP_DAG Z1
                : ^^^^^^^^^^
-             4 | 
+             3 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP_DAG
-               ,-[6:1]
-             5 | # Perform a SQRT_X_DAG gate on qubit 1.
-             6 | SPP_DAG X1
+               ,-[5:1]
+             4 | # Perform a SQRT_X_DAG gate on qubit 1.
+             5 | SPP_DAG X1
                : ^^^^^^^^^^
-             7 | 
+             6 | 
                `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP_DAG
-                ,-[9:1]
-              8 | # Perform a SQRT_X gate on qubit 1.
-              9 | SPP_DAG !X1
-                : ^^^^^^^^^^^
-             10 | 
-                `----
+               ,-[8:1]
+             7 | # Perform a SQRT_X gate on qubit 1.
+             8 | SPP_DAG !X1
+               : ^^^^^^^^^^^
+             9 | 
+               `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP_DAG
-                ,-[12:1]
-             11 | # Perform a SQRT_XX_DAG gate between qubit 1 and qubit 2.
-             12 | SPP_DAG X1*X2
+                ,-[11:1]
+             10 | # Perform a SQRT_XX_DAG gate between qubit 1 and qubit 2.
+             11 | SPP_DAG X1*X2
                 : ^^^^^^^^^^^^^
-             13 | 
+             12 | 
                 `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP_DAG
-                ,-[15:1]
-             14 | # Perform a SQRT_YY_DAG gate between qubit 1 and 2, and a SQRT_ZZ between qubit 3 and 4.
-             15 | SPP_DAG Y1*Y2 !Z1*Z2
+                ,-[14:1]
+             13 | # Perform a SQRT_YY_DAG gate between qubit 1 and 2, and a SQRT_ZZ between qubit 3 and 4.
+             14 | SPP_DAG Y1*Y2 !Z1*Z2
                 : ^^^^^^^^^^^^^^^^^^^^
-             16 | 
+             15 | 
                 `----
 
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: SPP_DAG
-                ,-[18:1]
-             17 | # Phase the -1 eigenspace of -X1*Y2*Z3 by -i.
-             18 | SPP_DAG !X1*Y2*Z3
+                ,-[17:1]
+             16 | # Phase the -1 eigenspace of -X1*Y2*Z3 by -i.
+             17 | SPP_DAG !X1*Y2*Z3
                 : ^^^^^^^^^^^^^^^^^
                 `----
         "#]],
@@ -426,24 +427,23 @@ SPP_DAG !X1*Y2*Z3
 
 #[test]
 fn repeat_yields_unsupported_error() {
-    let source = "
-REPEAT 10 {
-    CNOT 0 1
-    CNOT 2 1
-    M 1
-}
-";
+    let source = indoc! {"
+        REPEAT 10 {
+          CNOT 0 1
+          CNOT 2 1
+          M 1
+        }
+    "};
     check(
         source,
         &expect![[r#"
             Qdk.Stim.Compiler.UnsupportedInstruction
 
               x unsupported instruction: REPEAT
-               ,-[2:1]
-             1 | 
-             2 | REPEAT 10 {
+               ,-[1:1]
+             1 | REPEAT 10 {
                : ^^^^^^^^^
-             3 |     CNOT 0 1
+             2 |   CNOT 0 1
                `----
         "#]],
     );


### PR DESCRIPTION
This PR implements the following scoping rules for the PREPARE blocks in stim:

1- An outer scope is allowed to reach into an inner one
2- An inner scope isn't allowed to reach into an outer one
3- The only blocks that have scoping rules are the prepare blocks

So, for example:

This should work:
```
PREPARE {
     M 0
}
    REQUIRE rec[-1]
```
    
   
But this should not:
```
  M 0
  PREPARE {
      REQUIRE rec[-1]
  }
```

Nor this:
```
M 0
PREPARE {
  CX rec[-1] 1
}
```

On top of that, it also renames the PREPARE block to SELECT.
