### PR TITLE
Support negated targets in stim collapsing gates

### DIFF
--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -332,9 +332,9 @@ pub enum Error {
         #[label]
         span: Span,
     },
-    #[error("measurement record control cannot be negated in instruction: {instruction}")]
-    #[diagnostic(code("Qdk.Stim.Compiler.NegatedMeasurementRecord"))]
-    NegatedMeasurementRecord {
+    #[error("target cannot be negated in instruction: {instruction}")]
+    #[diagnostic(code("Qdk.Stim.Compiler.NegatedTarget"))]
+    NegatedTarget {
         instruction: String,
         #[label]
         span: Span,
@@ -944,7 +944,7 @@ impl<'noise> Compiler<'noise> {
     fn broadcast(&mut self, instruction: &Instruction, mut f: impl FnMut(&mut Self, u32)) {
         self.unsupported_args(instruction); // Temporary error
         for target in &instruction.targets {
-            let Some(q) = self.expect_qubit(instruction, target) else {
+            let Some(q) = self.expect_qubit(instruction, target, false) else {
                 continue;
             };
             f(self, q);
@@ -961,10 +961,10 @@ impl<'noise> Compiler<'noise> {
             return;
         };
         for pair in pairs {
-            let Some(q0) = self.expect_qubit(instruction, &pair[0]) else {
+            let Some(q0) = self.expect_qubit(instruction, &pair[0], false) else {
                 continue;
             };
-            let Some(q1) = self.expect_qubit(instruction, &pair[1]) else {
+            let Some(q1) = self.expect_qubit(instruction, &pair[1], false) else {
                 continue;
             };
             f(self, q0, q1);
@@ -985,10 +985,10 @@ impl<'noise> Compiler<'noise> {
         for pair in pairs {
             match (&pair[0].kind, &pair[1].kind) {
                 (TargetKind::Qubit { .. }, TargetKind::Qubit { .. }) => {
-                    let Some(control) = self.expect_qubit(instruction, &pair[0]) else {
+                    let Some(control) = self.expect_qubit(instruction, &pair[0], false) else {
                         continue;
                     };
-                    let Some(target) = self.expect_qubit(instruction, &pair[1]) else {
+                    let Some(target) = self.expect_qubit(instruction, &pair[1], false) else {
                         continue;
                     };
                     quantum(self, control, target);
@@ -1045,7 +1045,7 @@ impl<'noise> Compiler<'noise> {
             return;
         };
         if negated {
-            self.push_error(Error::NegatedMeasurementRecord {
+            self.push_error(Error::NegatedTarget {
                 instruction: instruction.name.clone(),
                 span: rec_target.span,
             });
@@ -1054,7 +1054,7 @@ impl<'noise> Compiler<'noise> {
         let Some(result_id) = self.resolve_record_offset(rec_target, offset) else {
             return;
         };
-        let Some(target) = self.expect_qubit(instruction, qubit_target) else {
+        let Some(target) = self.expect_qubit(instruction, qubit_target, false) else {
             return;
         };
         let qubit = self.id_map.allocate_qubit(target);
@@ -1201,7 +1201,7 @@ impl<'noise> Compiler<'noise> {
             return;
         };
         for target in &instruction.targets {
-            let Some(value) = self.expect_qubit(instruction, target) else {
+            let Some(value) = self.expect_qubit(instruction, target, false) else {
                 continue;
             };
             self.current_correlated_group
@@ -1221,7 +1221,7 @@ impl<'noise> Compiler<'noise> {
         };
         let each = probability / 3.0;
         for target in &instruction.targets {
-            let Some(value) = self.expect_qubit(instruction, target) else {
+            let Some(value) = self.expect_qubit(instruction, target, false) else {
                 continue;
             };
             {
@@ -1249,10 +1249,10 @@ impl<'noise> Compiler<'noise> {
             return;
         };
         for pair in pairs {
-            let Some(q0) = self.expect_qubit(instruction, &pair[0]) else {
+            let Some(q0) = self.expect_qubit(instruction, &pair[0], false) else {
                 continue;
             };
-            let Some(q1) = self.expect_qubit(instruction, &pair[1]) else {
+            let Some(q1) = self.expect_qubit(instruction, &pair[1], false) else {
                 continue;
             };
             {
@@ -1384,19 +1384,28 @@ impl<'noise> Compiler<'noise> {
         self.writer.write_noise_intrinsic(&name, &column_ids);
     }
 
-    fn expect_qubit(&mut self, instruction: &Instruction, target: &Target) -> Option<u32> {
+    fn expect_qubit(
+        &mut self,
+        instruction: &Instruction,
+        target: &Target,
+        allow_negated: bool,
+    ) -> Option<u32> {
         // TODO: lacks support for negated qubits and pauli targets
-        let TargetKind::Qubit {
-            value,
-            negated: false,
-        } = target.kind
-        else {
+        let TargetKind::Qubit { value, negated } = target.kind else {
             self.push_error(Error::UnsupportedTarget {
                 instruction: instruction.name.clone(),
                 span: target.span,
             });
             return None;
         };
+
+        if negated && !allow_negated {
+            self.push_error(Error::NegatedTarget {
+                instruction: instruction.name.clone(),
+                span: target.span,
+            });
+            return None;
+        }
         Some(value)
     }
 

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -853,33 +853,37 @@ impl<'noise> Compiler<'noise> {
             }
 
             // Collapsing Gates
-            "M" | "MZ" => self.broadcast(instruction, |s, q| s.op_measure("m", q)),
-            "MR" | "MRZ" => self.broadcast(instruction, |s, q| s.op_measure("mresetz", q)),
-            "MRX" => self.broadcast(instruction, |s, q| {
+            "M" | "MZ" => self.broadcast_measure(instruction, |s, q, invert| {
+                s.op_measure("m", q, invert);
+            }),
+            "MR" | "MRZ" => self.broadcast_measure(instruction, |s, q, invert| {
+                s.op_measure_reset("mresetz", q, invert);
+            }),
+            "MRX" => self.broadcast_measure(instruction, |s, q, invert| {
                 // Stim decomposition (into H, S, CX, M, R): H 0; M 0; R 0; H 0
                 s.op("h", q); // X -> Z
-                s.op_measure("mresetz", q); // MRZ
+                s.op_measure_reset("mresetz", q, invert); // MRZ
                 s.op("h", q); // Z -> X
             }),
-            "MRY" => self.broadcast(instruction, |s, q| {
+            "MRY" => self.broadcast_measure(instruction, |s, q, invert| {
                 // Stim decomposition (into H, S, CX, M, R): S 0; S 0; S 0; H 0; M 0; R 0; H 0; S 0
                 s.op_adj("s", q); // Y -> X
                 s.op("h", q); // X -> Z
-                s.op_measure("mresetz", q); // MRZ
+                s.op_measure_reset("mresetz", q, invert); // MRZ
                 s.op("h", q); // Z -> X
                 s.op("s", q); // X -> Y
             }),
-            "MX" => self.broadcast(instruction, |s, q| {
+            "MX" => self.broadcast_measure(instruction, |s, q, invert| {
                 // Stim decomposition (into H, S, CX, M, R): H 0; M 0; H 0
                 s.op("h", q); // X -> Z
-                s.op_measure("m", q); // MZ
+                s.op_measure("m", q, invert); // MZ
                 s.op("h", q); // Z -> X
             }),
-            "MY" => self.broadcast(instruction, |s, q| {
+            "MY" => self.broadcast_measure(instruction, |s, q, invert| {
                 // Stim decomposition (into H, S, CX, M, R): S 0; S 0; S 0; H 0; M 0; H 0; S 0
                 s.op_adj("s", q); // Y -> X
                 s.op("h", q); // X -> Z
-                s.op_measure("m", q); // MZ
+                s.op_measure("m", q, invert); // MZ
                 s.op("h", q); // Z -> X
                 s.op("s", q); // X -> Y
             }),
@@ -897,31 +901,31 @@ impl<'noise> Compiler<'noise> {
             }),
 
             // Pair Measurement Gates
-            "MXX" => self.broadcast_pair(instruction, |s, q0, q1| {
+            "MXX" => self.broadcast_measure_pair(instruction, |s, q0, q1, invert| {
                 // Stim decomposition (into H, S, CX, M, R): CX 0 1; H 0; M 0; H 0; CX 0 1
                 s.op_2("cx", q0, q1);
                 s.op("h", q0);
-                s.op_measure("m", q0);
+                s.op_measure("m", q0, invert);
                 s.op("h", q0);
                 s.op_2("cx", q0, q1);
             }),
-            "MYY" => self.broadcast_pair(instruction, |s, q0, q1| {
+            "MYY" => self.broadcast_measure_pair(instruction, |s, q0, q1, invert| {
                 // Stim decomposition (into H, S, CX, M, R): S 0; S 1; CX 0 1; H 0; M 0; S 1; S 1; H 0; CX 0 1; S 0; S 1
                 s.op("s", q0);
                 s.op("s", q1);
                 s.op_2("cx", q0, q1);
                 s.op("h", q0);
-                s.op_measure("m", q0);
+                s.op_measure("m", q0, invert);
                 s.op("z", q1);
                 s.op("h", q0);
                 s.op_2("cx", q0, q1);
                 s.op("s", q0);
                 s.op("s", q1);
             }),
-            "MZZ" => self.broadcast_pair(instruction, |s, q0, q1| {
+            "MZZ" => self.broadcast_measure_pair(instruction, |s, q0, q1, invert| {
                 // Stim decomposition (into H, S, CX, M, R): CX 0 1; M 1; CX 0 1
                 s.op_2("cx", q0, q1);
-                s.op_measure("m", q1);
+                s.op_measure("m", q1, invert);
                 s.op_2("cx", q0, q1);
             }),
 
@@ -942,12 +946,46 @@ impl<'noise> Compiler<'noise> {
     }
 
     fn broadcast(&mut self, instruction: &Instruction, mut f: impl FnMut(&mut Self, u32)) {
-        self.unsupported_args(instruction); // Temporary error
+        self.unsupported_args(instruction);
         for target in &instruction.targets {
-            let Some(q) = self.expect_qubit(instruction, target, false) else {
+            let Some((q, _)) = self.expect_qubit(instruction, target, false) else {
                 continue;
             };
             f(self, q);
+        }
+    }
+
+    fn broadcast_measure(
+        &mut self,
+        instruction: &Instruction,
+        mut f: impl FnMut(&mut Self, u32, bool),
+    ) {
+        self.unsupported_args(instruction);
+        for target in &instruction.targets {
+            let Some((q, negated)) = self.expect_qubit(instruction, target, true) else {
+                continue;
+            };
+            f(self, q, negated);
+        }
+    }
+
+    fn broadcast_measure_pair(
+        &mut self,
+        instruction: &Instruction,
+        mut f: impl FnMut(&mut Self, u32, u32, bool),
+    ) {
+        self.unsupported_args(instruction);
+        let Some(pairs) = self.expect_target_pairs(instruction) else {
+            return;
+        };
+        for pair in pairs {
+            let Some((q0, neg0)) = self.expect_qubit(instruction, &pair[0], true) else {
+                continue;
+            };
+            let Some((q1, neg1)) = self.expect_qubit(instruction, &pair[1], true) else {
+                continue;
+            };
+            f(self, q0, q1, neg0 ^ neg1);
         }
     }
 
@@ -961,10 +999,10 @@ impl<'noise> Compiler<'noise> {
             return;
         };
         for pair in pairs {
-            let Some(q0) = self.expect_qubit(instruction, &pair[0], false) else {
+            let Some((q0, _)) = self.expect_qubit(instruction, &pair[0], false) else {
                 continue;
             };
-            let Some(q1) = self.expect_qubit(instruction, &pair[1], false) else {
+            let Some((q1, _)) = self.expect_qubit(instruction, &pair[1], false) else {
                 continue;
             };
             f(self, q0, q1);
@@ -985,10 +1023,10 @@ impl<'noise> Compiler<'noise> {
         for pair in pairs {
             match (&pair[0].kind, &pair[1].kind) {
                 (TargetKind::Qubit { .. }, TargetKind::Qubit { .. }) => {
-                    let Some(control) = self.expect_qubit(instruction, &pair[0], false) else {
+                    let Some((control, _)) = self.expect_qubit(instruction, &pair[0], false) else {
                         continue;
                     };
-                    let Some(target) = self.expect_qubit(instruction, &pair[1], false) else {
+                    let Some((target, _)) = self.expect_qubit(instruction, &pair[1], false) else {
                         continue;
                     };
                     quantum(self, control, target);
@@ -1054,7 +1092,7 @@ impl<'noise> Compiler<'noise> {
         let Some(result_id) = self.resolve_record_offset(rec_target, offset) else {
             return;
         };
-        let Some(target) = self.expect_qubit(instruction, qubit_target, false) else {
+        let Some((target, _)) = self.expect_qubit(instruction, qubit_target, false) else {
             return;
         };
         let qubit = self.id_map.allocate_qubit(target);
@@ -1071,8 +1109,23 @@ impl<'noise> Compiler<'noise> {
         self.writer.write_qis_adj_call(intrinsic, &[q]);
     }
 
-    fn op_measure(&mut self, intrinsic: &str, qubit: u32) {
+    fn op_measure(&mut self, intrinsic: &str, qubit: u32, invert: bool) {
         let q = self.id_map.allocate_qubit(qubit);
+        if invert {
+            self.writer.write_qis_call("x", &[q]);
+        }
+        let r = self.id_map.allocate_record();
+        self.writer.write_qis_call(intrinsic, &[q, r]);
+        if invert {
+            self.writer.write_qis_call("x", &[q]);
+        }
+    }
+
+    fn op_measure_reset(&mut self, intrinsic: &str, qubit: u32, invert: bool) {
+        let q = self.id_map.allocate_qubit(qubit);
+        if invert {
+            self.writer.write_qis_call("x", &[q]);
+        }
         let r = self.id_map.allocate_record();
         self.writer.write_qis_call(intrinsic, &[q, r]);
     }
@@ -1201,7 +1254,7 @@ impl<'noise> Compiler<'noise> {
             return;
         };
         for target in &instruction.targets {
-            let Some(value) = self.expect_qubit(instruction, target, false) else {
+            let Some((value, _)) = self.expect_qubit(instruction, target, false) else {
                 continue;
             };
             self.current_correlated_group
@@ -1221,7 +1274,7 @@ impl<'noise> Compiler<'noise> {
         };
         let each = probability / 3.0;
         for target in &instruction.targets {
-            let Some(value) = self.expect_qubit(instruction, target, false) else {
+            let Some((value, _)) = self.expect_qubit(instruction, target, false) else {
                 continue;
             };
             {
@@ -1249,10 +1302,10 @@ impl<'noise> Compiler<'noise> {
             return;
         };
         for pair in pairs {
-            let Some(q0) = self.expect_qubit(instruction, &pair[0], false) else {
+            let Some((q0, _)) = self.expect_qubit(instruction, &pair[0], false) else {
                 continue;
             };
-            let Some(q1) = self.expect_qubit(instruction, &pair[1], false) else {
+            let Some((q1, _)) = self.expect_qubit(instruction, &pair[1], false) else {
                 continue;
             };
             {
@@ -1389,7 +1442,7 @@ impl<'noise> Compiler<'noise> {
         instruction: &Instruction,
         target: &Target,
         allow_negated: bool,
-    ) -> Option<u32> {
+    ) -> Option<(u32, bool)> {
         // TODO: lacks support for negated qubits and pauli targets
         let TargetKind::Qubit { value, negated } = target.kind else {
             self.push_error(Error::UnsupportedTarget {
@@ -1406,7 +1459,7 @@ impl<'noise> Compiler<'noise> {
             });
             return None;
         }
-        Some(value)
+        Some((value, negated))
     }
 
     fn expect_measurement_record(

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -1443,7 +1443,6 @@ impl<'noise> Compiler<'noise> {
         target: &Target,
         allow_negated: bool,
     ) -> Option<(u32, bool)> {
-        // TODO: lacks support for negated qubits and pauli targets
         let TargetKind::Qubit { value, negated } = target.kind else {
             self.push_error(Error::UnsupportedTarget {
                 instruction: instruction.name.clone(),

--- a/source/compiler/stim_compiler/src/qir/tests/collapsing_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/collapsing_gates.rs
@@ -446,6 +446,251 @@ fn ry_gate_yields_expected_qir() {
 }
 
 #[test]
+fn m_gate_with_negated_target_yields_expected_qir() {
+    let source = "M !0";
+    check(source, &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__qis__x__body(ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__m__body(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]]);
+}
+
+#[test]
+fn mx_gate_with_negated_target_yields_expected_qir() {
+    let source = "MX !0";
+    check(source, &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__qis__m__body(ptr, ptr)
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__qis__x__body(ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__h__body(ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]]);
+}
+
+#[test]
+fn my_gate_with_negated_target_yields_expected_qir() {
+    let source = "MY !0";
+    check(source, &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__qis__s__body(ptr)
+        declare void @__quantum__qis__s__adj(ptr)
+        declare void @__quantum__qis__h__body(ptr)
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__qis__x__body(ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__m__body(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]]);
+}
+
+#[test]
+fn mr_gate_with_negated_target_yields_expected_qir() {
+    let source = "MR !0";
+    check(source, &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__qis__x__body(ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]]);
+}
+
+#[test]
+fn mrx_gate_with_negated_target_yields_expected_qir() {
+    let source = "MRX !0";
+    check(source, &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__qis__x__body(ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__qis__h__body(ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]]);
+}
+
+#[test]
+fn mry_gate_with_negated_target_yields_expected_qir() {
+    let source = "MRY !0";
+    check(source, &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__qis__s__body(ptr)
+        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+        declare void @__quantum__qis__s__adj(ptr)
+        declare void @__quantum__qis__h__body(ptr)
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+        declare void @__quantum__qis__x__body(ptr)
+        declare void @__quantum__rt__initialize(ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]]);
+}
+
+#[test]
 fn rz_gate_yields_expected_qir() {
     let source = "RZ 0";
     check(

--- a/source/compiler/stim_compiler/src/qir/tests/collapsing_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/collapsing_gates.rs
@@ -448,7 +448,9 @@ fn ry_gate_yields_expected_qir() {
 #[test]
 fn m_gate_with_negated_target_yields_expected_qir() {
     let source = "M !0";
-    check(source, &expect![[r#"
+    check(
+        source,
+        &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
           call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
@@ -480,13 +482,16 @@ fn m_gate_with_negated_target_yields_expected_qir() {
         !5 = !{i32 5, !"float_computations", !{!"double"}}
         !6 = !{i32 7, !"backwards_branching", i2 3}
         !7 = !{i32 1, !"arrays", i1 true}
-    "#]]);
+    "#]],
+    );
 }
 
 #[test]
 fn mx_gate_with_negated_target_yields_expected_qir() {
     let source = "MX !0";
-    check(source, &expect![[r#"
+    check(
+        source,
+        &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
           call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
@@ -521,13 +526,16 @@ fn mx_gate_with_negated_target_yields_expected_qir() {
         !5 = !{i32 5, !"float_computations", !{!"double"}}
         !6 = !{i32 7, !"backwards_branching", i2 3}
         !7 = !{i32 1, !"arrays", i1 true}
-    "#]]);
+    "#]],
+    );
 }
 
 #[test]
 fn my_gate_with_negated_target_yields_expected_qir() {
     let source = "MY !0";
-    check(source, &expect![[r#"
+    check(
+        source,
+        &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
           call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
@@ -566,13 +574,16 @@ fn my_gate_with_negated_target_yields_expected_qir() {
         !5 = !{i32 5, !"float_computations", !{!"double"}}
         !6 = !{i32 7, !"backwards_branching", i2 3}
         !7 = !{i32 1, !"arrays", i1 true}
-    "#]]);
+    "#]],
+    );
 }
 
 #[test]
 fn mr_gate_with_negated_target_yields_expected_qir() {
     let source = "MR !0";
-    check(source, &expect![[r#"
+    check(
+        source,
+        &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
           call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
@@ -603,13 +614,16 @@ fn mr_gate_with_negated_target_yields_expected_qir() {
         !5 = !{i32 5, !"float_computations", !{!"double"}}
         !6 = !{i32 7, !"backwards_branching", i2 3}
         !7 = !{i32 1, !"arrays", i1 true}
-    "#]]);
+    "#]],
+    );
 }
 
 #[test]
 fn mrx_gate_with_negated_target_yields_expected_qir() {
     let source = "MRX !0";
-    check(source, &expect![[r#"
+    check(
+        source,
+        &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
           call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
@@ -643,13 +657,16 @@ fn mrx_gate_with_negated_target_yields_expected_qir() {
         !5 = !{i32 5, !"float_computations", !{!"double"}}
         !6 = !{i32 7, !"backwards_branching", i2 3}
         !7 = !{i32 1, !"arrays", i1 true}
-    "#]]);
+    "#]],
+    );
 }
 
 #[test]
 fn mry_gate_with_negated_target_yields_expected_qir() {
     let source = "MRY !0";
-    check(source, &expect![[r#"
+    check(
+        source,
+        &expect![[r#"
         define i64 @ENTRYPOINT__main() #0 {
           call void @__quantum__rt__initialize(ptr null)
           call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
@@ -687,7 +704,8 @@ fn mry_gate_with_negated_target_yields_expected_qir() {
         !5 = !{i32 5, !"float_computations", !{!"double"}}
         !6 = !{i32 7, !"backwards_branching", i2 3}
         !7 = !{i32 1, !"arrays", i1 true}
-    "#]]);
+    "#]],
+    );
 }
 
 #[test]

--- a/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
@@ -347,9 +347,9 @@ fn cx_with_negated_rec_control_yields_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedMeasurementRecord
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x measurement record control cannot be negated in instruction: CX
+              x target cannot be negated in instruction: CX
                ,-[2:4]
              1 | M 0
              2 | CX !rec[-1] 1
@@ -541,9 +541,9 @@ fn cy_with_negated_rec_control_yields_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedMeasurementRecord
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x measurement record control cannot be negated in instruction: CY
+              x target cannot be negated in instruction: CY
                ,-[2:4]
              1 | M 0
              2 | CY !rec[-1] 1
@@ -786,9 +786,9 @@ fn cz_with_negated_rec_on_first_target_yields_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedMeasurementRecord
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x measurement record control cannot be negated in instruction: CZ
+              x target cannot be negated in instruction: CZ
                ,-[2:4]
              1 | M 0
              2 | CZ !rec[-1] 1
@@ -804,9 +804,9 @@ fn cz_with_negated_rec_on_second_target_yields_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedMeasurementRecord
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x measurement record control cannot be negated in instruction: CZ
+              x target cannot be negated in instruction: CZ
                ,-[2:6]
              1 | M 0
              2 | CZ 0 !rec[-1]
@@ -892,9 +892,9 @@ fn xcz_with_negated_rec_on_second_target_yields_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedMeasurementRecord
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x measurement record control cannot be negated in instruction: XCZ
+              x target cannot be negated in instruction: XCZ
                ,-[2:7]
              1 | M 0
              2 | XCZ 1 !rec[-1]
@@ -980,9 +980,9 @@ fn ycz_with_negated_rec_on_second_target_yields_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedMeasurementRecord
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x measurement record control cannot be negated in instruction: YCZ
+              x target cannot be negated in instruction: YCZ
                ,-[2:7]
              1 | M 0
              2 | YCZ 1 !rec[-1]

--- a/source/compiler/stim_compiler/src/qir/tests/pair_measurements.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/pair_measurements.rs
@@ -54,9 +54,9 @@ fn mxx_with_negated_target_yields_unsupported_target_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.UnsupportedTarget
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x unsupported target in instruction: MXX
+              x target cannot be negated in instruction: MXX
                ,----
              1 | MXX !0 1
                :     ^^
@@ -139,9 +139,9 @@ fn myy_with_negated_target_yields_unsupported_target_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.UnsupportedTarget
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x unsupported target in instruction: MYY
+              x target cannot be negated in instruction: MYY
                ,----
              1 | MYY !0 1
                :     ^^
@@ -214,9 +214,9 @@ fn mzz_with_negated_target_yields_unsupported_target_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.UnsupportedTarget
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x unsupported target in instruction: MZZ
+              x target cannot be negated in instruction: MZZ
                ,----
              1 | MZZ !0 1
                :     ^^

--- a/source/compiler/stim_compiler/src/qir/tests/pair_measurements.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/pair_measurements.rs
@@ -49,18 +49,48 @@ fn mxx_measurement_yields_correct_qir() {
 }
 
 #[test]
-fn mxx_with_negated_target_yields_unsupported_target_error() {
+fn mxx_with_negated_target_yields_correct_qir() {
     let source = "MXX !0 1";
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedTarget
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__rt__array_record_output(i64 1, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              ret i64 0
+            }
 
-              x target cannot be negated in instruction: MXX
-               ,----
-             1 | MXX !0 1
-               :     ^^
-               `----
+            declare void @__quantum__qis__cx__body(ptr, ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__qis__x__body(ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__h__body(ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
         "#]],
     );
 }
@@ -134,18 +164,55 @@ fn myy_measurement_yields_correct_qir() {
 }
 
 #[test]
-fn myy_with_negated_target_yields_unsupported_target_error() {
+fn myy_with_negated_target_yields_correct_qir() {
     let source = "MYY !0 1";
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedTarget
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__rt__array_record_output(i64 1, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              ret i64 0
+            }
 
-              x target cannot be negated in instruction: MYY
-               ,----
-             1 | MYY !0 1
-               :     ^^
-               `----
+            declare void @__quantum__qis__cx__body(ptr, ptr)
+            declare void @__quantum__qis__z__body(ptr)
+            declare void @__quantum__qis__s__body(ptr)
+            declare void @__quantum__qis__h__body(ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__qis__x__body(ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
         "#]],
     );
 }
@@ -209,18 +276,45 @@ fn mzz_measurement_yields_correct_qir() {
 }
 
 #[test]
-fn mzz_with_negated_target_yields_unsupported_target_error() {
+fn mzz_with_negated_target_yields_correct_qir() {
     let source = "MZZ !0 1";
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedTarget
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__rt__array_record_output(i64 1, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              ret i64 0
+            }
 
-              x target cannot be negated in instruction: MZZ
-               ,----
-             1 | MZZ !0 1
-               :     ^^
-               `----
+            declare void @__quantum__qis__cx__body(ptr, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__qis__x__body(ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
         "#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/pair_measurements_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/pair_measurements_broadcasting.rs
@@ -60,9 +60,9 @@ fn mxx_with_negated_target_yields_unsupported_target_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.UnsupportedTarget
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x unsupported target in instruction: MXX
+              x target cannot be negated in instruction: MXX
                ,----
              1 | MXX !0 1 2 3
                :     ^^
@@ -156,9 +156,9 @@ fn myy_with_negated_target_yields_unsupported_target_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.UnsupportedTarget
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x unsupported target in instruction: MYY
+              x target cannot be negated in instruction: MYY
                ,----
              1 | MYY !0 1 2 3
                :     ^^
@@ -235,9 +235,9 @@ fn mzz_with_negated_target_yields_unsupported_target_error() {
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.UnsupportedTarget
+            Qdk.Stim.Compiler.NegatedTarget
 
-              x unsupported target in instruction: MZZ
+              x target cannot be negated in instruction: MZZ
                ,----
              1 | MZZ !0 1 2 3
                :     ^^

--- a/source/compiler/stim_compiler/src/qir/tests/pair_measurements_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/pair_measurements_broadcasting.rs
@@ -55,18 +55,54 @@ fn mxx_measurement_yields_correct_qir() {
 }
 
 #[test]
-fn mxx_with_negated_target_yields_unsupported_target_error() {
+fn mxx_with_negated_target_yields_correct_qir() {
     let source = "MXX !0 1 2 3";
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedTarget
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__rt__array_record_output(i64 2, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+              ret i64 0
+            }
 
-              x target cannot be negated in instruction: MXX
-               ,----
-             1 | MXX !0 1 2 3
-               :     ^^
-               `----
+            declare void @__quantum__qis__cx__body(ptr, ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__qis__x__body(ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__h__body(ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
         "#]],
     );
 }
@@ -151,18 +187,66 @@ fn myy_measurement_yields_correct_qir() {
 }
 
 #[test]
-fn myy_with_negated_target_yields_unsupported_target_error() {
+fn myy_with_negated_target_yields_correct_qir() {
     let source = "MYY !0 1 2 3";
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedTarget
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__z__body(ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__rt__array_record_output(i64 2, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+              ret i64 0
+            }
 
-              x target cannot be negated in instruction: MYY
-               ,----
-             1 | MYY !0 1 2 3
-               :     ^^
-               `----
+            declare void @__quantum__qis__cx__body(ptr, ptr)
+            declare void @__quantum__qis__z__body(ptr)
+            declare void @__quantum__qis__s__body(ptr)
+            declare void @__quantum__qis__h__body(ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__qis__x__body(ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
         "#]],
     );
 }
@@ -230,18 +314,49 @@ fn mzz_measurement_yields_correct_qir() {
 }
 
 #[test]
-fn mzz_with_negated_target_yields_unsupported_target_error() {
+fn mzz_with_negated_target_yields_correct_qir() {
     let source = "MZZ !0 1 2 3";
     check(
         source,
         &expect![[r#"
-            Qdk.Stim.Compiler.NegatedTarget
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+              call void @__quantum__rt__array_record_output(i64 2, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+              ret i64 0
+            }
 
-              x target cannot be negated in instruction: MZZ
-               ,----
-             1 | MZZ !0 1 2 3
-               :     ^^
-               `----
+            declare void @__quantum__qis__cx__body(ptr, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__qis__x__body(ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
         "#]],
     );
 }


### PR DESCRIPTION
This PR implements support for the following operations:

`M !0`, `MX !0`, `MY !0`,
`MR !0`, `MRX !0`, `MRY !0`, 
`MZZ !0 1`, `MXX !0 1`, `MYY !0 1`, 

where M, MZ; MR, MRZ are interchangeable,
and on pair measurements we can negate either target, or both, but the negation will invert the result by the XOR of both negations. For example:

`MZZ !0 1` = `MZZ 0 !1`
`MZZ !0 !1` = `MZZ 0 1`

In terms of the implementation, all that had to be done was adding an X gate before and after the emitted M operations (all collapsing gates are eventually decomposed to a single M in a qubit). For measurement reset operations, we only add the X gate before the measurement (as we don't care about post-measurement state).

