### PR TITLE
Fix a bug in Compiler::new

### DIFF
--- a/source/compiler/qsc/src/incremental.rs
+++ b/source/compiler/qsc/src/incremental.rs
@@ -50,7 +50,8 @@ impl Compiler {
         dependencies: &Dependencies,
         qsharp_config: FxHashMap<Rc<str>, Value>,
     ) -> Result<Self, Errors> {
-        let mut passes = PassContext::new(qsharp_config.clone());
+        let qsharp_config_rc = Rc::new(qsharp_config);
+        let mut passes = PassContext::new(qsharp_config_rc.clone());
         let (mut unit, errors) = compile_with_pass_context(
             &store,
             dependencies,
@@ -83,7 +84,7 @@ impl Compiler {
         Ok(Self {
             store,
             source_package_id,
-            passes: PassContext::new(qsharp_config),
+            passes: PassContext::new(qsharp_config_rc),
             frontend,
         })
     }

--- a/source/compiler/qsc/src/incremental.rs
+++ b/source/compiler/qsc/src/incremental.rs
@@ -50,7 +50,7 @@ impl Compiler {
         dependencies: &Dependencies,
         qsharp_config: FxHashMap<Rc<str>, Value>,
     ) -> Result<Self, Errors> {
-        let mut passes = PassContext::new(qsharp_config);
+        let mut passes = PassContext::new(qsharp_config.clone());
         let (mut unit, errors) = compile_with_pass_context(
             &store,
             dependencies,
@@ -83,7 +83,7 @@ impl Compiler {
         Ok(Self {
             store,
             source_package_id,
-            passes,
+            passes: PassContext::new(qsharp_config),
             frontend,
         })
     }

--- a/source/compiler/qsc/src/interpret/tests.rs
+++ b/source/compiler/qsc/src/interpret/tests.rs
@@ -3667,5 +3667,48 @@ mod given_interpreter {
                 }
             }
         }
+
+        /// Regression test for `MutableClosure` false positive compilation error which can happen
+        /// if the same `PassContext` is reused to compile sources and for interactive compilation.
+        #[test]
+        fn valid_lambda_in_second_compilation_should_not_error() {
+            let source = String::from(
+                r#"
+                    namespace Test {
+                        function Add(a : Int, b : Int) : Int { a + b }
+                        operation Seed() : Int {mutable m1 = 1; 0 }
+                    }
+                "#,
+            );
+
+            let sources = SourceMap::new([("test".into(), source.into())], None);
+            let (std_id, store) =
+                crate::compile::package_store_with_stdlib(TargetCapabilityFlags::all());
+            let mut interpreter = Interpreter::new(
+                sources,
+                PackageType::Lib,
+                TargetCapabilityFlags::all(),
+                LanguageFeatures::default(),
+                store,
+                &[(std_id, None)],
+                Default::default(),
+            )
+            .expect("interpreter should be created");
+
+            let (result, output) = line(
+                &mut interpreter,
+                indoc! {r#"
+                    operation Run() : Int {
+                        let x = 1;
+                        let f = r -> Test.Add(x, _)(r[0]);
+                        f([1])
+                    }
+                "#},
+            );
+            is_only_value(&result, &output, &Value::unit());
+
+            let (result, output) = line(&mut interpreter, "Run()");
+            is_only_value(&result, &output, &Value::Int(2));
+        }
     }
 }

--- a/source/compiler/qsc_passes/src/lib.rs
+++ b/source/compiler/qsc_passes/src/lib.rs
@@ -91,18 +91,18 @@ pub fn lower_hir_to_fir(
 pub struct PassContext {
     borrow_check: borrowck::Checker,
     /// Read-only config values exposed to Q# via Std.Core.ConfigValue.
-    qsharp_config: FxHashMap<Rc<str>, Value>,
+    qsharp_config: Rc<FxHashMap<Rc<str>, Value>>,
 }
 
 impl Default for PassContext {
     fn default() -> Self {
-        Self::new(FxHashMap::default())
+        Self::new(Default::default())
     }
 }
 
 impl PassContext {
     #[must_use]
-    pub fn new(qsharp_config: FxHashMap<Rc<str>, Value>) -> Self {
+    pub fn new(qsharp_config: Rc<FxHashMap<Rc<str>, Value>>) -> Self {
         Self {
             borrow_check: borrowck::Checker::default(),
             qsharp_config,


### PR DESCRIPTION
* There was a bug introduced in https://github.com/microsoft/qdk/pull/3486 when instead of using two separate instances of PassContext (one to compile sources and one to keep in Compiler for incremental compilation), it used the same PassContext.
* It manifested itself as false-positive "lambdas cannot close over mutable variables" compilation error, but the root cause was that Assigner and borrowck::Checker were having different lifetimes. So if the first pass had a mutable variable, its NodeId would be stored in the set of mutable variables. On second pass if new assigner happens to assign same NodeId to immutable variable and that variable is used in lambda, that would trigger an error.
* This PR restores having 2 PassContexts, as it was prior to https://github.com/microsoft/qdk/pull/3486 and adds a regression test.
* To avoid cloning the map, I changed stored type of config to be `Rc<FxHashMap>`.