### PR TITLE
Avoid spurious out-of-bounds error on iterating over empty array

### DIFF
--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -2661,7 +2661,11 @@ impl<'a> PartialEvaluator<'a> {
             )
             .map_err(Error::from),
             Value::Var(var) => {
-                self.eval_expr_dynamic_index(&array, var, array_package_span, index_package_span)
+                let array_ty = &self.get_expr(array_expr_id).ty;
+                let Ty::Array(elem_ty) = array_ty else {
+                    panic!("expected array type in index expression");
+                };
+                self.eval_expr_dynamic_index(&array, var, array_package_span, elem_ty)
             }
             _ => panic!("invalid kind of value for index"),
         }?;
@@ -4648,10 +4652,9 @@ impl<'a> PartialEvaluator<'a> {
         array: &Rc<Vec<Value>>,
         var: Var,
         array_package_span: PackageSpan,
-        index_package_span: PackageSpan,
+        array_elem_ty: &Ty,
     ) -> Result<Value, Error> {
-        let array_literal =
-            convert_to_array_literal(array, array_package_span, index_package_span)?;
+        let array_literal = convert_to_array_literal(array, array_package_span, array_elem_ty)?;
         let array_elem_ty = array_literal.ty;
 
         let const_array_id = if let Some(idx) = self
@@ -5090,21 +5093,9 @@ fn try_get_eval_var_type(value: &Value) -> Option<VarTy> {
 fn convert_to_array_literal(
     array: &Rc<Vec<Value>>,
     array_package_span: PackageSpan,
-    index_package_span: PackageSpan,
+    array_elem_ty: &Ty,
 ) -> Result<rir::ArrayLiteral, Error> {
-    if array.is_empty() {
-        // Even though we don't know what the index value is, we know any index into an empty array is out of range,
-        // so just return an error with index 0 here.
-        return Err(EvalError::IndexOutOfRange(0, index_package_span).into());
-    }
-
-    let elem_varty = try_get_eval_var_type(&array[0]).ok_or_else(|| {
-        Error::Unimplemented(
-            format!("array element type `{}`", array[0].type_name()),
-            array_package_span,
-        )
-    })?;
-    let rir::Ty::Prim(elem_rir_prim_ty) = map_eval_var_type_to_rir_type(elem_varty) else {
+    let Ok(rir::Ty::Prim(elem_rir_prim_ty)) = map_fir_type_to_rir_type(array_elem_ty) else {
         return Err(Error::Unexpected(
             "array with non-primitive RIR type".to_string(),
             array_package_span,

--- a/source/compiler/qsc_partial_eval/src/tests/loops.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/loops.rs
@@ -869,6 +869,97 @@ fn for_loop_over_qubits_unrolled() {
 }
 
 #[test]
+fn for_loop_over_empty_array_emits_successfully() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Unit {
+                use q = Qubit();
+                for theta in [] {
+                    Rx(theta, q);
+                }
+            }
+        }
+        "#,
+    });
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: Integer
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__rt__initialize
+                    call_type: Regular
+                    input_type:
+                        [0]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: Rx
+                    call_type: Regular
+                    input_type:
+                        [0]: Double
+                        [1]: Qubit
+                    input_vars:
+                        [0]: 4
+                        [1]: 5
+                    output_type: <VOID>
+                    body: 4
+                Callable 3: Callable:
+                    name: __quantum__qis__rx__body
+                    call_type: Regular
+                    input_type:
+                        [0]: Double
+                        [1]: Qubit
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Pointer, )
+                    Variable(0, Integer) = Store Integer(0)
+                    Jump(1)
+                Block 1: Block:
+                    Variable(1, Boolean) = Icmp Slt, Variable(0, Integer), Integer(0)
+                    Branch Variable(1, Boolean), 3, 2
+                Block 2: Block:
+                    Call id(4), args( Integer(0), Tag(0, 3), )
+                    Return Integer(0)
+                Block 3: Block:
+                    Variable(2, Double) = Index Array(0), Variable(0, Integer)
+                    Variable(3, Double) = Store Variable(2, Double)
+                    Call id(2), args( Variable(3, Double), Qubit(0), )
+                    Variable(6, Integer) = Add Variable(0, Integer), Integer(1)
+                    Variable(0, Integer) = Store Variable(6, Integer)
+                    Jump(1)
+                Block 4: Block:
+                    Call id(3), args( Variable(4, Double), Variable(5, Qubit), )
+                    Return
+            config: Config:
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | StaticSizedArrays | CallSupport)
+            num_qubits: 1
+            num_results: 0
+            tags:
+                [0]: 0_t
+            array_literals:
+                [0]: []
+    "#]].assert_eq(&program.to_string());
+}
+
+#[test]
 fn rotation_call_within_a_while_loop() {
     let program = get_rir_program_with_adaptive_profile(indoc! {
         r#"


### PR DESCRIPTION
This fixes an issue with QIR codegen where partial evaluation for `Adaptive` profile would return an out-of-bounds error on iteration over an empty array because it could not infer the type of the array from the contents. Instead, propagating the type information from the outer expression allows the code to be generated, despite the fact that the iteration should never actually occur.