### PR TITLE
Propagate static values through Partial Eval

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -971,21 +971,21 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
         block_1:
           br label %block_2
         block_2:
-          %var_235 = phi i1 [true, %block_0], [false, %block_1]
+          %var_187 = phi i1 [true, %block_0], [false, %block_1]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
           %var_11 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 1 to %Result*))
           br i1 %var_11, label %block_3, label %block_4
         block_3:
           br label %block_4
         block_4:
-          %var_236 = phi i1 [%var_235, %block_2], [false, %block_3]
+          %var_188 = phi i1 [%var_187, %block_2], [false, %block_3]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
           %var_13 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 2 to %Result*))
           br i1 %var_13, label %block_5, label %block_6
         block_5:
           br label %block_6
         block_6:
-          %var_237 = phi i1 [%var_236, %block_4], [false, %block_5]
+          %var_189 = phi i1 [%var_188, %block_4], [false, %block_5]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -1002,21 +1002,21 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
         block_7:
           br label %block_8
         block_8:
-          %var_238 = phi i1 [true, %block_6], [false, %block_7]
+          %var_190 = phi i1 [true, %block_6], [false, %block_7]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
           %var_27 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 4 to %Result*))
           br i1 %var_27, label %block_9, label %block_10
         block_9:
           br label %block_10
         block_10:
-          %var_239 = phi i1 [%var_238, %block_8], [false, %block_9]
+          %var_191 = phi i1 [%var_190, %block_8], [false, %block_9]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
           %var_29 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 5 to %Result*))
           br i1 %var_29, label %block_11, label %block_12
         block_11:
           br label %block_12
         block_12:
-          %var_240 = phi i1 [%var_239, %block_10], [false, %block_11]
+          %var_192 = phi i1 [%var_191, %block_10], [false, %block_11]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -1075,26 +1075,26 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
-          %var_154 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 6 to %Result*))
-          br i1 %var_154, label %block_13, label %block_14
+          %var_122 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 6 to %Result*))
+          br i1 %var_122, label %block_13, label %block_14
         block_13:
           br label %block_14
         block_14:
-          %var_241 = phi i1 [true, %block_12], [false, %block_13]
+          %var_193 = phi i1 [true, %block_12], [false, %block_13]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
-          %var_156 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 7 to %Result*))
-          br i1 %var_156, label %block_15, label %block_16
+          %var_124 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 7 to %Result*))
+          br i1 %var_124, label %block_15, label %block_16
         block_15:
           br label %block_16
         block_16:
-          %var_242 = phi i1 [%var_241, %block_14], [false, %block_15]
+          %var_194 = phi i1 [%var_193, %block_14], [false, %block_15]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 8 to %Result*))
-          %var_158 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 8 to %Result*))
-          br i1 %var_158, label %block_17, label %block_18
+          %var_126 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 8 to %Result*))
+          br i1 %var_126, label %block_17, label %block_18
         block_17:
           br label %block_18
         block_18:
-          %var_243 = phi i1 [%var_242, %block_16], [false, %block_17]
+          %var_195 = phi i1 [%var_194, %block_16], [false, %block_17]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
@@ -1133,32 +1133,32 @@ fn deutsch_jozsa_sample_shape_generates_qir() {
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 9 to %Result*))
-          %var_227 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 9 to %Result*))
-          br i1 %var_227, label %block_19, label %block_20
+          %var_179 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 9 to %Result*))
+          br i1 %var_179, label %block_19, label %block_20
         block_19:
           br label %block_20
         block_20:
-          %var_244 = phi i1 [true, %block_18], [false, %block_19]
+          %var_196 = phi i1 [true, %block_18], [false, %block_19]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 10 to %Result*))
-          %var_229 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 10 to %Result*))
-          br i1 %var_229, label %block_21, label %block_22
+          %var_181 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 10 to %Result*))
+          br i1 %var_181, label %block_21, label %block_22
         block_21:
           br label %block_22
         block_22:
