### PR TITLE
switch OpenQASM grammar from variable length to fixed length lookbehind

### DIFF
--- a/source/vscode/syntaxes/openqasm.tmLanguage.json
+++ b/source/vscode/syntaxes/openqasm.tmLanguage.json
@@ -47,11 +47,11 @@
       "patterns": [
         {
           "name": "keyword.control.openqasm",
-          "match": "(?<!\\s*\\.\\s*)\\b(in|for|return|if|else|switch|while)\\b(?!\\s*\\.)"
+          "match": "(?<!\\.)\\b(in|for|return|if|else|switch|while)\\b(?!\\s*\\.)"
         },
         {
           "name": "keyword.other.openqasm",
-          "match": "(?<!\\s*\\.\\s*)\\b(OPENQASM|include|qubit|reset|mutable|readonly|#dim|stretch|delay|barrier|box|input|output|int|float|bit|bool|uint|angle|complex|const|defcal|def|gate|array|duration|let|measure|pragma|defcalgrammar|cal|qreg|creg|extern|port|frame|waveform)\\b(?!\\s*\\.)"
+          "match": "(?<!\\.)\\b(OPENQASM|include|qubit|reset|mutable|readonly|#dim|stretch|delay|barrier|box|input|output|int|float|bit|bool|uint|angle|complex|const|defcal|def|gate|array|duration|let|measure|pragma|defcalgrammar|cal|qreg|creg|extern|port|frame|waveform)\\b(?!\\s*\\.)"
         }
       ]
     },


### PR DESCRIPTION
Fixes #3479 

This should have minimal impact (only edge cases). The intent is preserved - don't highlight as keywords when used as member access. 

It really only affects member access where whitespace or a line break sits between the `.` AND an identifier that happens to match one of the keywords.

For example none of the committed qasm/inc files has such edge case.