### PR TITLE
Rename panic telemetry property

### DIFF
--- a/source/npm/qsharp/src/main.ts
+++ b/source/npm/qsharp/src/main.ts
@@ -102,7 +102,7 @@ export async function instantiateWasm() {
     // Only the target is included to distinguish errors; message
     // content (including stack) is omitted for privacy.
     if (level === 1) {
-      log.logTelemetry({ id: "wasm-error", data: { target } });
+      log.logTelemetry({ id: "wasm-error", data: { panicTarget: target } });
     }
     log.logWithLevel(level, target, ...args);
   }, log.getLogLevel());

--- a/source/npm/qsharp/src/workers/worker.ts
+++ b/source/npm/qsharp/src/workers/worker.ts
@@ -220,7 +220,7 @@ function initService<
     // Only the target is included to distinguish errors; message
     // content is omitted for privacy.
     if (level === 1) {
-      postTelemetryMessage({ id: "wasm-error", data: { target } });
+      postTelemetryMessage({ id: "wasm-error", data: { panicTarget: target } });
     }
 
     if (log.getLogLevel() < level) {

--- a/source/vscode/src/telemetry.ts
+++ b/source/vscode/src/telemetry.ts
@@ -358,7 +358,7 @@ type EventTypes = {
   };
   [EventType.WasmError]: {
     properties: {
-      target: string;
+      panicTarget: string;
     };
     measurements: Empty;
   };
@@ -413,7 +413,7 @@ export function initTelemetry(context: vscode.ExtensionContext) {
   log.setTelemetryCollector((event) => {
     if (event.id === "wasm-error") {
       sendTelemetryEvent(EventType.WasmError, {
-        target: event.data?.target ?? "unknown",
+        panicTarget: event.data?.panicTarget ?? "unknown",
       });
     }
   });


### PR DESCRIPTION
...from "target" to "panicTarget" because "target" is a common property with the wrong privacy classification.

Updates #3443