### PR TITLE
Redact accessToken and idToken in debug log

### DIFF
--- a/source/vscode/src/azure/auth.ts
+++ b/source/vscode/src/azure/auth.ts
@@ -32,7 +32,14 @@ export async function getAuthSession(
         createIfNone: true,
       });
     }
-    log.debug("Got session: ", JSON.stringify(session, null, 2));
+    log.debug(
+      "Got session: ",
+      JSON.stringify(
+        { ...session, accessToken: "REDACTED", idToken: "REDACTED" },
+        null,
+        2,
+      ),
+    );
     sendTelemetryEvent(
       EventType.AuthSessionEnd,
       {

--- a/source/vscode/src/azure/networkRequests.ts
+++ b/source/vscode/src/azure/networkRequests.ts
@@ -27,7 +27,13 @@ export async function azureRequest(
 
   try {
     log.debug(`Fetching ${uri} with method ${method}`);
-    log.trace("Request headers & body: ", headers, body);
+    log.trace(
+      "Request headers & body: ",
+      headers.map(([k, v]) =>
+        k === "Authorization" ? [k, "REDACTED"] : [k, v],
+      ),
+      body,
+    );
     const response = await fetch(uri, {
       headers,
       method,

--- a/source/vscode/src/azure/networkRequests.ts
+++ b/source/vscode/src/azure/networkRequests.ts
@@ -30,7 +30,9 @@ export async function azureRequest(
     log.trace(
       "Request headers & body: ",
       headers.map(([k, v]) =>
-        k === "Authorization" ? [k, "REDACTED"] : [k, v],
+        k === "Authorization" || k === "x-ms-quantum-api-key"
+          ? [k, "REDACTED"]
+          : [k, v],
       ),
       body,
     );


### PR DESCRIPTION
Reduces log spew and protects user tokens.