### PR TITLE
use regular comments instead of doc comments for sample file summaries

### DIFF
--- a/samples/algorithms/BernsteinVazirani.qs
+++ b/samples/algorithms/BernsteinVazirani.qs
@@ -1,11 +1,11 @@
-/// # Sample
-/// Bernstein-Vazirani Algorithm
-///
-/// # Description
-/// The Bernstein-Vazirani algorithm determines the value of a bit string
-/// encoded in a function.
-///
-/// This Q# program implements the Bernstein-Vazirani algorithm.
+// # Sample
+// Bernstein-Vazirani Algorithm
+//
+// # Description
+// The Bernstein-Vazirani algorithm determines the value of a bit string
+// encoded in a function.
+//
+// This Q# program implements the Bernstein-Vazirani algorithm.
 import Std.Arrays.*;
 import Std.Convert.*;
 import Std.Diagnostics.*;

--- a/samples/algorithms/BernsteinVaziraniNISQ.qs
+++ b/samples/algorithms/BernsteinVaziraniNISQ.qs
@@ -1,11 +1,11 @@
-/// # Sample
-/// Bernstein-Vazirani Algorithm
-///
-/// # Description
-/// The Bernstein-Vazirani algorithm determines the value of a bit string
-/// encoded in a function.
-///
-/// This Q# program implements the Bernstein-Vazirani algorithm.
+// # Sample
+// Bernstein-Vazirani Algorithm
+//
+// # Description
+// The Bernstein-Vazirani algorithm determines the value of a bit string
+// encoded in a function.
+//
+// This Q# program implements the Bernstein-Vazirani algorithm.
 import Std.Arrays.*;
 import Std.Convert.*;
 import Std.Diagnostics.*;

--- a/samples/algorithms/BitFlipCode.qs
+++ b/samples/algorithms/BitFlipCode.qs
@@ -1,23 +1,23 @@
-/// # Sample
-/// Bit-Flip Code
-///
-/// # Description
-/// This sample demonstrates the three-qubit bit-flip code. This code is a
-/// simple quantum error correction strategy for protecting against a single
-/// bit-flip error by encoding a logical qubit into three physical qubits. A
-/// single bit-flip error is when one of the three physical qubits has its
-/// state changed erroneously in a way that is equivalent to applying the X
-/// gate to it.
-///
-/// The bit-flip correction code works by checking the parity of the physical
-/// qubits. By measuring only their parity, the quantum superposition of the
-/// qubits is preserved. Because all the physical qubits are supposed to have
-/// the same state, when the parity checks detect a difference in state, the
-/// erroneous qubit can be identified and corrected.
-///
-/// This Q# program prepares a logical qubit encoded as three physical qubits
-/// with one of the qubits being bit-flipped. It then identifies and corrects
-/// the flipped qubit.
+// # Sample
+// Bit-Flip Code
+//
+// # Description
+// This sample demonstrates the three-qubit bit-flip code. This code is a
+// simple quantum error correction strategy for protecting against a single
+// bit-flip error by encoding a logical qubit into three physical qubits. A
+// single bit-flip error is when one of the three physical qubits has its
+// state changed erroneously in a way that is equivalent to applying the X
+// gate to it.
+//
+// The bit-flip correction code works by checking the parity of the physical
+// qubits. By measuring only their parity, the quantum superposition of the
+// qubits is preserved. Because all the physical qubits are supposed to have
+// the same state, when the parity checks detect a difference in state, the
+// erroneous qubit can be identified and corrected.
+//
+// This Q# program prepares a logical qubit encoded as three physical qubits
+// with one of the qubits being bit-flipped. It then identifies and corrects
+// the flipped qubit.
 import Std.Math.*;
 import Std.Diagnostics.*;
 

--- a/samples/algorithms/DeutschJozsa.qs
+++ b/samples/algorithms/DeutschJozsa.qs
@@ -1,12 +1,12 @@
-/// # Sample
-/// Deutsch–Jozsa Algorithm
-///
-/// # Description
-/// Deutsch–Jozsa is a quantum algorithm that determines whether a given Boolean
-/// function 𝑓 is constant (0 on all inputs or 1 on all inputs) or balanced
-/// (1 for exactly half of the input domain and 0 for the other half).
-///
-/// This Q# program implements the Deutsch–Jozsa algorithm.
+// # Sample
+// Deutsch–Jozsa Algorithm
+//
+// # Description
+// Deutsch–Jozsa is a quantum algorithm that determines whether a given Boolean
+// function 𝑓 is constant (0 on all inputs or 1 on all inputs) or balanced
+// (1 for exactly half of the input domain and 0 for the other half).
+//
+// This Q# program implements the Deutsch–Jozsa algorithm.
 import Std.Diagnostics.*;
 import Std.Math.*;
 import Std.Measurement.*;