-          %var_245 = phi i1 [%var_244, %block_20], [false, %block_21]
+          %var_197 = phi i1 [%var_196, %block_20], [false, %block_21]
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 11 to %Result*))
-          %var_231 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 11 to %Result*))
-          br i1 %var_231, label %block_23, label %block_24
+          %var_183 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 11 to %Result*))
+          br i1 %var_183, label %block_23, label %block_24
         block_23:
           br label %block_24
         block_24:
-          %var_246 = phi i1 [%var_245, %block_22], [false, %block_23]
+          %var_198 = phi i1 [%var_197, %block_22], [false, %block_23]
           call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 3 to %Qubit*))
           call void @__quantum__rt__array_record_output(i64 4, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_237, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_240, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_243, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
-          call void @__quantum__rt__bool_record_output(i1 %var_246, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_189, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_192, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_195, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
+          call void @__quantum__rt__bool_record_output(i1 %var_198, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
           ret i64 0
         }
 

--- a/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
@@ -2298,26 +2298,40 @@ fn value_returning_ir_function_rir_reloads_after_same_block_store() {
 #[test]
 fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
     let source = "
-    operation Main() : Result {
-        use q = Qubit();
-        Std.StatePreparation.PreparePureStateD([0.0, 1.0], [q]);
-        MResetZ(q)
+    operation Main() : Result[] {
+        use qs = Qubit[2];
+        Std.StatePreparation.PreparePureStateD([0.5, 0.5, 0.5, 0.5], qs);
+        MResetEachZ(qs)
     }
     ";
     let qir = compile_source_to_qir(source, *CAPABILITIES);
     expect![[r#"
-        @0 = internal constant [4 x i8] c"0_r\00"
+        @0 = internal constant [4 x i8] c"0_a\00"
+        @1 = internal constant [6 x i8] c"1_a0r\00"
+        @2 = internal constant [6 x i8] c"2_a1r\00"
 
         define i64 @ENTRYPOINT__main() #0 {
         block_0:
           call void @__quantum__rt__initialize(ptr null)
           call void @S__Adj(ptr inttoptr (i64 0 to ptr))
           call void @H(ptr inttoptr (i64 0 to ptr))
-          call void @Rz(double 3.141592653589793, ptr inttoptr (i64 0 to ptr))
+          call void @Rz(double 1.5707963267948966, ptr inttoptr (i64 0 to ptr))
           call void @H__Adj(ptr inttoptr (i64 0 to ptr))
           call void @S(ptr inttoptr (i64 0 to ptr))
+          call void @S__Adj(ptr inttoptr (i64 1 to ptr))
+          call void @H(ptr inttoptr (i64 1 to ptr))
+          call void @Rz(double 1.5707963267948966, ptr inttoptr (i64 1 to ptr))
+          call void @CNOT__Adj(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+          call void @CNOT__Adj(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+          call void @H__Adj(ptr inttoptr (i64 1 to ptr))
+          call void @S(ptr inttoptr (i64 1 to ptr))
+          call void @CNOT__Adj(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+          call void @CNOT__Adj(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
           call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr @0)
+          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+          call void @__quantum__rt__array_record_output(i64 2, ptr @0)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr @1)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr @2)
           ret i64 0
         }
 
@@ -2339,33 +2353,43 @@ fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
 
         declare void @__quantum__qis__h__body(ptr)
 
-        define void @Rz(double %var_11, ptr %var_12) {
+        define void @Rz(double %var_7, ptr %var_8) {
         block_3:
-          call void @__quantum__qis__rz__body(double %var_11, ptr %var_12)
+          call void @__quantum__qis__rz__body(double %var_7, ptr %var_8)
           ret void
         }
 
         declare void @__quantum__qis__rz__body(double, ptr)
 
-        define void @H__Adj(ptr %var_13) {
+        define void @H__Adj(ptr %var_9) {
         block_4:
-          call void @__quantum__qis__h__body(ptr %var_13)
+          call void @__quantum__qis__h__body(ptr %var_9)
           ret void
         }
 
-        define void @S(ptr %var_14) {
+        define void @S(ptr %var_10) {
         block_5:
-          call void @__quantum__qis__s__body(ptr %var_14)
+          call void @__quantum__qis__s__body(ptr %var_10)
           ret void
         }
 
         declare void @__quantum__qis__s__body(ptr)
 
+        define void @CNOT__Adj(ptr %var_15, ptr %var_16) {
+        block_6:
+          call void @__quantum__qis__cx__body(ptr %var_15, ptr %var_16)
+          ret void
+        }
+
+        declare void @__quantum__qis__cx__body(ptr, ptr)
+
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
+
+        declare void @__quantum__rt__array_record_output(i64, ptr)
 
         declare void @__quantum__rt__result_record_output(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
         attributes #1 = { "irreversible" }
 
         ; module flags

--- a/source/compiler/qsc/src/codegen/tests/adaptive_ri_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_ri_profile.rs
@@ -614,10 +614,10 @@ fn terminal_result_return_with_qubit_cleanup_generates_rir() {
 #[test]
 fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
     let source = "
-    operation Main() : Result {
-        use q = Qubit();
-        Std.StatePreparation.PreparePureStateD([0.0, 1.0], [q]);
-        MResetZ(q)
+    operation Main() : Result[] {
+        use qs = Qubit[2];
+        Std.StatePreparation.PreparePureStateD([0.5, 0.5, 0.5, 0.5], qs);
+        MResetEachZ(qs)
     }
     ";
     let qir = compile_source_to_qir(source, *CAPABILITIES);
@@ -625,18 +625,32 @@ fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
         %Result = type opaque
         %Qubit = type opaque
 
-        @0 = internal constant [4 x i8] c"0_r\00"
+        @0 = internal constant [4 x i8] c"0_a\00"
+        @1 = internal constant [6 x i8] c"1_a0r\00"
+        @2 = internal constant [6 x i8] c"2_a1r\00"
 
         define i64 @ENTRYPOINT__main() #0 {
         block_0:
           call void @__quantum__rt__initialize(i8* null)
           call void @__quantum__qis__s__adj(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__rz__body(double 3.141592653589793, %Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__rz__body(double 1.5707963267948966, %Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__s__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__s__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__rz__body(double 1.5707963267948966, %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__s__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 2, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
           ret i64 0
         }
 
@@ -650,11 +664,15 @@ fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
 
         declare void @__quantum__qis__s__body(%Qubit*)
 
+        declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+
         declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
         attributes #1 = { "irreversible" }
 
         ; module flags

--- a/source/compiler/qsc/src/codegen/tests/adaptive_rif_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_rif_profile.rs
@@ -711,10 +711,10 @@ fn dynamic_double_intrinsic() {
 #[test]
 fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
     let source = "
-    operation Main() : Result {
-        use q = Qubit();
-        Std.StatePreparation.PreparePureStateD([0.0, 1.0], [q]);
-        MResetZ(q)
+    operation Main() : Result[] {
+        use qs = Qubit[2];
+        Std.StatePreparation.PreparePureStateD([0.5, 0.5, 0.5, 0.5], qs);
+        MResetEachZ(qs)
     }
     ";
     let qir = compile_source_to_qir(source, *CAPABILITIES);
@@ -722,18 +722,32 @@ fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
         %Result = type opaque
         %Qubit = type opaque
 
-        @0 = internal constant [4 x i8] c"0_r\00"
+        @0 = internal constant [4 x i8] c"0_a\00"
+        @1 = internal constant [6 x i8] c"1_a0r\00"
+        @2 = internal constant [6 x i8] c"2_a1r\00"
 
         define i64 @ENTRYPOINT__main() #0 {
         block_0:
           call void @__quantum__rt__initialize(i8* null)
           call void @__quantum__qis__s__adj(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__rz__body(double 3.141592653589793, %Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__rz__body(double 1.5707963267948966, %Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__s__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__s__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__rz__body(double 1.5707963267948966, %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__s__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
           call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 2, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
           ret i64 0
         }
 
@@ -747,11 +761,15 @@ fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
 
         declare void @__quantum__qis__s__body(%Qubit*)
 
+        declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+
         declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
         attributes #1 = { "irreversible" }
 
         ; module flags

--- a/source/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/source/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -12,7 +12,7 @@ use qsc_rir::rir::{BlockId, Literal, VariableId};
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
-use crate::ScopeDbgContext;
+use crate::{ScopeDbgContext, is_static_value};
 
 /// Struct that keeps track of the active RIR blocks (where RIR instructions are added) and the active scopes (which
 /// correspond to the Q#'s program call stack).
@@ -144,9 +144,15 @@ impl Scope {
                     Arg::Discard(value) => value,
                     Arg::Var(_, var) => &var.value,
                 };
-                ComputeKind::Dynamic {
-                    runtime_features: RuntimeFeatureFlags::empty(),
-                    value_kind: map_eval_value_to_value_kind(value),
+                if is_static_value(value) {
+                    // When values are statically known, treat them as such so the new scope's
+                    // application generator set is seeded properly.
+                    ComputeKind::Static
+                } else {
+                    ComputeKind::Dynamic {
+                        runtime_features: RuntimeFeatureFlags::empty(),
+                        value_kind: map_eval_value_to_value_kind(value),
+                    }
                 }
             })
             .collect();

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -4740,8 +4740,8 @@ impl<'a> PartialEvaluator<'a> {
 // to full evaluation without requiring any emission of RIR instructions.
 fn is_static_value(args_value: &Value) -> bool {
     match args_value {
-        // Qubit/Result ids and variables values cannot be treated as static.
-        Value::Qubit(_) | Value::Result(val::Result::Id(_)) | Value::Var(_) => false,
+        // Result ids and variables values cannot be treated as static.
+        Value::Result(val::Result::Id(_)) | Value::Var(_) => false,
         Value::Array(inner) => inner.iter().all(is_static_value),
         Value::Tuple(inner, _) => inner.iter().all(is_static_value),
         Value::Closure(c) => c.fixed_args.iter().all(is_static_value),

--- a/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
@@ -9,21 +9,21 @@
 define i64 @ENTRYPOINT__main() #0 {
 block_0:
   %var_3 = alloca i64
-  %var_13 = alloca i64
+  %var_12 = alloca i64
   call void @__quantum__rt__initialize(ptr null)
   call void @X(ptr inttoptr (i64 5 to ptr))
   store i64 0, ptr %var_3
   br label %block_1
 block_1:
-  %var_20 = load i64, ptr %var_3
-  %var_4 = icmp slt i64 %var_20, 5
+  %var_19 = load i64, ptr %var_3
+  %var_4 = icmp slt i64 %var_19, 5
   br i1 %var_4, label %block_2, label %block_3
 block_2:
-  %var_26 = load i64, ptr %var_3
-  %var_5 = getelementptr ptr, ptr @array0, i64 %var_26
-  %var_27 = load ptr, ptr %var_5
-  call void @H(ptr %var_27)
-  %var_8 = add i64 %var_26, 1
+  %var_25 = load i64, ptr %var_3
+  %var_5 = getelementptr ptr, ptr @array0, i64 %var_25
+  %var_26 = load ptr, ptr %var_5
+  call void @H(ptr %var_26)
+  %var_8 = add i64 %var_25, 1
   store i64 %var_8, ptr %var_3
   br label %block_1
 block_3:
@@ -31,19 +31,19 @@ block_3:
   call void @CNOT(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 5 to ptr))
   call void @CNOT(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 5 to ptr))
   call void @CNOT(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 5 to ptr))
-  store i64 4, ptr %var_13
+  store i64 4, ptr %var_12
   br label %block_4
 block_4:
-  %var_22 = load i64, ptr %var_13
-  %var_14 = icmp sge i64 %var_22, 0
-  br i1 %var_14, label %block_5, label %block_6
+  %var_21 = load i64, ptr %var_12
+  %var_13 = icmp sge i64 %var_21, 0
+  br i1 %var_13, label %block_5, label %block_6
 block_5:
-  %var_23 = load i64, ptr %var_13
-  %var_15 = getelementptr ptr, ptr @array0, i64 %var_23
-  %var_24 = load ptr, ptr %var_15
-  call void @H__Adj(ptr %var_24)
-  %var_18 = add i64 %var_23, -1
-  store i64 %var_18, ptr %var_13
+  %var_22 = load i64, ptr %var_12
+  %var_14 = getelementptr ptr, ptr @array0, i64 %var_22
+  %var_23 = load ptr, ptr %var_14
+  call void @H__Adj(ptr %var_23)
+  %var_17 = add i64 %var_22, -1
+  store i64 %var_17, ptr %var_12
   br label %block_4
 block_6:
   call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
@@ -79,25 +79,25 @@ block_8:
 
 declare void @__quantum__qis__h__body(ptr)
 
-define void @CNOT(ptr %var_11, ptr %var_12) {
+define void @CNOT(ptr %var_10, ptr %var_11) {
 block_9:
-  call void @__quantum__qis__cx__body(ptr %var_11, ptr %var_12)
+  call void @__quantum__qis__cx__body(ptr %var_10, ptr %var_11)
   ret void
 }
 
 declare void @__quantum__qis__cx__body(ptr, ptr)
 
-define void @H__Adj(ptr %var_17) {
+define void @H__Adj(ptr %var_16) {
 block_10:
-  call void @__quantum__qis__h__body(ptr %var_17)
+  call void @__quantum__qis__h__body(ptr %var_16)
   ret void
 }
 
 declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-define void @Reset(ptr %var_20) {
+define void @Reset(ptr %var_19) {
 block_11:
-  call void @__quantum__qis__reset__body(ptr %var_20)
+  call void @__quantum__qis__reset__body(ptr %var_19)
   ret void
 }
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ExpandedTests.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ExpandedTests.ll
@@ -231,17 +231,17 @@ block_33:
 
 declare void @__quantum__qis__rz__body(double, ptr)
 
-define void @Rzz(double %var_62, ptr %var_63, ptr %var_64) {
+define void @Rzz(double %var_59, ptr %var_60, ptr %var_61) {
 block_34:
-  call void @__quantum__qis__rzz__body(double %var_62, ptr %var_63, ptr %var_64)
+  call void @__quantum__qis__rzz__body(double %var_59, ptr %var_60, ptr %var_61)
   ret void
 }
 
 declare void @__quantum__qis__rzz__body(double, ptr, ptr)
 
-define void @CNOT__Adj(ptr %var_65, ptr %var_66) {
+define void @CNOT__Adj(ptr %var_62, ptr %var_63) {
 block_35:
-  call void @__quantum__qis__cx__body(ptr %var_65, ptr %var_66)
+  call void @__quantum__qis__cx__body(ptr %var_62, ptr %var_63)
   ret void
 }
 

--- a/source/samples_test/src/tests/OpenQASM.rs
+++ b/source/samples_test/src/tests/OpenQASM.rs
@@ -41,7 +41,7 @@ pub const SIMPLE1DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18979"];
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 10243"];
+    expect!["generated QIR of length 10241"];
 pub const TELEPORTATION_EXPECT: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_DEBUG: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 2086"];

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -10,8 +10,8 @@ pub const BERNSTEINVAZIRANI_EXPECT: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 29822"];
 pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE_RIF: Expect =
-    expect!["generated QIR of length 20287"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 20214"];
+    expect!["generated QIR of length 20277"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 18472"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =


### PR DESCRIPTION
This change updates how variables with known static values propagate across callable invocations in Partial Evaluation. By recognizing the static values and setting the corresponding argument `ComputeKind` in the call scope, we can ensure the computed application generator set from RCA is invoked properly and unnecessary dynamism is not propagated.