### PR TITLE
Use a `+json` mimetype for the Q# config output so executed notebooks stay nbformat-valid

### DIFF
--- a/source/qdk_package/qdk/_types.py
+++ b/source/qdk_package/qdk/_types.py
@@ -18,7 +18,6 @@ Types defined here:
 - ``QirInputData`` — compiled QIR wrapper for azure-quantum submission.
 """
 
-import json
 import os
 from pathlib import Path
 from typing import (
@@ -281,8 +280,8 @@ class Config:
     # (i.e. the language service) can read and interpret the data.
     def _repr_mimebundle_(
         self, include: Union[Any, None] = None, exclude: Union[Any, None] = None
-    ) -> Dict[str, str]:
-        return {"application/x.qsharp-config": json.dumps(self._config)}
+    ) -> Dict[str, Dict[str, Any]]:
+        return {"application/x.qsharp-config+json": self._config}
 
     def get_target_profile(self) -> str:
         """

--- a/source/qdk_package/qdk/_types.py
+++ b/source/qdk_package/qdk/_types.py
@@ -18,6 +18,7 @@ Types defined here:
 - ``QirInputData`` — compiled QIR wrapper for azure-quantum submission.
 """
 
+import json
 import os
 from pathlib import Path
 from typing import (
@@ -280,8 +281,8 @@ class Config:
     # (i.e. the language service) can read and interpret the data.
     def _repr_mimebundle_(
         self, include: Union[Any, None] = None, exclude: Union[Any, None] = None
-    ) -> Dict[str, Dict[str, Any]]:
-        return {"application/x.qsharp-config": self._config}
+    ) -> Dict[str, str]:
+        return {"application/x.qsharp-config": json.dumps(self._config)}
 
     def get_target_profile(self) -> str:
         """

--- a/source/vscode/src/language-service/notebook.ts
+++ b/source/vscode/src/language-service/notebook.ts
@@ -10,7 +10,7 @@ import {
   jupyterNotebookType,
 } from "../notebook.js";
 
-const qsharpConfigMimeType = "application/x.qsharp-config";
+const qsharpConfigMimeType = "application/x.qsharp-config+json";
 
 const openQdkNotebooks = new Set<string>();
 


### PR DESCRIPTION
`qsharp.init(...)` produces a custom output that carries Q# configuration
(target profile, language features, manifest, project root) for editor tooling.
This output was emitted under the mimetype `application/x.qsharp-config` with a
raw object value, which violates the nbformat output schema. As of `nbformat`
5.11.0 this now causes `nbconvert` to fail when validating an executed notebook.

This PR renames the mimetype to `application/x.qsharp-config+json`, which the
schema recognizes as a JSON mimetype and therefore permits an arbitrary object
value.

## Problem

The nbformat output `mimebundle` schema only allows arbitrary (object) values
for mimetypes matching `^application/(.*\+)?json$`. Any other mimetype must be a
string (or an array of strings). Because `application/x.qsharp-config` does not
match that pattern, an object value there is invalid.

When a notebook cell ends with a trailing `qsharp.init(...)` expression (e.g.
`samples/chemistry/Variational Quantum Algorithms.ipynb`, which calls
`qsharp.init(project_root="SPSA")`), the config object is emitted as cell output
and `nbconvert` fails to validate the executed notebook:

```
nbformat.validator.NotebookValidationError: {'targetProfile': 'unrestricted', 'manifest': '...', 'projectRoot': 'file:///.../samples/chemistry/SPSA'} is not valid under any of the given schemas

Failed validating 'oneOf' in notebook['properties']['data']['additionalProperties']:
On instance['data']['application/x.qsharp-config']:
```

### Why this started failing now

The output has always been an invalid object under this custom mimetype, but it
was not being surfaced until recently:

- `nbformat` 5.11.0 was released on 2026-08-06 (the previous release, 5.10.4, was
  from April 2024). Its changelog includes "Remove deprecated kwargs from
  `validate()`" and a refactor of validation handling, removing the lenient
  auto-fix/relaxation behavior that previously masked this schema violation.
- `build.py` installs `nbconvert` (and transitively `nbformat`) unpinned, so CI
  picks up the newest release automatically.

Together, this turned a long-latent schema violation into a hard failure within
~24 hours of the `nbformat` release.

## Fix

In `source/qdk_package/qdk/_types.py`, `Config._repr_mimebundle_` now emits the
config under `application/x.qsharp-config+json`. Because the mimetype ends in
`+json`, the nbformat schema treats it as JSON output and allows the object
value to be emitted directly (no string encoding required).

```python
def _repr_mimebundle_(self, include=None, exclude=None) -> Dict[str, Dict[str, Any]]:
    return {"application/x.qsharp-config+json": self._config}
```

The VS Code language service reader in
`source/vscode/src/language-service/notebook.ts` is updated to look for the new
mimetype:

```ts
const qsharpConfigMimeType = "application/x.qsharp-config+json";
```