--- a/samples/algorithms/DeutschJozsaNISQ.qs
+++ b/samples/algorithms/DeutschJozsaNISQ.qs
@@ -1,12 +1,12 @@
-/// # Sample
-/// Deutsch–Jozsa Algorithm
-///
-/// # Description
-/// Deutsch–Jozsa is a quantum algorithm that determines whether a given Boolean
-/// function 𝑓 is constant (0 on all inputs or 1 on all inputs) or balanced
-/// (1 for exactly half of the input domain and 0 for the other half).
-///
-/// This Q# program implements the Deutsch–Jozsa algorithm.
+// # Sample
+// Deutsch–Jozsa Algorithm
+//
+// # Description
+// Deutsch–Jozsa is a quantum algorithm that determines whether a given Boolean
+// function 𝑓 is constant (0 on all inputs or 1 on all inputs) or balanced
+// (1 for exactly half of the input domain and 0 for the other half).
+//
+// This Q# program implements the Deutsch–Jozsa algorithm.
 import Std.Measurement.*;
 
 operation Main() : (Result[], Result[]) {

--- a/samples/algorithms/Grover.qs
+++ b/samples/algorithms/Grover.qs
@@ -1,14 +1,14 @@
-/// # Sample
-/// Grover's Search Algorithm
-///
-/// # Description
-/// Grover's search algorithm is a quantum algorithm that finds with high
-/// probability the unique input to a black box function that produces a
-/// particular output value.
-///
-/// This Q# program implements the Grover's search algorithm and applies it
-/// to a specific problem: finding a marked state in a register of qubits.
-/// The marked state selected for this sample is |01010⟩.
+// # Sample
+// Grover's Search Algorithm
+//
+// # Description
+// Grover's search algorithm is a quantum algorithm that finds with high
+// probability the unique input to a black box function that produces a
+// particular output value.
+//
+// This Q# program implements the Grover's search algorithm and applies it
+// to a specific problem: finding a marked state in a register of qubits.
+// The marked state selected for this sample is |01010⟩.
 
 import Std.Convert.*;
 import Std.Math.*;

--- a/samples/algorithms/HiddenShift.qs
+++ b/samples/algorithms/HiddenShift.qs
@@ -1,13 +1,13 @@
-/// # Sample
-/// Hidden Shift
-///
-/// # Description
-/// There is a family of problems known as hidden shift problems, in which it
-/// is given that two Boolean functions 𝑓 and 𝑔 satisfy the relation
-///     𝑔(𝑥) = 𝑓(𝑥 ⊕ 𝑠) for all 𝑥
-/// where 𝑠 is a hidden bit string that we would like to find.
-///
-/// This Q# program implements an algorithm to solve the hidden shift problem.
+// # Sample
+// Hidden Shift
+//
+// # Description
+// There is a family of problems known as hidden shift problems, in which it
+// is given that two Boolean functions 𝑓 and 𝑔 satisfy the relation
+//     𝑔(𝑥) = 𝑓(𝑥 ⊕ 𝑠) for all 𝑥
+// where 𝑠 is a hidden bit string that we would like to find.
+//
+// This Q# program implements an algorithm to solve the hidden shift problem.
 import Std.Arrays.*;
 import Std.Convert.*;
 import Std.Diagnostics.*;

--- a/samples/algorithms/HiddenShiftNISQ.qs
+++ b/samples/algorithms/HiddenShiftNISQ.qs
@@ -1,13 +1,13 @@
-/// # Sample
-/// Hidden Shift
-///
-/// # Description
-/// There is a family of problems known as hidden shift problems, in which it
-/// is given that two Boolean functions 𝑓 and 𝑔 satisfy the relation
-///     𝑔(𝑥) = 𝑓(𝑥 ⊕ 𝑠) for all 𝑥
-/// where 𝑠 is a hidden bit string that we would like to find.
-///
-/// This Q# program implements an algorithm to solve the hidden shift problem.
+// # Sample
+// Hidden Shift
+//
+// # Description
+// There is a family of problems known as hidden shift problems, in which it
+// is given that two Boolean functions 𝑓 and 𝑔 satisfy the relation
+//     𝑔(𝑥) = 𝑓(𝑥 ⊕ 𝑠) for all 𝑥
+// where 𝑠 is a hidden bit string that we would like to find.
+//
+// This Q# program implements an algorithm to solve the hidden shift problem.
 import Std.Arrays.*;
 import Std.Convert.*;
 import Std.Diagnostics.*;

--- a/samples/algorithms/HypercubeLookup/src/Main.qs
+++ b/samples/algorithms/HypercubeLookup/src/Main.qs
@@ -1,5 +1,5 @@
-/// # Sample
-/// Grover Search on hypercube
+// # Sample
+// Grover Search on hypercube
 
 // Import standard libraries
 import Std.Diagnostics.*;

--- a/samples/algorithms/Ising/Simple1dIsingOrder1.qs
+++ b/samples/algorithms/Ising/Simple1dIsingOrder1.qs
@@ -1,14 +1,14 @@
-/// # Sample
-/// Simulation of a simple Ising model evolution
-/// on a 1D grid with first-order Trotterization.
-///
-/// # Description
-/// This sample demonstrates simulation of an Ising model Hamiltonian
-/// on 1D grid of size N using a first-order Trotter-Suzuki approximation.
-/// This sample can be easily simulated classically with the grid of size 9
-/// and 1000 shots. This sample is suitable for Base Profile.
-/// For the purpose of simplicity this sample intentionally doesn't
-/// post-process results or perform eigenvalue estimation.
+// # Sample
+// Simulation of a simple Ising model evolution
+// on a 1D grid with first-order Trotterization.
+//
+// # Description
+// This sample demonstrates simulation of an Ising model Hamiltonian
+// on 1D grid of size N using a first-order Trotter-Suzuki approximation.
+// This sample can be easily simulated classically with the grid of size 9
+// and 1000 shots. This sample is suitable for Base Profile.
+// For the purpose of simplicity this sample intentionally doesn't
+// post-process results or perform eigenvalue estimation.
 operation Main() : Result[] {
     // The size of a 1D grid is N
     let N : Int = 9;

--- a/samples/algorithms/Ising/Simple2dIsingOrder1.qs
+++ b/samples/algorithms/Ising/Simple2dIsingOrder1.qs
@@ -1,14 +1,14 @@
-/// # Sample
-/// Simulation of a simple Ising model evolution
-/// on a 2D grid with first-order Trotterization.
-///
-/// # Description
-/// This sample demonstrates simulation of an Ising model Hamiltonian
-/// on N1xN2 2D grid using a first-order Trotter-Suzuki approximation.
-/// This sample can be easily simulated classically with 3x3 grid and
-/// about 1000 shots. This sample is suitable for Base Profile.
-/// For the purpose of simplicity this sample intentionally doesn't
-/// post-process results or perform eigenvalue estimation.
+// # Sample
+// Simulation of a simple Ising model evolution
+// on a 2D grid with first-order Trotterization.
+//
+// # Description
+// This sample demonstrates simulation of an Ising model Hamiltonian
+// on N1xN2 2D grid using a first-order Trotter-Suzuki approximation.
+// This sample can be easily simulated classically with 3x3 grid and
+// about 1000 shots. This sample is suitable for Base Profile.
+// For the purpose of simplicity this sample intentionally doesn't
+// post-process results or perform eigenvalue estimation.
 operation Main() : Result[] {
     // Dimensions of a 2D grid is N1 x N2
     let N1 : Int = 3;

--- a/samples/algorithms/Ising/Simple2dIsingOrder2.qs
+++ b/samples/algorithms/Ising/Simple2dIsingOrder2.qs
@@ -1,14 +1,14 @@
-/// # Sample
-/// Simulation of a simple Ising model evolution
-/// on a 2D grid with second-order Trotterization.
-///
-/// # Description
-/// This sample demonstrates simulation of an Ising model Hamiltonian
-/// on N1xN2 2D grid using a second-order Trotter-Suzuki approximation.
-/// This sample can be easily simulated classically with 3x3 grid and
-/// about 1000 shots. This sample is suitable for Base Profile.
-/// For the purpose of simplicity this sample intentionally doesn't
-/// post-process results or perform eigenvalue estimation.
+// # Sample
+// Simulation of a simple Ising model evolution
+// on a 2D grid with second-order Trotterization.
+//
+// # Description
+// This sample demonstrates simulation of an Ising model Hamiltonian
+// on N1xN2 2D grid using a second-order Trotter-Suzuki approximation.
+// This sample can be easily simulated classically with 3x3 grid and
+// about 1000 shots. This sample is suitable for Base Profile.
+// For the purpose of simplicity this sample intentionally doesn't
+// post-process results or perform eigenvalue estimation.
 operation Main() : Result[] {
     // Dimensions of a 2D grid is N1 x N2
     let N1 : Int = 3;

--- a/samples/algorithms/MajoranaQubits/src/GateSet.qs
+++ b/samples/algorithms/MajoranaQubits/src/GateSet.qs
@@ -1,9 +1,9 @@
-/// A set of gates built upon the custom measurements
-/// provided by the hardware provider.
-///
-/// Source:
-///  [1] Surface code compilation via edge-disjoint paths
-///      https://arxiv.org/pdf/2110.11493
+// A set of gates built upon the custom measurements
+// provided by the hardware provider.
+//
+// Source:
+//  [1] Surface code compilation via edge-disjoint paths
+//      https://arxiv.org/pdf/2110.11493
 
 /// Apply a CNOT gate to the given qubits.
 /// Source: [1] Figure 3.

--- a/samples/algorithms/MajoranaQubits/src/HardwareIntrinsics.qs
+++ b/samples/algorithms/MajoranaQubits/src/HardwareIntrinsics.qs
@@ -1,5 +1,5 @@
-/// A set of custom measurements exposed from a hardware
-/// provider using Majorana Qubits.
+// A set of custom measurements exposed from a hardware
+// provider using Majorana Qubits.
 
 @Measurement()
 @SimulatableIntrinsic()

--- a/samples/algorithms/MajoranaQubits/src/Main.qs
+++ b/samples/algorithms/MajoranaQubits/src/Main.qs
@@ -1,13 +1,13 @@
-/// # Sample
-/// Majorana Qubits
-///
-/// # Description
-/// In hardware providing majorana qubits, common quantum operations
-/// are implemented using measurements and Pauli corrections. This
-/// sample shows a hypothetical hardware provider exposing some custom
-/// gates to Q# and a small library built on top of it.
+// # Sample
+// Majorana Qubits
+//
+// # Description
+// In hardware providing majorana qubits, common quantum operations
+// are implemented using measurements and Pauli corrections. This
+// sample shows a hypothetical hardware provider exposing some custom
+// gates to Q# and a small library built on top of it.
 
-/// Sample program using custom gates from a hardware provider.
+// Sample program using custom gates from a hardware provider.
 operation Main() : (Result, Result) {
     // Create a Bell Pair in the |𝚽⁺⟩ state.
     use qs = Qubit[2];

--- a/samples/algorithms/PhaseEstimation.qs
+++ b/samples/algorithms/PhaseEstimation.qs
@@ -1,11 +1,11 @@
-/// # Sample
-/// Quantum Phase Estimation
-///
-/// # Description
-/// This sample demonstrates how to use Quantum Phase Estimation (QPE) algorithm
-/// to estimate the eigenvalue of a specific unitary operation.
-/// QPE algorithm is performed by calling `ApplyQPE` library operation.
-/// Run this sample and check the histogram of results.
+// # Sample
+// Quantum Phase Estimation
+//
+// # Description
+// This sample demonstrates how to use Quantum Phase Estimation (QPE) algorithm
+// to estimate the eigenvalue of a specific unitary operation.
+// QPE algorithm is performed by calling `ApplyQPE` library operation.
+// Run this sample and check the histogram of results.
 
 import Std.Math.*;
 

--- a/samples/algorithms/PhaseFlipCode.qs
+++ b/samples/algorithms/PhaseFlipCode.qs
@@ -1,23 +1,23 @@
-/// # Sample
-/// Phase-Flip Code
-///
-/// # Description
-/// This sample demonstrates the three-qubit phase-flip code. This code is a
-/// simple quantum error correction strategy for protecting against a single
-/// phase-flip error by encoding a logical qubit into three physical qubits. A
-/// single phase-flip error is when one of the three physical qubits has its
-/// state changed erroneously in a way that is equivalent to applying the Z
-/// gate to it.
-///
-/// The phase-flip correction code works by checking the parity of the physical
-/// qubits. By measuring only their parity, the quantum superposition of the
-/// qubits is preserved. Because all the physical qubits are supposed to have
-/// the same state, when the parity checks detect a difference in state, the
-/// erroneous qubit can be identified and corrected.
-///
-/// This Q# program prepares a logical qubit encoded as three physical qubits
-/// with one of the qubits being phase-flipped. It then identifies and corrects
-/// the flipped qubit.
+// # Sample
+// Phase-Flip Code
+//
+// # Description
+// This sample demonstrates the three-qubit phase-flip code. This code is a
+// simple quantum error correction strategy for protecting against a single
+// phase-flip error by encoding a logical qubit into three physical qubits. A
+// single phase-flip error is when one of the three physical qubits has its
+// state changed erroneously in a way that is equivalent to applying the Z
+// gate to it.
+//
+// The phase-flip correction code works by checking the parity of the physical
+// qubits. By measuring only their parity, the quantum superposition of the
+// qubits is preserved. Because all the physical qubits are supposed to have
+// the same state, when the parity checks detect a difference in state, the
+// erroneous qubit can be identified and corrected.
+//
+// This Q# program prepares a logical qubit encoded as three physical qubits
+// with one of the qubits being phase-flipped. It then identifies and corrects
+// the flipped qubit.
 import Std.Math.*;
 import Std.Diagnostics.*;
 

--- a/samples/algorithms/QRNG.qs
+++ b/samples/algorithms/QRNG.qs
@@ -1,9 +1,9 @@
-/// # Sample
-/// Quantum Random Number Generator
-///
-/// # Description
-/// This program implements a quantum random number generator by setting qubits
-/// in superposition and then using the measurement results as random bits.
+// # Sample
+// Quantum Random Number Generator
+//
+// # Description
+// This program implements a quantum random number generator by setting qubits
+// in superposition and then using the measurement results as random bits.
 import Std.Convert.*;
 
 operation Main() : Int {

--- a/samples/algorithms/Shor.qs
+++ b/samples/algorithms/Shor.qs
@@ -1,11 +1,11 @@
-/// # Sample
-/// Shor's Algorithm
-///
-/// # Description
-/// Shor's algorithm is a quantum algorithm for finding the prime factors of an
-/// integer.
-///
-/// This Q# program implements Shor's algorithm.
+// # Sample
+// Shor's Algorithm
+//
+// # Description
+// Shor's algorithm is a quantum algorithm for finding the prime factors of an
+// integer.
+//
+// This Q# program implements Shor's algorithm.
 import Std.Convert.*;
 import Std.Diagnostics.*;
 import Std.Random.*;

--- a/samples/algorithms/SimplePhaseEstimation.qs
+++ b/samples/algorithms/SimplePhaseEstimation.qs
@@ -1,13 +1,13 @@
-/// # Sample
-/// Simple Quantum Phase Estimation
-///
-/// # Description
-/// This sample demonstrates how to use ApplyQPE to perform
-/// Quantum Phase Estimation of a simple unitary operation.
-/// Rz gate is used as the unitary operation,
-/// and the eigenvector |1⟩ is chosen for the phase estimation.
-/// Run this sample and check the histogram of results.
-/// This sample is suitable for base profile.
+// # Sample
+// Simple Quantum Phase Estimation
+//
+// # Description
+// This sample demonstrates how to use ApplyQPE to perform
+// Quantum Phase Estimation of a simple unitary operation.
+// Rz gate is used as the unitary operation,
+// and the eigenvector |1⟩ is chosen for the phase estimation.
+// Run this sample and check the histogram of results.
+// This sample is suitable for base profile.
 
 /// # Summary
 /// Estimate the phase of the eigenvalue of the unitary gate U

--- a/samples/algorithms/SimpleVQE.qs
+++ b/samples/algorithms/SimpleVQE.qs
@@ -1,19 +1,19 @@
-/// # Sample
-/// Simplified Sample of a Variational Quantum Eigensolver
-///
-/// # Description
-/// This is an example of a Variational Quantum Eigensolver (VQE).
-/// This example includes:
-///   1. Simple classical optimization to find minimum of a multi-variable function
-///      in order to find an approximation to the minimum eigenvalue of a Hamiltonian
-///   2. Finding Hamiltonian expectation value as a weighted sum of terms.
-///   3. Finding one term expectation value by performing multiple shots.
-///   4. Ansatz state preparation similar to the circuit in the referenced paper.
-/// To keep this sample simple Hamiltonian terms are generated randomly.
-///
-/// # Reference
-/// Ground-state energy estimation of the water molecule on a trapped ion quantum
-/// computer by Yunseong Nam et al., 2019. https://arxiv.org/abs/1902.10171
+// # Sample
+// Simplified Sample of a Variational Quantum Eigensolver
+//
+// # Description
+// This is an example of a Variational Quantum Eigensolver (VQE).
+// This example includes:
+//   1. Simple classical optimization to find minimum of a multi-variable function
+//      in order to find an approximation to the minimum eigenvalue of a Hamiltonian
+//   2. Finding Hamiltonian expectation value as a weighted sum of terms.
+//   3. Finding one term expectation value by performing multiple shots.
+//   4. Ansatz state preparation similar to the circuit in the referenced paper.
+// To keep this sample simple Hamiltonian terms are generated randomly.
+//
+// # Reference
+// Ground-state energy estimation of the water molecule on a trapped ion quantum
+// computer by Yunseong Nam et al., 2019. https://arxiv.org/abs/1902.10171
 
 import Std.Arrays.IsEmpty;
 import Std.Arrays.IndexRange;

--- a/samples/algorithms/SuperdenseCoding.qs
+++ b/samples/algorithms/SuperdenseCoding.qs
@@ -1,13 +1,13 @@
-/// # Sample
-/// Superdense Coding
-///
-/// # Description
-/// Superdense coding is a quantum communication protocol to communicate a
-/// number of classical bits of information by only transmitting a smaller
-/// number of qubits.
-///
-/// This Q# program implements superdense coding to send two classical bits of
-/// information.
+// # Sample
+// Superdense Coding
+//
+// # Description
+// Superdense coding is a quantum communication protocol to communicate a
+// number of classical bits of information by only transmitting a smaller
+// number of qubits.
+//
+// This Q# program implements superdense coding to send two classical bits of
+// information.
 operation Main() : ((Bool, Bool), (Bool, Bool)) {
     use (aliceQubit, bobQubit) = (Qubit(), Qubit());
 

--- a/samples/algorithms/Teleportation.qs
+++ b/samples/algorithms/Teleportation.qs
@@ -1,14 +1,14 @@
-/// # Sample
-/// Quantum Teleportation
-///
-/// # Description
-/// Quantum teleportation provides a way of moving a quantum state from one
-/// location to another without having to move physical particle(s) along with
-/// it. This is done with the help of previously shared quantum entanglement
-/// between the sending and the receiving locations, and classical
-/// communication.
-///
-/// This Q# program implements quantum teleportation.
+// # Sample
+// Quantum Teleportation
+//
+// # Description
+// Quantum teleportation provides a way of moving a quantum state from one
+// location to another without having to move physical particle(s) along with
+// it. This is done with the help of previously shared quantum entanglement
+// between the sending and the receiving locations, and classical
+// communication.
+//
+// This Q# program implements quantum teleportation.
 import Std.Diagnostics.*;
 import Std.Intrinsic.*;
 import Std.Measurement.*;

--- a/samples/circuit_integration/src/Main.qs
+++ b/samples/circuit_integration/src/Main.qs
@@ -1,18 +1,18 @@
-/// # Sample
-/// Circuit Integration
-///
-/// # Description
-/// This sample demonstrates the ability to use circuit files in Q# projects.
-/// It shows how to import and use custom quantum circuits defined in their own files.
-/// The circuit file, JointMeasurement.qsc, contains a joint measurement circuit for three qubits.
-/// This circuit file can be opened in VS Code and edited with a visual editor.
-/// Here, we import a circuit for performing a joint measurement of three
-/// qubits, with one auxiliary qubit. The results of the measurements should always
-/// contain 1 or 3 `Zero` results.
+// # Sample
+// Circuit Integration
+//
+// # Description
+// This sample demonstrates the ability to use circuit files in Q# projects.
+// It shows how to import and use custom quantum circuits defined in their own files.
+// The circuit file, JointMeasurement.qsc, contains a joint measurement circuit for three qubits.
+// This circuit file can be opened in VS Code and edited with a visual editor.
+// Here, we import a circuit for performing a joint measurement of three
+// qubits, with one auxiliary qubit. The results of the measurements should always
+// contain 1 or 3 `Zero` results.
 
 import JointMeasurement.JointMeasurement;
 
-/// Sample program using custom gates from a hardware provider.
+// Sample program using custom gates from a hardware provider.
 operation Main() : Result[] {
     use qs = Qubit[4];
     ApplyToEach(H, qs[0..2]);

--- a/samples/estimation/Dynamics.qs
+++ b/samples/estimation/Dynamics.qs
@@ -1,15 +1,15 @@
-/// # Sample
-/// Quantum Dynamics
-///
-/// # Description
-/// This example demonstrates quantum dynamics in a style tailored for
-/// resource estimation. The sample is specifically the simulation
-/// of an Ising model Hamiltonian on an N1xN2 2D lattice using a
-/// fourth-order Trotter Suzuki product formula, assuming
-/// a 2D qubit architecture with nearest-neighbor connectivity.
-/// The is an example of a program that is not amenable to simulating
-/// classically, but can be run through resource estimation to determine
-/// what size of quantum system would be needed to solve the problem.
+// # Sample
+// Quantum Dynamics
+//
+// # Description
+// This example demonstrates quantum dynamics in a style tailored for
+// resource estimation. The sample is specifically the simulation
+// of an Ising model Hamiltonian on an N1xN2 2D lattice using a
+// fourth-order Trotter Suzuki product formula, assuming
+// a 2D qubit architecture with nearest-neighbor connectivity.
+// The is an example of a program that is not amenable to simulating
+// classically, but can be run through resource estimation to determine
+// what size of quantum system would be needed to solve the problem.
 
 import Std.Math.*;
 import Std.Arrays.*;

--- a/samples/estimation/EkeraHastadFactoring.qs
+++ b/samples/estimation/EkeraHastadFactoring.qs
@@ -1,13 +1,13 @@
-/// # Sample
-/// Resource Estimation for Integer Factoring
-///
-/// # Description
-/// In this sample we concentrate on costing quantum part in the algorithm for
-/// factoring RSA integers based on Ekerå and Håstad
-/// [ia.cr/2017/077](https://eprint.iacr.org/2017/077) based on the
-/// implementation described in
-/// [arXiv:1905.09749](https://arxiv.org/abs/1905.09749). This makes it ideal
-/// for use with the Microsoft Quantum Resource Estimator.
+// # Sample
+// Resource Estimation for Integer Factoring
+//
+// # Description
+// In this sample we concentrate on costing quantum part in the algorithm for
+// factoring RSA integers based on Ekerå and Håstad
+// [ia.cr/2017/077](https://eprint.iacr.org/2017/077) based on the
+// implementation described in
+// [arXiv:1905.09749](https://arxiv.org/abs/1905.09749). This makes it ideal
+// for use with the Microsoft Quantum Resource Estimator.
 import Std.Convert.*;
 import Std.Math.*;
 import Std.ResourceEstimation.*;

--- a/samples/estimation/Precalculated.qs
+++ b/samples/estimation/Precalculated.qs
@@ -1,14 +1,14 @@
-/// # Sample
-/// Using pre-calculated logical counts for resource estimation
-///
-/// # Description
-/// This sample demonstrates how to use the `AccountForEstimates` function to
-/// estimate the resources required to run a factoring program from pre-calculated
-/// logical counts. The logical counts used in this sample are the ones obtained
-/// for a 2048-bit integer factoring application based on the implementation
-/// described in [[Quantum 5, 433 (2021)](https://quantum-journal.org/papers/q-2021-04-15-433/)].
-/// Our implementation incorporates all techniques described in the paper, except for
-/// carry runways.
+// # Sample
+// Using pre-calculated logical counts for resource estimation
+//
+// # Description
+// This sample demonstrates how to use the `AccountForEstimates` function to
+// estimate the resources required to run a factoring program from pre-calculated
+// logical counts. The logical counts used in this sample are the ones obtained
+// for a 2048-bit integer factoring application based on the implementation
+// described in [[Quantum 5, 433 (2021)](https://quantum-journal.org/papers/q-2021-04-15-433/)].
+// Our implementation incorporates all techniques described in the paper, except for
+// carry runways.
 import Std.ResourceEstimation.*;
 
 operation Main() : Unit {

--- a/samples/estimation/ShorRE.qs
+++ b/samples/estimation/ShorRE.qs
@@ -1,11 +1,11 @@
-/// # Sample
-/// Estimating Frequency for Shor's algorithm
-///
-/// # Description
-/// In this sample we concentrate on costing the `EstimateFrequency`
-/// operation, which is the core quantum operation in Shor's algorithm, and
-/// we omit the classical pre- and post-processing. This makes it ideal for
-/// use with the Microsoft Quantum Resource Estimator.
+// # Sample
+// Estimating Frequency for Shor's algorithm
+//
+// # Description
+// In this sample we concentrate on costing the `EstimateFrequency`
+// operation, which is the core quantum operation in Shor's algorithm, and
+// we omit the classical pre- and post-processing. This makes it ideal for
+// use with the Microsoft Quantum Resource Estimator.
 import Std.Arrays.*;
 import Std.Canon.*;
 import Std.Convert.*;

--- a/samples/getting_started/BellPair.qs
+++ b/samples/getting_started/BellPair.qs
@@ -1,13 +1,13 @@
-/// # Summary
-/// Bell Pair sample
-///
-/// # Description
-/// Bell pairs are specific quantum states of two qubits that represent
-/// the simplest (and maximal) examples of quantum entanglement. This sample
-/// prepares |Φ⁺⟩ = (|00⟩+|11⟩)/√2. For other Bell states see BellStates.qs
-///
-/// # References
-/// - [Bell state](https://en.wikipedia.org/wiki/Bell_state)
+// # Summary
+// Bell Pair sample
+//
+// # Description
+// Bell pairs are specific quantum states of two qubits that represent
+// the simplest (and maximal) examples of quantum entanglement. This sample
+// prepares |Φ⁺⟩ = (|00⟩+|11⟩)/√2. For other Bell states see BellStates.qs
+//
+// # References
+// - [Bell state](https://en.wikipedia.org/wiki/Bell_state)
 operation Main() : (Result, Result) {
     // Allocate the two qubits that will be used to create a Bell pair.
     use (q1, q2) = (Qubit(), Qubit());

--- a/samples/getting_started/BellStates.qs
+++ b/samples/getting_started/BellStates.qs
@@ -1,15 +1,15 @@
-/// # Summary
-/// Bell States sample
-///
-/// # Description
-/// This Q# sample shows how to prepare the four different Bell states.
-///
-/// # Remarks
-/// Bell states or EPR pairs are specific quantum states of two qubits
-/// that represent the simplest (and maximal) examples of quantum entanglement.
-///
-/// # References
-/// - [Bell state](https://en.wikipedia.org/wiki/Bell_state)
+// # Summary
+// Bell States sample
+//
+// # Description
+// This Q# sample shows how to prepare the four different Bell states.
+//
+// # Remarks
+// Bell states or EPR pairs are specific quantum states of two qubits
+// that represent the simplest (and maximal) examples of quantum entanglement.
+//
+// # References
+// - [Bell state](https://en.wikipedia.org/wiki/Bell_state)
 operation Main() : (Result, Result)[] {
     // Prepare and measure each pair. Return an array of these results.
     [

--- a/samples/getting_started/CatStates.qs
+++ b/samples/getting_started/CatStates.qs
@@ -1,21 +1,21 @@
-/// # Summary
-/// Greenberger–Horne–Zeilinger state sample
-///
-/// # Description
-/// This Q# program shows how to prepare a generalized Greenberger–Horne–Zeilinger
-/// state (aka Cat state) in a register of 5 qubits.
-///
-/// # Remarks
-/// The Greenberger–Horne–Zeilinger state, or GHZ state, aka Cat state,
-/// is a state defined as: |GHZ〉 = (|0...0〉 + |1...1〉)/√2.
-///
-/// The GHZ state is said to be a maximally entangled state, a multi-qubit
-/// state where the state of any one qubit is not separable from the state
-/// of any of the other qubits.
-///
-/// # References
-/// - [Greenberger–Horne–Zeilinger state](https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state)
-/// - [Cat state](https://en.wikipedia.org/wiki/Cat_state)
+// # Summary
+// Greenberger–Horne–Zeilinger state sample
+//
+// # Description
+// This Q# program shows how to prepare a generalized Greenberger–Horne–Zeilinger
+// state (aka Cat state) in a register of 5 qubits.
+//
+// # Remarks
+// The Greenberger–Horne–Zeilinger state, or GHZ state, aka Cat state,
+// is a state defined as: |GHZ〉 = (|0...0〉 + |1...1〉)/√2.
+//
+// The GHZ state is said to be a maximally entangled state, a multi-qubit
+// state where the state of any one qubit is not separable from the state
+// of any of the other qubits.
+//
+// # References
+// - [Greenberger–Horne–Zeilinger state](https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state)
+// - [Cat state](https://en.wikipedia.org/wiki/Cat_state)
 operation Main() : Result[] {
     // Allocate 5 qubits for Cat₅ state.
     use cat5 = Qubit[5];

--- a/samples/getting_started/Entanglement.qs
+++ b/samples/getting_started/Entanglement.qs
@@ -1,12 +1,12 @@
-/// # Summary
-/// Entanglement sample
-///
-/// # Description
-/// This Q# program entangles two qubits and measures them.
-///
-/// # Remarks
-/// Qubits are said to be entangled when the state of each one of them
-/// cannot be described independently from the state of the others.
+// # Summary
+// Entanglement sample
+//
+// # Description
+// This Q# program entangles two qubits and measures them.
+//
+// # Remarks
+// Qubits are said to be entangled when the state of each one of them
+// cannot be described independently from the state of the others.
 operation Main() : Result[] {
     // Allocate the two qubits that will be entangled.
     use q1 = Qubit();

--- a/samples/getting_started/JointMeasurement.qs
+++ b/samples/getting_started/JointMeasurement.qs
@@ -1,12 +1,12 @@
 import Std.Diagnostics.*;
 
-/// # Summary
-/// Joint Measurement sample
-///
-/// # Description
-/// This Q# program demonstrates how to use Joint measurements.
-/// Joint measurement, also known as Pauli measurements, are a generalization
-/// of 2-outcome measurements to multiple qubits and other bases.
+// # Summary
+// Joint Measurement sample
+//
+// # Description
+// This Q# program demonstrates how to use Joint measurements.
+// Joint measurement, also known as Pauli measurements, are a generalization
+// of 2-outcome measurements to multiple qubits and other bases.
 operation Main() : (Result, Result[]) {
     // Prepare an entangled state.
     use qs = Qubit[2];  // |00〉

--- a/samples/getting_started/Measurement.qs
+++ b/samples/getting_started/Measurement.qs
@@ -1,13 +1,13 @@
-/// # Summary
-/// Measurement sample
-///
-/// # Description
-/// This Q# program demonstrates how to perform measurements in Z basis.
-///
-/// # Remarks
-/// Quantum measurement is an irreversible operation in which a quantum system
-/// is manipulated to yield a numerical result. Measuring a quantum system
-/// generally changes the quantum state that describes that system.
+// # Summary
+// Measurement sample
+//
+// # Description
+// This Q# program demonstrates how to perform measurements in Z basis.
+//
+// # Remarks
+// Quantum measurement is an irreversible operation in which a quantum system
+// is manipulated to yield a numerical result. Measuring a quantum system
+// generally changes the quantum state that describes that system.
 operation Main() : (Result, Result[]) {
     // Allocate a qubit. Qubit is in |0〉 state after allocation.
     use q = Qubit();

--- a/samples/getting_started/QuantumHelloWorld.qs
+++ b/samples/getting_started/QuantumHelloWorld.qs
@@ -1,10 +1,10 @@
-/// # Summary
-/// Quantum Hello World sample
-///
-/// # Description
-/// This is one of the simplest Q# programs that contains quantum part.
-/// This code prints the message then allocates a qubit and immediately measures it.
-/// Since the qubit starts in |0〉 state such measurement will always yield `Zero`.
+// # Summary
+// Quantum Hello World sample
+//
+// # Description
+// This is one of the simplest Q# programs that contains quantum part.
+// This code prints the message then allocates a qubit and immediately measures it.
+// Since the qubit starts in |0〉 state such measurement will always yield `Zero`.
 operation Main() : Result {
     // Print the message (when running on a simulator).
     Message("Hello world!");

--- a/samples/getting_started/RandomBits.qs
+++ b/samples/getting_started/RandomBits.qs
@@ -1,10 +1,10 @@
-/// # Summary
-/// Simple Quantum Random Number Generator sample
-///
-/// # Description
-/// This program implements a quantum random number generator by setting qubits
-/// into superposition and then using the measurement results as random bits.
-/// This is equivalent to generating a random number in the range of 0..2ᴺ-1.
+// # Summary
+// Simple Quantum Random Number Generator sample
+//
+// # Description
+// This program implements a quantum random number generator by setting qubits
+// into superposition and then using the measurement results as random bits.
+// This is equivalent to generating a random number in the range of 0..2ᴺ-1.
 operation Main() : Result[] {
     // Generate a 5-bit random number.
     GenerateNRandomBits(5)

--- a/samples/getting_started/SimpleTeleportation.qs
+++ b/samples/getting_started/SimpleTeleportation.qs
@@ -1,10 +1,10 @@
-/// # Summary
-/// Simple quantum teleportation sample
-///
-/// # Description
-/// This Q# program demonstrates how to teleport quantum state
-/// by communicating two classical bits and using previously entangled qubits.
-/// This code teleports one specific state, but any state can be teleported.
+// # Summary
+// Simple quantum teleportation sample
+//
+// # Description
+// This Q# program demonstrates how to teleport quantum state
+// by communicating two classical bits and using previously entangled qubits.
+// This code teleports one specific state, but any state can be teleported.
 operation Main() : Bool {
     // Allocate `qAlice`, `qBob` qubits
     use (qAlice, qBob) = (Qubit(), Qubit());

--- a/samples/getting_started/Superposition.qs
+++ b/samples/getting_started/Superposition.qs
@@ -1,9 +1,9 @@
-/// # Summary
-/// Superposition sample
-///
-/// # Description
-/// This Q# program sets a qubit in a superposition of the computational basis
-/// states |0〉 and |1〉 by applying a Hadamard transformation.
+// # Summary
+// Superposition sample
+//
+// # Description
+// This Q# program sets a qubit in a superposition of the computational basis
+// states |0〉 and |1〉 by applying a Hadamard transformation.
 operation Main() : Result {
     // Allocate a qubit. Qubit is in |0〉 state after allocation.
     use qubit = Qubit();

--- a/samples/language/CustomMeasurements.qs
+++ b/samples/language/CustomMeasurements.qs
@@ -11,8 +11,8 @@
 // # Who is this for?
 // The target audience are library authors targeting specific hardware.
 
-/// Try running the command `Q#: Get QIR for the current Q# program`
-/// in VS-Code's Command Palette.
+// Try running the command `Q#: Get QIR for the current Q# program`
+// in VS-Code's Command Palette.
 operation Main() : Result {
     use q = Qubit();
     H(q);

--- a/samples/language/FailStatement.qs
+++ b/samples/language/FailStatement.qs
@@ -1,10 +1,10 @@
-/// # Sample
-/// Fail Statement
-///
-/// # Description
-/// A fail statement collects information about the current state of the program,
-/// and then terminates execution entirely. The collected information will be
-/// presented to the user along with the message specified with the fail statement.
+// # Sample
+// Fail Statement
+//
+// # Description
+// A fail statement collects information about the current state of the program,
+// and then terminates execution entirely. The collected information will be
+// presented to the user along with the message specified with the fail statement.
 
 operation Main() : Unit {
     use q = Qubit();

--- a/samples/language/Namespaces.qs
+++ b/samples/language/Namespaces.qs
@@ -1,10 +1,10 @@
-/// # Sample
-/// Namespaces
-///
-/// # Description
-/// Every Q# file defines a namespace. A namespace helps
-/// you organize related functionality this is useful when you are writing
-/// libraries or reusable code.
+// # Sample
+// Namespaces
+//
+// # Description
+// Every Q# file defines a namespace. A namespace helps
+// you organize related functionality this is useful when you are writing
+// libraries or reusable code.
 // The name of the file, minus the extension `.qs`, is the name of the namespace.
 
 // The following `import` statement is used to import all types and callables declared in the

--- a/samples/python_interop/eval_single_file/sample.qs
+++ b/samples/python_interop/eval_single_file/sample.qs
@@ -1,10 +1,10 @@
-/// # Summary
-/// Simple Quantum Random Number Generator sample
-///
-/// # Description
-/// This program implements a quantum random number generator by setting qubits
-/// into superposition and then using the measurement results as random bits.
-/// This is equivalent to generating a random number in the range of 0..2ᴺ-1.
+// # Summary
+// Simple Quantum Random Number Generator sample
+//
+// # Description
+// This program implements a quantum random number generator by setting qubits
+// into superposition and then using the measurement results as random bits.
+// This is equivalent to generating a random number in the range of 0..2ᴺ-1.
 operation Main() : Result[] {
     // Generate a 5-bit random number.
     GenerateNRandomBits(5)


### PR DESCRIPTION
### Description

Fixes #3428.

Follow-up to #1770 / #2652. Sample files used Q# doc comments (`///`) for their top-of-file "file summary" blocks. Since a leading `///` block attaches to the first code item, the auto-import quick-fix couldn't insert between the comment and the item, so imports were placed on line 1 (above the summary). PR #2652 taught the compiler to skip leading regular `//` comments but deliberately kept `///` attached, since it can't distinguish a file header from real API docs.

This PR aligns the samples with that behavior by converting the leading file-summary blocks from `///` to `//`.

### Changes

- Converted leading file-summary comment blocks from `///` to `//` across `samples/**/*.qs` (getting_started, algorithms, estimation, language, circuit_integration, python_interop, MajoranaQubits).
- Also, I flipped a few stray non-API `///` prose notes that preceded the first item.
- **Left unchanged:** genuine per-callable API docs (`# Input`/`# Output`/ `# Summary` on functions/operations/types, e.g `samples/testing/**`, `chemistry/SPSA`, `df-chemistry`), intentional teaching comments (`language/Comments.qs`), `library/**`, and OpenQASM samples.

### Testing

- `cargo test -p samples_test` 415 passed, 0 failed (comments do not affect compilation, QIR, or circuit output).
- Also, I verified only 3 sample files still start with `///`, all under `samples/testing/**`, and all are legitimate per-callable API docs.