### PR TITLE
Handle corrupt kata progress

### DIFF
--- a/source/vscode/ai/qdk-learning.agent.md
+++ b/source/vscode/ai/qdk-learning.agent.md
@@ -81,6 +81,12 @@ Call `get-state` first. If the user is asking to navigate, run, check, reset, et
 
 Render tool results in chat. Keep responses short and tutor-like.
 
+### Error Handling
+
+When you call `get-state`, you may receive an error indicating a problem loading the user's progress.  When this occurs, you have two options:
+1. **Preferred** Read the error message and the contents of `qdk-learning.json`.  Together, they should indicate what's wrong.  Explain to the user what's wrong and offer to fix the problem.
+2. **Last resort** Explain to the user what's wrong and that you cannot proceed until the problem is resolved.  Offer to delete `qdk-learning.json`, but explain that their progress will be reset.  Do not attempt to delete the file unless the user requests it.
+
 ### Hint Strategy
 
 Call `hint` and `read-code` together. The response contains `hints` (short nudges, easiest→hardest) and `solutionExplanation` (deeper walkthrough).

--- a/source/vscode/ai/qdk-learning.agent.md
+++ b/source/vscode/ai/qdk-learning.agent.md
@@ -83,9 +83,10 @@ Render tool results in chat. Keep responses short and tutor-like.
 
 ### Error Handling
 
-When you call `get-state`, you may receive an error indicating a problem loading the user's progress.  When this occurs, you have two options:
-1. **Preferred** Read the error message and the contents of `qdk-learning.json`.  Together, they should indicate what's wrong.  Explain to the user what's wrong and offer to fix the problem.
-2. **Last resort** Explain to the user what's wrong and that you cannot proceed until the problem is resolved.  Offer to delete `qdk-learning.json`, but explain that their progress will be reset.  Do not attempt to delete the file unless the user requests it.
+When you call `get-state`, you may receive an error indicating a problem loading the user's progress. When this occurs, you have two options:
+
+1. **Preferred** Read the error message and the contents of `qdk-learning.json`. Together, they should indicate what's wrong. Explain to the user what's wrong and offer to fix the problem.
+2. **Last resort** Explain to the user what's wrong and that you cannot proceed until the problem is resolved. Offer to delete `qdk-learning.json`, but explain that their progress will be reset. Do not attempt to delete the file unless the user requests it.
 
 ### Hint Strategy
 

