### PR TITLE
Fix multiplatform pipeline error for macos-latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@vscode/debugprotocol": "^1.68.0",
         "@vscode/extension-telemetry": "0.8.5",
         "@vscode/markdown-it-katex": "^1.0.0",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/test-web": "^0.0.81",
         "3dmol": "^2.5.4",
         "chai": "^6.2.2",
@@ -2268,9 +2268,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha1-Rrk9EY3NOzyJyq4pahP5p/XrY8U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2281,7 +2281,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/test-electron/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@vscode/debugprotocol": "^1.68.0",
     "@vscode/extension-telemetry": "0.8.5",
     "@vscode/markdown-it-katex": "^1.0.0",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/test-web": "^0.0.81",
     "3dmol": "^2.5.4",
     "chai": "^6.2.2",


### PR DESCRIPTION
Fixes [issue](https://github.com/microsoft/qdk/issues/3530), which was caused by a breaking change (or a sequence of them) by the vscode repo.

First, they renamed the MacOS executable path from `.../Contents/MacOS/Electron` to `.../Contents/MacOS/Code` (or `.../Contents/MacOS/Code - Insiders`) [PR #291948](https://github.com/microsoft/vscode/pull/291948/changes). But they still kept the symlink, so that didn't cause the break.

Then, they removed the symlink: [PR #326502](https://github.com/microsoft/vscode/pull/326502), which caused this error, since the original path wasn't accessible anymore.

But the vscode-test repo fixed it last week: [PR #350](https://github.com/microsoft/vscode-test/pull/350)

So all I had to do was update the package to the latest version. I ran the multiplatform pipeline again and it worked: [link](https://github.com/microsoft/qdk/actions/runs/30659943911)


