### PR TITLE
Enable source maps in source/npm/qsharp/src

### DIFF
--- a/.vscode/launch.shared.json
+++ b/.vscode/launch.shared.json
@@ -12,7 +12,10 @@
         "--extensionDevelopmentPath=${workspaceFolder}/source/vscode",
         "${workspaceFolder}/samples/"
       ],
-      "outFiles": ["${workspaceFolder}/source/vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/source/vscode/out/**/*.js",
+        "${workspaceFolder}/source/npm/qsharp/dist/**/*.js"
+      ]
     },
     {
       // Launches the extension in "web extension" mode (like vscode.dev).
@@ -26,7 +29,10 @@
         "--extensionDevelopmentKind=web",
         "${workspaceFolder}/samples/"
       ],
-      "outFiles": ["${workspaceFolder}/source/vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/source/vscode/out/**/*.js",
+        "${workspaceFolder}/source/npm/qsharp/dist/**/*.js"
+      ]
     },
     {
       // Use when developing in WSL.
@@ -43,7 +49,10 @@
         "--extensionDevelopmentPath=${workspaceFolder}/source/vscode",
         "${workspaceFolder}/samples/"
       ],
-      "outFiles": ["${workspaceFolder}/source/vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/source/vscode/out/**/*.js",
+        "${workspaceFolder}/source/npm/qsharp/dist/**/*.js"
+      ]
     },
     {
       // Use when developing in Codespaces.
@@ -61,7 +70,10 @@
         "--extensionDevelopmentPath=${workspaceFolder}/source/vscode",
         "${workspaceFolder}/samples/"
       ],
-      "outFiles": ["${workspaceFolder}/source/vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/source/vscode/out/**/*.js",
+        "${workspaceFolder}/source/npm/qsharp/dist/**/*.js"
+      ]
     }
   ]
 }

--- a/source/npm/qsharp/src/tsconfig.json
+++ b/source/npm/qsharp/src/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["WebWorker", "ES2022"],
     "outDir": "../dist",
     "declaration": true,
+    "sourceMap": true,
     "strict": true /* enable all strict type-checking options */,
     "isolatedModules": true,
     "skipLibCheck": false /* to catch errors in the wasm-bindgen generated .d.ts */,


### PR DESCRIPTION
Lets us set breakpoints in those TS files.