### PR TITLE
fix deprecated assign update expression for nested expressions

### DIFF
--- a/source/compiler/qsc_linter/src/lints/ast.rs
+++ b/source/compiler/qsc_linter/src/lints/ast.rs
@@ -297,13 +297,33 @@ impl AstLintPass for DeprecatedAssignUpdateExpr {
         if let ExprKind::AssignUpdate(record, index, value) = expr.kind.as_ref()
             && let Some(Ty::Array(_)) = compilation.compile_unit.ast.tys.terms.get(record.id)
         {
-            let record_src = compilation.get_source_code(record.span);
-            let index_src = compilation.get_source_code(index.span);
+            let mut lhs = format!(
+                "{}[{}]",
+                compilation.get_source_code(record.span),
+                compilation.get_source_code(index.span)
+            );
+
+            let mut value = value;
+            loop {
+                while let ExprKind::Paren(inner) = value.kind.as_ref() {
+                    value = inner;
+                }
+
+                let ExprKind::TernOp(TernOp::Update, inner_record, inner_index, inner_value) =
+                    value.kind.as_ref()
+                else {
+                    break;
+                };
+                if compilation.get_source_code(inner_record.span) != lhs {
+                    break;
+                }
+
+                lhs = format!("{lhs}[{}]", compilation.get_source_code(inner_index.span));
+                value = inner_value;
+            }
+
             let value_src = compilation.get_source_code(value.span);
-            let edits = vec![(
-                format!("{record_src}[{index_src}] = {value_src}"),
-                expr.span,
-            )];
+            let edits = vec![(format!("{lhs} = {value_src}"), expr.span)];
             buffer.push(lint!(
                 self,
                 expr.span,

--- a/source/compiler/qsc_linter/src/lints/ast.rs
+++ b/source/compiler/qsc_linter/src/lints/ast.rs
@@ -287,6 +287,27 @@ impl AstLintPass for DiscourageChainAssignment {
     }
 }
 
+fn is_pure_expr(expr: &Expr) -> bool {
+    match expr.kind.as_ref() {
+        ExprKind::Lit(_) | ExprKind::Path(_) | ExprKind::Hole => true,
+        ExprKind::Paren(inner) | ExprKind::UnOp(_, inner) | ExprKind::Field(inner, _) => {
+            is_pure_expr(inner)
+        }
+        ExprKind::BinOp(_, lhs, rhs)
+        | ExprKind::Index(lhs, rhs)
+        | ExprKind::ArrayRepeat(lhs, rhs) => is_pure_expr(lhs) && is_pure_expr(rhs),
+        ExprKind::TernOp(_, first, second, third) => {
+            is_pure_expr(first) && is_pure_expr(second) && is_pure_expr(third)
+        }
+        ExprKind::Array(exprs) | ExprKind::Tuple(exprs) => exprs.iter().all(|e| is_pure_expr(e)),
+        ExprKind::Range(start, step, end) => [start, step, end]
+            .into_iter()
+            .flatten()
+            .all(|e| is_pure_expr(e)),
+        _ => false,
+    }
+}
+
 #[derive(Default)]
 struct DeprecatedAssignUpdateExpr {
     level: LintLevel,
@@ -303,6 +324,7 @@ impl AstLintPass for DeprecatedAssignUpdateExpr {
                 compilation.get_source_code(index.span)
             );
 
+            let mut prefix_is_pure = is_pure_expr(record) && is_pure_expr(index);
             let mut value = value;
             loop {
                 while let ExprKind::Paren(inner) = value.kind.as_ref() {
@@ -317,8 +339,12 @@ impl AstLintPass for DeprecatedAssignUpdateExpr {
                 if compilation.get_source_code(inner_record.span) != lhs {
                     break;
                 }
+                if !prefix_is_pure {
+                    break;
+                }
 
                 lhs = format!("{lhs}[{}]", compilation.get_source_code(inner_index.span));
+                prefix_is_pure = prefix_is_pure && is_pure_expr(inner_index);
                 value = inner_value;
             }
 

--- a/source/compiler/qsc_linter/src/tests.rs
+++ b/source/compiler/qsc_linter/src/tests.rs
@@ -1010,6 +1010,139 @@ fn deprecated_assign_update_expr_mismatched_code_action() {
 }
 
 #[test]
+fn deprecated_assign_update_expr_impure_index_single_level_code_action() {
+    check(
+        "function NextIndex() : Int { 0 }
+        function RunProgram() : Unit {
+            mutable a = [[1, 2], [3, 4]];
+            a w/= NextIndex() <- (a[NextIndex()] w/ 1 <- 7);
+        }",
+        &expect![[r#"
+            [
+                SrcLint {
+                    source: "a w/= NextIndex() <- (a[NextIndex()] w/ 1 <- 7)",
+                    level: Allow,
+                    message: "deprecated use of update assignment expressions",
+                    help: "update assignment expressions \"a w/= b <- c\" are deprecated; consider using explicit assignment instead \"a[b] = c\"",
+                    code_action: Some(
+                        CodeAction {
+                            title: "Replace update assignment expression with explicit assignment",
+                            edits: [
+                                (
+                                    "a[NextIndex()] = a[NextIndex()] w/ 1 <- 7",
+                                    Span {
+                                        lo: 154,
+                                        hi: 201,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+                SrcLint {
+                    source: "a[NextIndex()] w/ 1 <- 7",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn deprecated_assign_update_expr_impure_value_pure_indices_code_action() {
+    check(
+        "function NextValue() : Int { 0 }
+        function RunProgram() : Unit {
+            mutable a = [[1, 2], [3, 4]];
+            a w/= 0 <- (a[0] w/ 1 <- NextValue());
+        }",
+        &expect![[r#"
+            [
+                SrcLint {
+                    source: "a w/= 0 <- (a[0] w/ 1 <- NextValue())",
+                    level: Allow,
+                    message: "deprecated use of update assignment expressions",
+                    help: "update assignment expressions \"a w/= b <- c\" are deprecated; consider using explicit assignment instead \"a[b] = c\"",
+                    code_action: Some(
+                        CodeAction {
+                            title: "Replace update assignment expression with explicit assignment",
+                            edits: [
+                                (
+                                    "a[0][1] = NextValue()",
+                                    Span {
+                                        lo: 154,
+                                        hi: 191,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+                SrcLint {
+                    source: "a[0] w/ 1 <- NextValue()",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn deprecated_assign_update_expr_impure_middle_index_partial_merge_code_action() {
+    check(
+        "function NextIndex() : Int { 0 }
+        function RunProgram() : Unit {
+            mutable a = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
+            a w/= 0 <- (a[0] w/ NextIndex() <- (a[0][NextIndex()] w/ 1 <- 7));
+        }",
+        &expect![[r#"
+            [
+                SrcLint {
+                    source: "a w/= 0 <- (a[0] w/ NextIndex() <- (a[0][NextIndex()] w/ 1 <- 7))",
+                    level: Allow,
+                    message: "deprecated use of update assignment expressions",
+                    help: "update assignment expressions \"a w/= b <- c\" are deprecated; consider using explicit assignment instead \"a[b] = c\"",
+                    code_action: Some(
+                        CodeAction {
+                            title: "Replace update assignment expression with explicit assignment",
+                            edits: [
+                                (
+                                    "a[0][NextIndex()] = a[0][NextIndex()] w/ 1 <- 7",
+                                    Span {
+                                        lo: 174,
+                                        hi: 239,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+                SrcLint {
+                    source: "a[0] w/ NextIndex() <- (a[0][NextIndex()] w/ 1 <- 7)",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+                SrcLint {
+                    source: "a[0][NextIndex()] w/ 1 <- 7",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+            ]
+        "#]],
+    );
+}
+
+#[test]
 fn ambiguous_unary_operator_after_if() {
     check(
         &wrap_in_callable("if true { 42 } else { 0 } - 1", CallableKind::Function),

--- a/source/compiler/qsc_linter/src/tests.rs
+++ b/source/compiler/qsc_linter/src/tests.rs
@@ -880,6 +880,136 @@ fn deprecated_assign_update_expr_code_action() {
 }
 
 #[test]
+fn deprecated_assign_update_expr_nested_code_action() {
+    check(
+        &wrap_in_callable(
+            "mutable a = [[1, 2], [3, 4]]; a w/= 1 <- (a[1] w/ 1 <- 7);",
+            CallableKind::Function,
+        ),
+        &expect![[r#"
+            [
+                SrcLint {
+                    source: "a w/= 1 <- (a[1] w/ 1 <- 7)",
+                    level: Allow,
+                    message: "deprecated use of update assignment expressions",
+                    help: "update assignment expressions \"a w/= b <- c\" are deprecated; consider using explicit assignment instead \"a[b] = c\"",
+                    code_action: Some(
+                        CodeAction {
+                            title: "Replace update assignment expression with explicit assignment",
+                            edits: [
+                                (
+                                    "a[1][1] = 7",
+                                    Span {
+                                        lo: 101,
+                                        hi: 128,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+                SrcLint {
+                    source: "a[1] w/ 1 <- 7",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn deprecated_assign_update_expr_deep_nested_code_action() {
+    check(
+        &wrap_in_callable(
+            "mutable a = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]; a w/= 0 <- (a[0] w/ 1 <- (a[0][1] w/ 0 <- 9));",
+            CallableKind::Function,
+        ),
+        &expect![[r#"
+            [
+                SrcLint {
+                    source: "a w/= 0 <- (a[0] w/ 1 <- (a[0][1] w/ 0 <- 9))",
+                    level: Allow,
+                    message: "deprecated use of update assignment expressions",
+                    help: "update assignment expressions \"a w/= b <- c\" are deprecated; consider using explicit assignment instead \"a[b] = c\"",
+                    code_action: Some(
+                        CodeAction {
+                            title: "Replace update assignment expression with explicit assignment",
+                            edits: [
+                                (
+                                    "a[0][1][0] = 9",
+                                    Span {
+                                        lo: 121,
+                                        hi: 166,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+                SrcLint {
+                    source: "a[0] w/ 1 <- (a[0][1] w/ 0 <- 9)",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+                SrcLint {
+                    source: "a[0][1] w/ 0 <- 9",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn deprecated_assign_update_expr_mismatched_code_action() {
+    check(
+        &wrap_in_callable(
+            "mutable a = [[1, 2], [3, 4]]; a w/= 0 <- (a[1] w/ 1 <- 7);",
+            CallableKind::Function,
+        ),
+        &expect![[r#"
+            [
+                SrcLint {
+                    source: "a w/= 0 <- (a[1] w/ 1 <- 7)",
+                    level: Allow,
+                    message: "deprecated use of update assignment expressions",
+                    help: "update assignment expressions \"a w/= b <- c\" are deprecated; consider using explicit assignment instead \"a[b] = c\"",
+                    code_action: Some(
+                        CodeAction {
+                            title: "Replace update assignment expression with explicit assignment",
+                            edits: [
+                                (
+                                    "a[0] = a[1] w/ 1 <- 7",
+                                    Span {
+                                        lo: 101,
+                                        hi: 128,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+                SrcLint {
+                    source: "a[1] w/ 1 <- 7",
+                    level: Allow,
+                    message: "deprecated use of update expressions",
+                    help: "update expressions \"a w/ b <- c\" are deprecated; consider using explicit assignment instead",
+                    code_action: None,
+                },
+            ]
+        "#]],
+    );
+}
+
+#[test]
 fn ambiguous_unary_operator_after_if() {
     check(
         &wrap_in_callable("if true { 42 } else { 0 } - 1", CallableKind::Function),


### PR DESCRIPTION
## Fix deprecated assign-update quick fix for nested expressions

The `DeprecatedAssignUpdateExpr` quick fix flattens nested `w/=` updates by matching index source text. That's unsafe for impure indices: the flattened form evaluates the index fewer times than the original, changing behavior.

Now it only merges levels where the shared indices are pure, otherwise falling back to the safe single-level rewrite. The assigned value is never required to be pure (it's evaluated once either way).

Example (`NextIndex()` returns a different value each call):

```text
a w/= NextIndex() <- (a[NextIndex()] w/ 1 <- 7)

before →  a[NextIndex()][1] = 7                     // runs NextIndex() once, wrong
after  →  a[NextIndex()] = a[NextIndex()] w/ 1 <- 7 // both calls preserved
```

Pure cases still flatten fully, e.g. `a w/= 0 <- (a[0] w/ 1 <- 7)` → `a[0][1] = 7`.