### PR TITLE
Fix unexpected loop variables in partial eval by falling back to static values

### DIFF
--- a/source/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/source/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -300,6 +300,16 @@ impl EvalControlFlow {
             Self::Return(_) => true,
         }
     }
+
+    pub fn map_value<F>(self, f: F) -> Self
+    where
+        F: FnOnce(Value) -> Value,
+    {
+        match self {
+            Self::Continue(value) => Self::Continue(f(value)),
+            Self::Return(value) => Self::Return(f(value)),
+        }
+    }
 }
 
 fn map_eval_value_to_value_kind(value: &Value) -> ValueKind {

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -1613,12 +1613,7 @@ impl<'a> PartialEvaluator<'a> {
         } else {
             spec_decl
                 .filter(|spec_decl| {
-                    self.is_ir_function_eligible(
-                        store_item_id,
-                        functor_app,
-                        spec_decl,
-                        callable_decl,
-                    )
+                    self.is_ir_function_eligible(store_item_id, spec_decl, callable_decl)
                 })
                 .map(|_| {
                     args.iter()
@@ -2111,7 +2106,6 @@ impl<'a> PartialEvaluator<'a> {
     fn is_ir_function_eligible(
         &self,
         store_item_id: StoreItemId,
-        functor_app: FunctorApp,
         spec_decl: &SpecDecl,
         callable_decl: &CallableDecl,
     ) -> bool {
@@ -2121,6 +2115,9 @@ impl<'a> PartialEvaluator<'a> {
             .capabilities
             .contains(TargetCapabilityFlags::CallSupport)
         {
+            // In this case, we know the target can't support any IR function calls, so always return false.
+            // This is needed because when the target does not have that support we don't emit the `MustBeInlined`
+            // capability on the call site.
             return false;
         }
 
@@ -2149,19 +2146,6 @@ impl<'a> PartialEvaluator<'a> {
             return false;
         }
 
-        // The base phase emits VOID (Unit-returning) IR functions and scalar-returning IR
-        // functions for the non-composite value types Int/Double/Bool. `Result` and `Qubit` returns
-        // have no by-value single-exit representation in the base-phase RIR and must continue to
-        // inline.
-        if callable_decl.output != Ty::UNIT
-            && !matches!(
-                callable_decl.output,
-                Ty::Prim(Prim::Int | Prim::Double | Prim::Bool)
-            )
-        {
-            return false;
-        }
-
         // Every flattened input-parameter leaf must be a non-composite scalar/qubit type that can
         // be threaded as an RIR variable operand. Composite (tuple/array/arrow) leaves, as well as
         // `Result` leaves (which have no evaluator-variable representation), force the whole callable
@@ -2182,44 +2166,7 @@ impl<'a> PartialEvaluator<'a> {
             return false;
         }
 
-        // Callables whose bodies contain calls that RCA could not
-        // statically resolve, and callables that transitively allocate qubits (unless dynamic qubit
-        // allocation is enabled) must be inlined. These are surfaced as inherent runtime features of
-        // the specialization by RCA. Unresolved-callee paths surface as
-        // `CallToUnresolvedCallee`; in all such cases the specialization is inlined.
-        let inherent_features = self.spec_inherent_runtime_features(store_item_id, functor_app);
-        if inherent_features.contains(RuntimeFeatureFlags::CallToUnresolvedCallee) {
-            return false;
-        }
-
         true
-    }
-
-    /// Reads the inherent runtime features of a resolved callable specialization from RCA. This
-    /// mirrors the specialization selection in `get_call_compute_kind` and is used by the
-    /// IR-function eligibility predicate to detect recursion and transitive qubit allocation.
-    fn spec_inherent_runtime_features(
-        &self,
-        store_item_id: StoreItemId,
-        functor_app: FunctorApp,
-    ) -> RuntimeFeatureFlags {
-        let ItemComputeProperties::Callable(callable_compute_properties) =
-            self.compute_properties.get_item(store_item_id)
-        else {
-            return RuntimeFeatureFlags::empty();
-        };
-        let generator_set = match (functor_app.adjoint, functor_app.controlled) {
-            (false, 0) => Some(&callable_compute_properties.body),
-            (false, _) => callable_compute_properties.ctl.as_ref(),
-            (true, 0) => callable_compute_properties.adj.as_ref(),
-            (true, _) => callable_compute_properties.ctl_adj.as_ref(),
-        };
-        match generator_set.map(|gen_set| gen_set.inherent) {
-            Some(ComputeKind::Dynamic {
-                runtime_features, ..
-            }) => runtime_features,
-            _ => RuntimeFeatureFlags::empty(),
-        }
     }
 
     /// Reports whether the resolved specialization has a `Dynamic` inherent compute kind, i.e.

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -1281,7 +1281,7 @@ impl<'a> PartialEvaluator<'a> {
     fn eval_dynamic_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
         let expr = self.get_expr(expr_id);
         let expr_package_span = self.get_expr_package_span(expr_id);
-        match &expr.kind {
+        let expr_control_flow = match &expr.kind {
             ExprKind::Array(exprs) => self.eval_expr_array(exprs),
             ExprKind::ArrayLit(_) => Err(Error::Unexpected(
                 "array literal should have been classically evaluated".to_string(),
@@ -1368,6 +1368,11 @@ impl<'a> PartialEvaluator<'a> {
             ExprKind::While(condition_expr_id, body_block_id) => {
                 self.eval_expr_while(expr_id, *condition_expr_id, *body_block_id)
             }
+        }?;
+        if self.is_variable_expr(expr_id) {
+            Ok(expr_control_flow)
+        } else {
+            Ok(expr_control_flow.map_value(|value| self.value_into_static_mapping(value)))
         }
     }
 
@@ -2184,15 +2189,6 @@ impl<'a> PartialEvaluator<'a> {
         // `CallToUnresolvedCallee`; in all such cases the specialization is inlined.
         let inherent_features = self.spec_inherent_runtime_features(store_item_id, functor_app);
         if inherent_features.contains(RuntimeFeatureFlags::CallToUnresolvedCallee) {
-            return false;
-        }
-        if inherent_features.contains(RuntimeFeatureFlags::QubitAllocation)
-            && !self
-                .program
-                .config
-                .capabilities
-                .contains(TargetCapabilityFlags::DynamicQubitAllocation)
-        {
             return false;
         }
 
@@ -4135,6 +4131,20 @@ impl<'a> PartialEvaluator<'a> {
             _ => unreachable!("unassignable pattern should be disallowed by compiler"),
         }
         Ok(())
+    }
+
+    fn value_into_static_mapping(&self, value: Value) -> Value {
+        match value {
+            Value::Var(var) => {
+                let current_scope = self.eval_context.get_current_scope();
+                if let Some(literal) = current_scope.get_static_value(var.id.into()) {
+                    map_rir_literal_to_eval_value(*literal).unwrap_or(Value::Var(var))
+                } else {
+                    value
+                }
+            }
+            _ => value,
+        }
     }
 
     fn generate_output_recording_instructions(

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -566,6 +566,8 @@ impl<'a> Analyzer<'a> {
             } = &ir_function_compute_kind
             // ...and the computed runtime features of the resulting IR function does not require qubit allocation when the target doesn't support it...
             && (!runtime_features.contains(RuntimeFeatureFlags::QubitAllocation) || self.target_capabilities.contains(TargetCapabilityFlags::DynamicQubitAllocation))
+            // ...and the computed runtime features of the function do not involve call to unresolved callee...
+            && !runtime_features.contains(RuntimeFeatureFlags::CallToUnresolvedCallee)
             // ...and those computed runtime features are all supported by the target capabilities...
             && get_missing_runtime_features(*runtime_features, self.target_capabilities)
                 .is_empty()
@@ -573,7 +575,7 @@ impl<'a> Analyzer<'a> {
                 && (matches!(
                     &callable_decl.output,
                     Ty::Prim(Prim::Int | Prim::Double | Prim::Bool)
-                ) || matches!(&callable_decl.output, Ty::Tuple(inner) if inner.is_empty()))
+                ) || callable_decl.output == Ty::UNIT)
             {
                 // ...then we can emit the callable as an IR function, and we update the compute kind of the call expression to reflect the
                 // capabilities of that IR function.

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -564,6 +564,8 @@ impl<'a> Analyzer<'a> {
             && if let ComputeKind::Dynamic {
                 runtime_features, ..
             } = &ir_function_compute_kind
+            // ...and the computed runtime features of the resulting IR function does not require qubit allocation when the target doesn't support it...
+            && (!runtime_features.contains(RuntimeFeatureFlags::QubitAllocation) || self.target_capabilities.contains(TargetCapabilityFlags::DynamicQubitAllocation))
             // ...and those computed runtime features are all supported by the target capabilities...
             && get_missing_runtime_features(*runtime_features, self.target_capabilities)
                 .is_empty()

--- a/source/samples_test/src/tests/OpenQASM.rs
+++ b/source/samples_test/src/tests/OpenQASM.rs
@@ -41,7 +41,7 @@ pub const SIMPLE1DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18979"];
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 10993"];
+    expect!["generated QIR of length 10243"];
 pub const TELEPORTATION_EXPECT: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_DEBUG: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 2086"];

--- a/source/samples_test/src/tests/algorithms_Ising.rs
+++ b/source/samples_test/src/tests/algorithms_Ising.rs
@@ -13,9 +13,8 @@ pub const SIMPLE2DISINGORDER2_EXPECT_DEBUG: Expect =
 pub const SIMPLE2DISINGORDER2_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 24940"];
 pub const SIMPLE2DISINGORDER2_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 20849"];
-// This is not expected, and tracked by https://github.com/microsoft/qdk/issues/3441
 pub const SIMPLE2DISINGORDER2_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["QIR generation error for `Simple2dIsingOrder2.Main()`: partial evaluation error"];
+    expect!["generated QIR of length 11721"];
 pub const SIMPLE1DISINGORDER1_EXPECT: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, Zero, Zero, Zero]"];
 pub const SIMPLE1DISINGORDER1_EXPECT_DEBUG: Expect =
@@ -31,6 +30,5 @@ pub const SIMPLE2DISINGORDER1_EXPECT_DEBUG: Expect =
 pub const SIMPLE2DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 24085"];
 pub const SIMPLE2DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 16214"];
-// This is not expected, and tracked by https://github.com/microsoft/qdk/issues/3441
 pub const SIMPLE2DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["QIR generation error for `Simple2dIsingOrder1.Main()`: partial evaluation error"];
+    expect!["generated QIR of length 11223"];


### PR DESCRIPTION
This fixes an issue with certain patterns in Adaptive QIR generation where partial evaluation would fail because it got back a variable when it expected a known static value. This fixes the issue by updating how we treat the results of evaluating a dynamic expression: if the RCA data structures indicate that the expression should be a dynamic constant, we check the static value map and use that value rather that the computed variable identifier. This allows known constants to propagate further during partial evaluation, this avoiding emitting branches (and loops) that are known to be unnecessary. Fixes #3441