### PR TITLE
Handle loss in stim control flow

### DIFF
--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -114,14 +114,7 @@ block_c{pauli}_exit:
     }
 
     fn write_noise_intrinsic(&mut self, name: &str, ids: &[u32]) {
-        write!(self, "  call void @{name}(");
-        for (i, &id) in ids.iter().enumerate() {
-            if i > 0 {
-                write!(self, ", ");
-            }
-            write!(self, "ptr inttoptr (i64 {id} to ptr)");
-        }
-        writeln!(self, ")");
+        self.write_call(name, ids);
         self.declare(name, || {
             let params = vec!["ptr"; ids.len()].join(", ");
             format!("declare void @{name}({params}) #2")
@@ -152,24 +145,12 @@ block_c{pauli}_exit:
         writeln!(self, "  br label %{label}");
     }
 
-    // Writes: `  %{dest} = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 N to ptr))`
-    fn write_read_result(&mut self, dest: &str, id: u32) {
-        write!(self, "  %{dest} = call i1 @__quantum__rt__read_result(");
+    // Writes: `  %{dest} = call i1 @{intrinsic}(ptr inttoptr (i64 N to ptr))`
+    fn write_read(&mut self, dest: &str, intrinsic: &str, id: u32) {
+        write!(self, "  %{dest} = call i1 @{intrinsic}(");
         self.write_ptr(id);
         writeln!(self, ")");
-        self.declare("__quantum__rt__read_result", || {
-            "declare i1 @__quantum__rt__read_result(ptr)".to_string()
-        });
-    }
-
-    // Writes: `  %{dest} = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 N to ptr))`
-    fn write_read_loss(&mut self, dest: &str, id: u32) {
-        write!(self, "  %{dest} = call i1 @__quantum__rt__read_loss(");
-        self.write_ptr(id);
-        writeln!(self, ")");
-        self.declare("__quantum__rt__read_loss", || {
-            "declare i1 @__quantum__rt__read_loss(ptr)".to_string()
-        });
+        self.declare(intrinsic, || format!("declare i1 @{intrinsic}(ptr)"));
     }
 
     // Writes: `  %{dest} = or i1 %{lhs}, %{rhs}`
@@ -1208,13 +1189,15 @@ impl<'noise> Compiler<'noise> {
 
     fn read_loss_register(&mut self, result_id: u32) -> String {
         let loss_register = self.id_map.fresh_name("l");
-        self.writer.write_read_loss(&loss_register, result_id);
+        self.writer
+            .write_read(&loss_register, "__quantum__rt__read_loss", result_id);
         loss_register
     }
 
     fn read_result_register(&mut self, result_id: u32, negated: bool) -> String {
         let result_register = self.id_map.fresh_name("r");
-        self.writer.write_read_result(&result_register, result_id);
+        self.writer
+            .write_read(&result_register, "__quantum__rt__read_result", result_id);
 
         if negated {
             let not_register = self.id_map.fresh_name("n");

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -1194,7 +1194,7 @@ impl<'noise> Compiler<'noise> {
         let parity = self.reduce_registers(&result_registers, "parity", QirWriter::write_xor);
 
         let restart = self.id_map.fresh_name("restart");
-        self.writer.write_or(&restart, &parity, &loss);
+        self.writer.write_or(&restart, &loss, &parity);
 
         let Scope::Select(scope) = self.id_map.current_scope() else {
             unreachable!("REQUIRE runs inside a select block");

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -162,6 +162,21 @@ block_c{pauli}_exit:
         });
     }
 
+    // Writes: `  %{dest} = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 N to ptr))`
+    fn write_read_loss(&mut self, dest: &str, id: u32) {
+        write!(self, "  %{dest} = call i1 @__quantum__rt__read_loss(");
+        self.write_ptr(id);
+        writeln!(self, ")");
+        self.declare("__quantum__rt__read_loss", || {
+            "declare i1 @__quantum__rt__read_loss(ptr)".to_string()
+        });
+    }
+
+    // Writes: `  %{dest} = or i1 %{lhs}, %{rhs}`
+    fn write_or(&mut self, dest: &str, lhs: &str, rhs: &str) {
+        writeln!(self, "  %{dest} = or i1 %{lhs}, %{rhs}");
+    }
+
     // Writes: `  %{dest} = xor i1 %{lhs}, %{rhs}`
     fn write_xor(&mut self, dest: &str, lhs: &str, rhs: &str) {
         writeln!(self, "  %{dest} = xor i1 %{lhs}, %{rhs}");
@@ -1160,7 +1175,8 @@ impl<'noise> Compiler<'noise> {
             return;
         }
 
-        let mut read_registers = Vec::new();
+        let mut loss_registers = Vec::new();
+        let mut result_registers = Vec::new();
         for target in &instruction.targets {
             let Some((offset, negated)) = self.expect_measurement_record(instruction, target)
             else {
@@ -1169,29 +1185,16 @@ impl<'noise> Compiler<'noise> {
             let Some(result_id) = self.resolve_record_offset(target, offset) else {
                 return;
             };
-            let read_register = self.id_map.fresh_name("r");
-            self.writer.write_read_result(&read_register, result_id);
 
-            let term = if negated {
-                let not_register = self.id_map.fresh_name("r");
-                self.writer.write_not(&not_register, &read_register);
-                not_register
-            } else {
-                read_register
-            };
-            read_registers.push(term);
+            loss_registers.push(self.read_loss_register(result_id));
+            result_registers.push(self.read_result_register(result_id, negated));
         }
 
-        let Some((first, rest)) = read_registers.split_first() else {
-            unreachable!("REQUIRE always has at least one target");
-        };
+        let loss = self.reduce_registers(&loss_registers, "loss", QirWriter::write_or);
+        let parity = self.reduce_registers(&result_registers, "parity", QirWriter::write_xor);
 
-        let mut parity = first.clone();
-        for reg in rest {
-            let temp = self.id_map.fresh_name("x");
-            self.writer.write_xor(&temp, &parity, reg);
-            parity = temp;
-        }
+        let restart = self.id_map.fresh_name("restart");
+        self.writer.write_or(&restart, &parity, &loss);
 
         let Scope::Select(scope) = self.id_map.current_scope() else {
             unreachable!("REQUIRE runs inside a select block");
@@ -1199,8 +1202,45 @@ impl<'noise> Compiler<'noise> {
         let restart_label = select_label(scope);
         let continue_label = self.id_map.fresh_name("continue");
         self.writer
-            .write_branch(&parity, &restart_label, &continue_label);
+            .write_branch(&restart, &restart_label, &continue_label);
         self.writer.write_label(&continue_label);
+    }
+
+    fn read_loss_register(&mut self, result_id: u32) -> String {
+        let loss_register = self.id_map.fresh_name("l");
+        self.writer.write_read_loss(&loss_register, result_id);
+        loss_register
+    }
+
+    fn read_result_register(&mut self, result_id: u32, negated: bool) -> String {
+        let result_register = self.id_map.fresh_name("r");
+        self.writer.write_read_result(&result_register, result_id);
+
+        if negated {
+            let not_register = self.id_map.fresh_name("n");
+            self.writer.write_not(&not_register, &result_register);
+            not_register
+        } else {
+            result_register
+        }
+    }
+
+    fn reduce_registers(
+        &mut self,
+        registers: &[String],
+        prefix: &'static str,
+        combine: fn(&mut QirWriter, &str, &str, &str),
+    ) -> String {
+        let (first, rest) = registers
+            .split_first()
+            .expect("REQUIRE always has at least one target");
+        let mut acc = first.clone();
+        for reg in rest {
+            let temp = self.id_map.fresh_name(prefix);
+            combine(&mut self.writer, &temp, &acc, reg);
+            acc = temp;
+        }
+        acc
     }
 
     fn resolve_record_offset(&mut self, target: &Target, offset: u32) -> Option<u32> {

--- a/source/compiler/stim_compiler/src/qir/tests/select_block.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/select_block.rs
@@ -198,6 +198,79 @@ fn multiple_requires_in_block() {
 }
 
 #[test]
+fn multiple_targets_in_require() {
+    let source = indoc! {"
+      SELECT {
+        M 0
+        M 1
+        M 2
+        M 3
+        REQUIRE rec[-1] rec[-2] rec[-3] rec[-4]
+      }
+    "};
+    check(
+        source,
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              br label %select_0
+            select_0:
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 3 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 3 to ptr))
+              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 3 to ptr))
+              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+              %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+              %l_3 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+              %r_3 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+              %loss_0 = or i1 %l_0, %l_1
+              %loss_1 = or i1 %loss_0, %l_2
+              %loss_2 = or i1 %loss_1, %l_3
+              %parity_0 = xor i1 %r_0, %r_1
+              %parity_1 = xor i1 %parity_0, %r_2
+              %parity_2 = xor i1 %parity_1, %r_3
+              %restart_0 = or i1 %loss_2, %parity_2
+              br i1 %restart_0, label %select_0, label %continue_0
+            continue_0:
+              call void @__quantum__rt__array_record_output(i64 4, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 3 to ptr), ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
+            declare i1 @__quantum__rt__read_result(ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+#[test]
 fn select_block_no_require() {
     // should compile to a QIR that works as if there was no select
     let source = indoc! {"

--- a/source/compiler/stim_compiler/src/qir/tests/select_block.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/select_block.rs
@@ -22,16 +22,19 @@ fn simple_select_block() {
               br label %select_0
             select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %select_0, label %continue_0
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
               ret i64 0
             }
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
@@ -81,12 +84,18 @@ fn long_select_block() {
               call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
               call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
               %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %x_0 = xor i1 %r_0, %r_1
-              %x_1 = xor i1 %x_0, %r_2
-              br i1 %x_1, label %select_0, label %continue_0
+              %loss_0 = or i1 %l_0, %l_1
+              %loss_1 = or i1 %loss_0, %l_2
+              %parity_0 = xor i1 %r_0, %r_1
+              %parity_1 = xor i1 %parity_0, %r_2
+              %restart_0 = or i1 %loss_1, %parity_1
+              br i1 %restart_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 3, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -95,11 +104,12 @@ fn long_select_block() {
               ret i64 0
             }
 
-            declare void @__quantum__qis__h__body(ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare i1 @__quantum__rt__read_result(ptr)
+            declare void @__quantum__qis__h__body(ptr)
             declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
 
@@ -140,14 +150,20 @@ fn multiple_requires_in_block() {
               br label %select_0
             select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %select_0, label %continue_0
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
               %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %x_0 = xor i1 %r_1, %r_2
-              br i1 %x_0, label %select_0, label %continue_1
+              %loss_0 = or i1 %l_1, %l_2
+              %parity_0 = xor i1 %r_1, %r_2
+              %restart_1 = or i1 %loss_0, %parity_0
+              br i1 %restart_1, label %select_0, label %continue_1
             continue_1:
               call void @__quantum__rt__array_record_output(i64 2, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -155,8 +171,9 @@ fn multiple_requires_in_block() {
               ret i64 0
             }
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
@@ -333,16 +350,19 @@ fn select_block_with_tag() {
               br label %select_0
             select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %select_0, label %continue_0
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
               ret i64 0
             }
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
@@ -382,17 +402,20 @@ fn require_with_negated_target() {
               br label %select_0
             select_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %r_1 = xor i1 %r_0, true
-              br i1 %r_1, label %select_0, label %continue_0
+              %n_0 = xor i1 %r_0, true
+              %restart_0 = or i1 %l_0, %n_0
+              br i1 %restart_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
               ret i64 0
             }
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
@@ -644,16 +667,19 @@ fn measure_reset_counts_as_measurement() {
               br label %select_0
             select_0:
               call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %select_0, label %continue_0
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
               ret i64 0
             }
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__mresetz__body(ptr, ptr)
@@ -695,8 +721,10 @@ fn pair_measurement_record_in_select() {
               call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
               call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %select_0, label %continue_0
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
             continue_0:
               call void @__quantum__rt__array_record_output(i64 1, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -704,8 +732,9 @@ fn pair_measurement_record_in_select() {
             }
 
             declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
@@ -777,12 +806,16 @@ fn nested_select_blocks() {
               br label %select_1
             select_1:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %select_1, label %continue_0
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_1, label %continue_0
             continue_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
               %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              br i1 %r_1, label %select_0, label %continue_1
+              %restart_1 = or i1 %l_1, %r_1
+              br i1 %restart_1, label %select_0, label %continue_1
             continue_1:
               call void @__quantum__rt__array_record_output(i64 2, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -790,8 +823,9 @@ fn nested_select_blocks() {
               ret i64 0
             }
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
@@ -843,16 +877,22 @@ fn deeply_nested_select_blocks() {
               br label %select_2
             select_2:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
               %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              br i1 %r_0, label %select_2, label %continue_0
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_2, label %continue_0
             continue_0:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
               %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              br i1 %r_1, label %select_1, label %continue_1
+              %restart_1 = or i1 %l_1, %r_1
+              br i1 %restart_1, label %select_1, label %continue_1
             continue_1:
               call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
               %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-              br i1 %r_2, label %select_0, label %continue_2
+              %restart_2 = or i1 %l_2, %r_2
+              br i1 %restart_2, label %select_0, label %continue_2
             continue_2:
               call void @__quantum__rt__array_record_output(i64 3, ptr null)
               call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
@@ -861,8 +901,9 @@ fn deeply_nested_select_blocks() {
               ret i64 0
             }
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
             declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
             declare i1 @__quantum__rt__read_result(ptr)
             declare void @__quantum__rt__initialize(ptr)
             declare void @__quantum__qis__m__body(ptr, ptr)
@@ -899,43 +940,46 @@ fn outer_select_reaches_into_inner_select() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          br label %select_1
-        select_1:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          br i1 %r_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              br label %select_0
+            select_0:
+              br label %select_1
+            select_1:
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
+            continue_0:
+              call void @__quantum__rt__array_record_output(i64 1, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              ret i64 0
+            }
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
+            declare i1 @__quantum__rt__read_result(ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
 
-        ; module flags
+            ; module flags
 
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
 
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
     );
 }
 
@@ -954,45 +998,48 @@ fn outer_select_reaches_into_deeply_nested_inner_select() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          br label %select_1
-        select_1:
-          br label %select_2
-        select_2:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          br i1 %r_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              br label %select_0
+            select_0:
+              br label %select_1
+            select_1:
+              br label %select_2
+            select_2:
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
+            continue_0:
+              call void @__quantum__rt__array_record_output(i64 1, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              ret i64 0
+            }
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
+            declare i1 @__quantum__rt__read_result(ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
 
-        ; module flags
+            ; module flags
 
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
 
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
     );
 }
 
@@ -1038,48 +1085,53 @@ fn sibling_select_blocks() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          br i1 %r_0, label %select_0, label %continue_0
-        continue_0:
-          br label %select_1
-        select_1:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-          br i1 %r_1, label %select_1, label %continue_1
-        continue_1:
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              br label %select_0
+            select_0:
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+              %restart_0 = or i1 %l_0, %r_0
+              br i1 %restart_0, label %select_0, label %continue_0
+            continue_0:
+              br label %select_1
+            select_1:
+              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+              %restart_1 = or i1 %l_1, %r_1
+              br i1 %restart_1, label %select_1, label %continue_1
+            continue_1:
+              call void @__quantum__rt__array_record_output(i64 2, ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+              ret i64 0
+            }
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare i1 @__quantum__rt__read_loss(ptr)
+            declare i1 @__quantum__rt__read_result(ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
 
-        ; module flags
+            ; module flags
 
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
 
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
     );
 }
 


### PR DESCRIPTION
In a REQUIRE statement inside of a PREPARE block, we need to make sure that the targets being required aren't LOSS. If they are, then we have to restart the prepare block instead of just continuing (which is what we currently do).

So for example:
```
PREPARE {
    LOSS_ERROR(0.2) 0
    M 0
    REQUIRE rec[-1]
}
```
When plotting the histogram for this, we should only see a 0 result, as the loss leads to a retry.

Meanwhile,
```
PREPARE {
    LOSS_ERROR(1) 0
    M 0
    REQUIRE rec[-1]
}
```
should result in an infinite loop as we are always getting loss