### PR TITLE
docs: added link to playground

### DIFF
--- a/source/playground/README.md
+++ b/source/playground/README.md
@@ -1,6 +1,6 @@
 # Playground
 
-This is a simple web site built using the Monaco editor and the qsharp npm package.
+This is a simple web site built using the Monaco editor and the qsharp npm package. A live version is hosted at https://microsoft.github.io/qdk/, and requires no installation.
 
 ## Building the Playground Locally
 


### PR DESCRIPTION
closes #3474.

This change adds a link to the live hosted playground (https://microsoft.github.io/qdk/) in `playground/README.md`.