### PR TITLE
Prevent divergent types from flowing out of loop and conjugate exprs

### DIFF
--- a/katas/content/teleportation/entanglement_swapping/Verification.qs
+++ b/katas/content/teleportation/entanglement_swapping/Verification.qs
@@ -35,10 +35,11 @@ namespace Kata.Verification {
                 return false;
             }
 
-            Message($"Correct.");
             ResetAll([qAlice1, qAlice2, qBob1, qBob2]);
-            return true;
         }
+
+        Message("Correct.");
+        return true;
     }
 
     @EntryPoint()

--- a/source/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/source/compiler/qsc_frontend/src/typeck/rules.rs
@@ -325,8 +325,7 @@ impl<'a> Context<'a> {
                 let within_span = within.span;
                 let within = self.infer_block(within);
                 self.inferrer.eq(within_span, Ty::UNIT, within.ty);
-                let apply = self.infer_block(apply);
-                apply.diverge_if(within.diverges)
+                self.infer_block(apply)
             }
             ExprKind::Fail(message) => {
                 let message_ty = self.infer_expr(message).ty;
@@ -365,7 +364,7 @@ impl<'a> Context<'a> {
                 let body_span = body.span;
                 let body = self.infer_block(body);
                 self.inferrer.eq(body_span, Ty::UNIT, body.ty);
-                converge(Ty::UNIT).diverge_if(container.diverges || body.diverges)
+                converge(Ty::UNIT)
             }
             ExprKind::If(cond, if_true, if_false) => {
                 let cond_span = cond.span;
@@ -502,16 +501,12 @@ impl<'a> Context<'a> {
                 let until_span = until.span;
                 let until = self.infer_expr(until);
                 self.inferrer.eq(until_span, Ty::Prim(Prim::Bool), until.ty);
-                let fixup_diverges = match fixup {
-                    None => false,
-                    Some(f) => {
-                        let f_span = f.span;
-                        let f = self.infer_block(f);
-                        self.inferrer.eq(f_span, Ty::UNIT, f.ty);
-                        f.diverges
-                    }
-                };
-                converge(Ty::UNIT).diverge_if(body.diverges || until.diverges || fixup_diverges)
+                if let Some(fixup) = fixup {
+                    let fixup_span = fixup.span;
+                    let fixup = self.infer_block(fixup);
+                    self.inferrer.eq(fixup_span, Ty::UNIT, fixup.ty);
+                }
+                converge(Ty::UNIT)
             }
             ExprKind::Return(expr) => {
                 let ty = self.infer_expr(expr).ty;
@@ -599,7 +594,7 @@ impl<'a> Context<'a> {
                 let body_span = body.span;
                 let body = self.infer_block(body);
                 self.inferrer.eq(body_span, Ty::UNIT, body.ty);
-                converge(Ty::UNIT).diverge_if(cond.diverges || body.diverges)
+                converge(Ty::UNIT)
             }
             ExprKind::Hole => {
                 self.typed_holes.push((expr.id, expr.span));

--- a/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
@@ -151,6 +151,7 @@ fn iter() {
                 for item in a {
                     return item;
                 }
+                false
             }
 
             function Main() : Unit {
@@ -162,21 +163,22 @@ fn iter() {
         &expect![[r##"
             #11 67-74 "(a: 'T)" : Param<"'T": 0>
             #12 68-73 "a: 'T" : Param<"'T": 0>
-            #19 82-180 "{\n                for item in a {\n                    return item;\n                }\n            }" : Bool
+            #19 82-202 "{\n                for item in a {\n                    return item;\n                }\n                false\n            }" : Bool
             #21 100-166 "for item in a {\n                    return item;\n                }" : Unit
             #22 104-108 "item" : Bool
             #24 112-113 "a" : Param<"'T": 0>
             #27 114-166 "{\n                    return item;\n                }" : Unit
             #29 136-147 "return item" : Unit
             #30 143-147 "item" : Bool
-            #36 207-209 "()" : Unit
-            #40 217-269 "{\n                let x = Foo([true]);\n            }" : Unit
-            #42 239-240 "x" : Bool
-            #44 243-254 "Foo([true])" : Bool
-            #45 243-246 "Foo" : (Bool[] -> Bool)
-            #48 246-254 "([true])" : Bool[]
-            #49 247-253 "[true]" : Bool[]
-            #50 248-252 "true" : Bool
+            #34 183-188 "false" : Bool
+            #38 229-231 "()" : Unit
+            #42 239-291 "{\n                let x = Foo([true]);\n            }" : Unit
+            #44 261-262 "x" : Bool
+            #46 265-276 "Foo([true])" : Bool
+            #47 265-268 "Foo" : (Bool[] -> Bool)
+            #50 268-276 "([true])" : Bool[]
+            #51 269-275 "[true]" : Bool[]
+            #52 270-274 "true" : Bool
             Error(Type(Error(UnrecognizedClass { span: Span { lo: 112, hi: 113 }, name: "Iterable" })))
         "##]],
     );

--- a/source/compiler/qsc_openqasm_compiler/src/tests/declaration/def.rs
+++ b/source/compiler/qsc_openqasm_compiler/src/tests/declaration/def.rs
@@ -293,7 +293,7 @@ fn missing_return_in_omitted_else_fails() {
 }
 
 #[test]
-fn return_from_for_loop() {
+fn return_only_from_for_loop_missing_fallback_return() {
     let source = r#"
         def square(int a) -> bit {
             for int i in {1, 2} {
@@ -305,11 +305,39 @@ fn return_from_for_loop() {
     check_qasm_to_qsharp(
         source,
         &expect![[r#"
+            Qdk.Qasm.Lowerer.NonVoidDefShouldAlwaysReturn
+
+              x non-void def should always return
+               ,-[Test.qasm:2:30]
+             1 | 
+             2 |         def square(int a) -> bit {
+               :                              ^^^
+             3 |             for int i in {1, 2} {
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn return_from_for_loop_with_fallback_return() {
+    let source = r#"
+        def square(int a) -> bit {
+            for int i in {1, 2} {
+                return 1;
+            }
+            return 0;
+        }
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
             import Std.OpenQASM.Intrinsic.*;
             function square(a : Int) : Result {
                 for i : Int in [1, 2] {
                     return Std.OpenQASM.Convert.IntAsResult(1);
                 }
+                return Std.OpenQASM.Convert.IntAsResult(0);
             }
         "#]],
     );
@@ -340,7 +368,7 @@ fn missing_return_in_for_loop_fails() {
 }
 
 #[test]
-fn return_from_while_loop() {
+fn return_only_from_while_loop_missing_fallback_return() {
     let source = r#"
         def square(int a) -> bit {
             while (true) {
@@ -352,11 +380,39 @@ fn return_from_while_loop() {
     check_qasm_to_qsharp(
         source,
         &expect![[r#"
+            Qdk.Qasm.Lowerer.NonVoidDefShouldAlwaysReturn
+
+              x non-void def should always return
+               ,-[Test.qasm:2:30]
+             1 | 
+             2 |         def square(int a) -> bit {
+               :                              ^^^
+             3 |             while (true) {
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn return_from_while_loop_with_fallback_return() {
+    let source = r#"
+        def square(int a) -> bit {
+            while (true) {
+                return 1;
+            }
+            return 0;
+        }
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
             import Std.OpenQASM.Intrinsic.*;
             function square(a : Int) : Result {
                 while true {
                     return Std.OpenQASM.Convert.IntAsResult(1);
                 }
+                return Std.OpenQASM.Convert.IntAsResult(0);
             }
         "#]],
     );

--- a/source/qdk_openqasm_parser/src/semantic/lowerer.rs
+++ b/source/qdk_openqasm_parser/src/semantic/lowerer.rs
@@ -1852,10 +1852,6 @@ impl Lowerer {
                 }
                 all_cases_return
             }
-            // We don't know if the iterable of the loop is empty at compile time.
-            // We take a best effort approach and check if the body always returns.
-            semantic::StmtKind::For(stmt) => Self::stmt_always_returns(&stmt.body),
-            semantic::StmtKind::WhileLoop(stmt) => Self::stmt_always_returns(&stmt.body),
             semantic::StmtKind::Return(..) | semantic::StmtKind::End(..) => true,
             _ => false,
         }


### PR DESCRIPTION
This is a follow up from #2700, which turns out didn't fully fix the problem. All three loop constructs are known to be of type `Unit` and should not have their type marked as divergent based on any containing expressions. This matches behavior of other languages like Rust that do not propagate the divergent/unknown/`!` type from within loop structures. Notably this makes for a change to both Q# and OpenQASM where a loop with a `fail` expr inside will no longer satisfy type checking on it's own, requiring some explicit return values to match an outer callable scope or binding. The OpenQASM lowerer detection of missing returns is updated to provide feedback to the user rather than assuming a loop with a return satisfies requirements.