--- a/source/vscode/src/gh-copilot/learningTools.ts
+++ b/source/vscode/src/gh-copilot/learningTools.ts
@@ -107,9 +107,14 @@ export class LearningTools {
    * so the caller can decide whether to prompt for initialization.
    */
   async getState(): Promise<
-    { initialized: false } | ({ initialized: true } & StateSnapshot)
+    | { initialized: false; error?: string }
+    | ({ initialized: true } & StateSnapshot)
   > {
     if (!this.service.initialized) {
+      const progressError = this.service.progressLoadingError;
+      if (progressError) {
+        return { initialized: false, error: progressError };
+      }
       const detected = await detectLearningWorkspace();
       if (!detected) {
         return { initialized: false };

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -1046,13 +1046,21 @@ export class LearningService {
       throw new Error(this._progressLoadingError);
     }
 
-    if (typeof parsed.completions !== "object" || parsed.completions === null) {
+    if (
+      typeof parsed.completions !== "object" ||
+      parsed.completions === null ||
+      Array.isArray(parsed.completions)
+    ) {
       this._progressLoadingError =
         'The qdk-learning.json file is missing or has an invalid "completions" field. Fix or delete the file to continue.';
       throw new Error(this._progressLoadingError);
     }
 
-    if (typeof parsed.position !== "object" || parsed.position === null) {
+    if (
+      typeof parsed.position !== "object" ||
+      parsed.position === null ||
+      Array.isArray(parsed.position)
+    ) {
       this._progressLoadingError =
         'The qdk-learning.json file is missing or has an invalid "position" field. Fix or delete the file to continue.';
       throw new Error(this._progressLoadingError);

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -1035,41 +1035,48 @@ export class LearningService {
       throw new Error(this._progressLoadingError);
     }
 
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      parsed.version === 1 &&
-      typeof parsed.completions === "object" &&
-      parsed.completions !== null &&
-      typeof parsed.position === "object" &&
-      parsed.position !== null
-    ) {
-      ws.progressData = parsed as ProgressFileData;
-      // Validate saved position references a known unit and activity
-      if (ws.catalog.units.length > 0) {
-        const unit = ws.catalog.units.find(
-          (k) => k.id === ws.progressData.position.unitId,
-        );
-        const activityValid =
-          unit &&
-          unit.activities.some(
-            (s) => s.id === ws.progressData.position.activityId,
-          );
-        if (!activityValid) {
-          ws.progressData.position = {
-            courseId: ws.catalog.id,
-            unitId: ws.catalog.units[0].id,
-            activityId: ws.catalog.units[0].activities[0]?.id ?? "",
-          };
-        }
-      }
-      return;
+    if (!parsed || typeof parsed !== "object") {
+      this._progressLoadingError =
+        "The qdk-learning.json file is corrupt (not a JSON object). Fix or delete the file to continue.";
+      throw new Error(this._progressLoadingError);
     }
 
-    // File exists but has unexpected structure.
-    this._progressLoadingError =
-      "The qdk-learning.json file is corrupt (unexpected structure). Fix or delete the file to continue.";
-    throw new Error(this._progressLoadingError);
+    if (parsed.version !== 1) {
+      this._progressLoadingError = `The qdk-learning.json file has an unsupported version (${JSON.stringify(parsed.version)}). Fix or delete the file to continue.`;
+      throw new Error(this._progressLoadingError);
+    }
+
+    if (typeof parsed.completions !== "object" || parsed.completions === null) {
+      this._progressLoadingError =
+        'The qdk-learning.json file is missing or has an invalid "completions" field. Fix or delete the file to continue.';
+      throw new Error(this._progressLoadingError);
+    }
+
+    if (typeof parsed.position !== "object" || parsed.position === null) {
+      this._progressLoadingError =
+        'The qdk-learning.json file is missing or has an invalid "position" field. Fix or delete the file to continue.';
+      throw new Error(this._progressLoadingError);
+    }
+
+    ws.progressData = parsed as ProgressFileData;
+    // Validate saved position references a known unit and activity
+    if (ws.catalog.units.length > 0) {
+      const unit = ws.catalog.units.find(
+        (k) => k.id === ws.progressData.position.unitId,
+      );
+      const activityValid =
+        unit &&
+        unit.activities.some(
+          (s) => s.id === ws.progressData.position.activityId,
+        );
+      if (!activityValid) {
+        ws.progressData.position = {
+          courseId: ws.catalog.id,
+          unitId: ws.catalog.units[0].id,
+          activityId: ws.catalog.units[0].activities[0]?.id ?? "",
+        };
+      }
+    }
   }
 
   private async saveProgress(): Promise<void> {

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -110,11 +110,17 @@ export class LearningService {
   private _progressFileWatcher: vscode.FileSystemWatcher | undefined;
   private _writingProgress = false;
   private _initPromise: Promise<boolean> | undefined;
+  private _progressLoadingError: string | undefined;
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
   get initialized(): boolean {
     return this.workspace !== undefined;
+  }
+
+  /** Non-null when the progress file is corrupt and blocks initialization. */
+  get progressLoadingError(): string | undefined {
+    return this._progressLoadingError;
   }
 
   get learningContentRoot(): vscode.Uri {
@@ -160,7 +166,13 @@ export class LearningService {
 
   dispose(): void {
     if (this.workspace) {
-      this.saveProgress().catch(() => {});
+      this.saveProgress().catch((err) => {
+        vscode.window.showWarningMessage(
+          `Could not save learning progress: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      });
     }
     this._onDidChangeState.dispose();
     this._onDidChangeProgress.dispose();
@@ -658,10 +670,19 @@ export class LearningService {
     const detected = await detectLearningWorkspace();
 
     if (detected) {
-      await this.loadWorkspace(
-        detected.workspaceRoot,
-        detected.learningContentRoot,
-      );
+      try {
+        await this.loadWorkspace(
+          detected.workspaceRoot,
+          detected.learningContentRoot,
+        );
+      } catch (err) {
+        const progressError = this._progressLoadingError;
+        if (progressError) {
+          vscode.window.showErrorMessage(progressError);
+          return false;
+        }
+        throw err;
+      }
       this.startWatcher();
       sendTelemetryEvent(
         EventType.LearningSessionStarted,
@@ -986,52 +1007,69 @@ export class LearningService {
   }
 
   private async loadProgress(ws: WorkspaceState): Promise<void> {
+    let bytes: Uint8Array;
     try {
-      const bytes = await vscode.workspace.fs.readFile(ws.learningFile);
-      const parsed = JSON.parse(new TextDecoder().decode(bytes));
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        parsed.version === 1 &&
-        typeof parsed.completions === "object" &&
-        parsed.completions !== null &&
-        typeof parsed.position === "object" &&
-        parsed.position !== null
-      ) {
-        ws.progressData = parsed as ProgressFileData;
-        // Validate saved position references a known unit and activity
-        if (ws.catalog.units.length > 0) {
-          const unit = ws.catalog.units.find(
-            (k) => k.id === ws.progressData.position.unitId,
-          );
-          const activityValid =
-            unit &&
-            unit.activities.some(
-              (s) => s.id === ws.progressData.position.activityId,
-            );
-          if (!activityValid) {
-            ws.progressData.position = {
-              courseId: ws.catalog.id,
-              unitId: ws.catalog.units[0].id,
-              activityId: ws.catalog.units[0].activities[0]?.id ?? "",
-            };
-          }
-        }
-        return;
-      }
+      bytes = await vscode.workspace.fs.readFile(ws.learningFile);
     } catch {
-      // expected when file is missing or corrupt
+      // File doesn't exist yet — use defaults.
+      ws.progressData = {
+        version: 1,
+        position: {
+          courseId: ws.catalog.id,
+          unitId: ws.catalog.units[0]?.id ?? "",
+          activityId: ws.catalog.units[0]?.activities[0]?.id ?? "",
+        },
+        completions: {},
+        startedAt: new Date().toISOString(),
+      };
+      return;
     }
-    ws.progressData = {
-      version: 1,
-      position: {
-        courseId: ws.catalog.id,
-        unitId: ws.catalog.units[0]?.id ?? "",
-        activityId: ws.catalog.units[0]?.activities[0]?.id ?? "",
-      },
-      completions: {},
-      startedAt: new Date().toISOString(),
-    };
+
+    // File exists — parse and validate.
+    let parsed: any;
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+      this._progressLoadingError =
+        "The qdk-learning.json file contains invalid JSON. Fix or delete the file to continue.";
+      throw new Error(this._progressLoadingError);
+    }
+
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      parsed.version === 1 &&
+      typeof parsed.completions === "object" &&
+      parsed.completions !== null &&
+      typeof parsed.position === "object" &&
+      parsed.position !== null
+    ) {
+      ws.progressData = parsed as ProgressFileData;
+      // Validate saved position references a known unit and activity
+      if (ws.catalog.units.length > 0) {
+        const unit = ws.catalog.units.find(
+          (k) => k.id === ws.progressData.position.unitId,
+        );
+        const activityValid =
+          unit &&
+          unit.activities.some(
+            (s) => s.id === ws.progressData.position.activityId,
+          );
+        if (!activityValid) {
+          ws.progressData.position = {
+            courseId: ws.catalog.id,
+            unitId: ws.catalog.units[0].id,
+            activityId: ws.catalog.units[0].activities[0]?.id ?? "",
+          };
+        }
+      }
+      return;
+    }
+
+    // File exists but has unexpected structure.
+    this._progressLoadingError =
+      "The qdk-learning.json file is corrupt (unexpected structure). Fix or delete the file to continue.";
+    throw new Error(this._progressLoadingError);
   }
 
   private async saveProgress(): Promise<void> {
@@ -1042,6 +1080,13 @@ export class LearningService {
       await vscode.workspace.fs.writeFile(
         ws.learningFile,
         new TextEncoder().encode(json),
+      );
+    } catch (err) {
+      throw new Error(
+        `Failed to save learning progress: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err },
       );
     } finally {
       this._writingProgress = false;


### PR DESCRIPTION
From #3242

When qdk-learning.json is invalid, we need to do something about it before the user can actually use the katas.  Enrich the error messages and give the agent instructions for how to handle errors.  It now does a pretty good job of making simple repairs to the file.