### PR TITLE
allow repeat-until loops in functions

### DIFF
--- a/source/compiler/qsc_passes/src/callable_limits.rs
+++ b/source/compiler/qsc_passes/src/callable_limits.rs
@@ -31,10 +31,6 @@ pub enum Error {
     #[diagnostic(code("Qdk.Qsc.CallableLimits.QubitAlloc"))]
     QubitAlloc(#[label] Span),
 
-    #[error("functions cannot use repeat-loop expressions")]
-    #[diagnostic(code("Qdk.Qsc.CallableLimits.Repeat"))]
-    Repeat(#[label] Span),
-
     #[error("functions cannot have specializations")]
     #[diagnostic(code("Qdk.Qsc.CallableLimits.Spec"))]
     Spec(#[label] Span),
@@ -78,9 +74,6 @@ impl Visitor<'_> for CallableLimits {
             }
             ExprKind::Conjugate(..) => {
                 self.errors.push(Error::Conjugate(expr.span));
-            }
-            ExprKind::Repeat(..) => {
-                self.errors.push(Error::Repeat(expr.span));
             }
             _ => {}
         }

--- a/source/compiler/qsc_passes/src/callable_limits/tests.rs
+++ b/source/compiler/qsc_passes/src/callable_limits/tests.rs
@@ -121,7 +121,7 @@ fn funcs_cannot_allocate_qubits() {
 }
 
 #[test]
-fn funcs_cannot_use_repeat() {
+fn funcs_can_use_repeat() {
     check(
         indoc! {"
             namespace Test {
@@ -131,14 +131,7 @@ fn funcs_cannot_use_repeat() {
             }
         "},
         &expect![[r#"
-            [
-                Repeat(
-                    Span {
-                        lo: 51,
-                        hi: 71,
-                    },
-                ),
-            ]
+            []
         "#]],
     );
 }


### PR DESCRIPTION
## Allow repeat-until loops in functions

Functions previously rejected `repeat`/`until` loops with the error *"functions cannot use repeat-loop expressions"*, even though `for` and `while` loops were already allowed. A repeat-until loop is ordinary classical control flow, so there was no reason to forbid it in functions.

This also produced contradictory tooling: the `NeedlessOperation` lint suggests turning a non-quantum operation into a function, but doing so failed to compile if the body used a repeat loop.

This removes the restriction in the `callable_limits` pass so functions may use repeat-until loops like any other classical loop. Operations are unaffected.

Fixes #3462

Example:

```qsharp
function CountDown() : Unit {
    mutable x = 3;
    repeat {
        set x -= 1;
    } until x == 0;
}

// before → error: functions cannot use repeat-loop expressions
// after  → compiles
```